### PR TITLE
Remove leading 'x' from repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-# xElm
-[![build status](https://travis-ci.org/exercism/xelm.svg?branch=master)](https://travis-ci.org/exercism/xelm)
+# Exercism Elm Track
+[![build status](https://travis-ci.org/exercism/elm.svg?branch=master)](https://travis-ci.org/exercism/elm)
 
 Exercism Exercises in Elm
 
@@ -76,7 +76,7 @@ tests =
         ]
 ```
 
- - All the tests for xElm exercises can be run from the top level of the repo with `bin/build.sh`. Please run this command before submitting your PR.
+ - All the tests for Exercism Elm Track exercises can be run from the top level of the repo with `bin/build.sh`. Please run this command before submitting your PR.
 
  - If you are submitting a new exercise, be sure to add it to the appropriate place in the `config.json` file. Also, please run `bin/fetch-configlet && bin/configlet` to ensure the exercise is configured correctly.
 

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
   "slug": "elm",
   "language": "Elm",
-  "repository": "https://github.com/exercism/xelm",
+  "repository": "https://github.com/exercism/elm",
   "active": true,
   "exercises": [
     {

--- a/exercises/accumulate/elm-package.json
+++ b/exercises/accumulate/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/accumulate/package.json
+++ b/exercises/accumulate/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/accumulate/tests/elm-package.json
+++ b/exercises/accumulate/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/allergies/elm-package.json
+++ b/exercises/allergies/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/allergies/package.json
+++ b/exercises/allergies/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/allergies/tests/elm-package.json
+++ b/exercises/allergies/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/anagram/elm-package.json
+++ b/exercises/anagram/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/anagram/package.json
+++ b/exercises/anagram/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/anagram/tests/elm-package.json
+++ b/exercises/anagram/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/atbash-cipher/elm-package.json
+++ b/exercises/atbash-cipher/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/atbash-cipher/package.json
+++ b/exercises/atbash-cipher/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/atbash-cipher/tests/elm-package.json
+++ b/exercises/atbash-cipher/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/bob/elm-package.json
+++ b/exercises/bob/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/bob/package.json
+++ b/exercises/bob/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/bob/tests/elm-package.json
+++ b/exercises/bob/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/difference-of-squares/elm-package.json
+++ b/exercises/difference-of-squares/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/difference-of-squares/package.json
+++ b/exercises/difference-of-squares/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/difference-of-squares/tests/elm-package.json
+++ b/exercises/difference-of-squares/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/gigasecond/elm-package.json
+++ b/exercises/gigasecond/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/gigasecond/package.json
+++ b/exercises/gigasecond/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/gigasecond/tests/elm-package.json
+++ b/exercises/gigasecond/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/grade-school/elm-package.json
+++ b/exercises/grade-school/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/grade-school/package.json
+++ b/exercises/grade-school/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/grade-school/tests/elm-package.json
+++ b/exercises/grade-school/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/grains/elm-package.json
+++ b/exercises/grains/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/grains/package.json
+++ b/exercises/grains/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/grains/tests/elm-package.json
+++ b/exercises/grains/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/hamming/elm-package.json
+++ b/exercises/hamming/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/hamming/package.json
+++ b/exercises/hamming/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/hamming/tests/elm-package.json
+++ b/exercises/hamming/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/hello-world/elm-package.json
+++ b/exercises/hello-world/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/hello-world/package.json
+++ b/exercises/hello-world/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/hello-world/tests/elm-package.json
+++ b/exercises/hello-world/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/largest-series-product/elm-package.json
+++ b/exercises/largest-series-product/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/largest-series-product/package.json
+++ b/exercises/largest-series-product/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/largest-series-product/tests/elm-package.json
+++ b/exercises/largest-series-product/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/leap/elm-package.json
+++ b/exercises/leap/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/leap/package.json
+++ b/exercises/leap/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/leap/tests/elm-package.json
+++ b/exercises/leap/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/list-ops/elm-package.json
+++ b/exercises/list-ops/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/list-ops/package.json
+++ b/exercises/list-ops/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/list-ops/tests/elm-package.json
+++ b/exercises/list-ops/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/nucleotide-count/elm-package.json
+++ b/exercises/nucleotide-count/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/nucleotide-count/package.json
+++ b/exercises/nucleotide-count/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/nucleotide-count/tests/elm-package.json
+++ b/exercises/nucleotide-count/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/pangram/elm-package.json
+++ b/exercises/pangram/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/pangram/package.json
+++ b/exercises/pangram/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/pangram/tests/elm-package.json
+++ b/exercises/pangram/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/phone-number/elm-package.json
+++ b/exercises/phone-number/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/phone-number/package.json
+++ b/exercises/phone-number/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/phone-number/tests/elm-package.json
+++ b/exercises/phone-number/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/raindrops/elm-package.json
+++ b/exercises/raindrops/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/raindrops/package.json
+++ b/exercises/raindrops/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/raindrops/tests/elm-package.json
+++ b/exercises/raindrops/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/rna-transcription/elm-package.json
+++ b/exercises/rna-transcription/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/rna-transcription/package.json
+++ b/exercises/rna-transcription/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/rna-transcription/tests/elm-package.json
+++ b/exercises/rna-transcription/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/robot-simulator/elm-package.json
+++ b/exercises/robot-simulator/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/robot-simulator/package.json
+++ b/exercises/robot-simulator/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/robot-simulator/tests/elm-package.json
+++ b/exercises/robot-simulator/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/roman-numerals/elm-package.json
+++ b/exercises/roman-numerals/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/roman-numerals/package.json
+++ b/exercises/roman-numerals/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/roman-numerals/tests/elm-package.json
+++ b/exercises/roman-numerals/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/run-length-encoding/elm-package.json
+++ b/exercises/run-length-encoding/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/run-length-encoding/package.json
+++ b/exercises/run-length-encoding/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/run-length-encoding/tests/elm-package.json
+++ b/exercises/run-length-encoding/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/say/elm-package.json
+++ b/exercises/say/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/say/package.json
+++ b/exercises/say/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/say/tests/elm-package.json
+++ b/exercises/say/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/scrabble-score/elm-package.json
+++ b/exercises/scrabble-score/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/scrabble-score/package.json
+++ b/exercises/scrabble-score/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/scrabble-score/tests/elm-package.json
+++ b/exercises/scrabble-score/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/series/elm-package.json
+++ b/exercises/series/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/series/package.json
+++ b/exercises/series/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/series/tests/elm-package.json
+++ b/exercises/series/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/space-age/elm-package.json
+++ b/exercises/space-age/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/space-age/package.json
+++ b/exercises/space-age/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/space-age/tests/elm-package.json
+++ b/exercises/space-age/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/strain/elm-package.json
+++ b/exercises/strain/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/strain/package.json
+++ b/exercises/strain/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/strain/tests/elm-package.json
+++ b/exercises/strain/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/sublist/elm-package.json
+++ b/exercises/sublist/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/sublist/package.json
+++ b/exercises/sublist/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/sublist/tests/elm-package.json
+++ b/exercises/sublist/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/sum-of-multiples/elm-package.json
+++ b/exercises/sum-of-multiples/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/sum-of-multiples/package.json
+++ b/exercises/sum-of-multiples/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/sum-of-multiples/tests/elm-package.json
+++ b/exercises/sum-of-multiples/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/triangle/elm-package.json
+++ b/exercises/triangle/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/triangle/package.json
+++ b/exercises/triangle/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/triangle/tests/elm-package.json
+++ b/exercises/triangle/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",

--- a/exercises/word-count/elm-package.json
+++ b/exercises/word-count/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         "."

--- a/exercises/word-count/package.json
+++ b/exercises/word-count/package.json
@@ -1,6 +1,6 @@
 {
     "description": "Exercism/Elm",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "MIT",
     "scripts": {
         "postinstall": "elm-package install -y",

--- a/exercises/word-count/tests/elm-package.json
+++ b/exercises/word-count/tests/elm-package.json
@@ -1,7 +1,7 @@
 {
     "version": "3.0.0",
     "summary": "Exercism problems in Elm.",
-    "repository": "https://github.com/exercism/xelm.git",
+    "repository": "https://github.com/exercism/elm.git",
     "license": "BSD3",
     "source-directories": [
         ".",


### PR DESCRIPTION
The leading 'x' is kind of arbitrary. Especially now that we can set
topics on the repositories, we don't need a pattern to distinguish what
is a track or not.

The repository itself has already been renamed. GitHub redirects from
the old name to the new name, so we do not have to rush to fix links to
the old repository name, though we should update them for the sake of
clarity.

See exercism/meta#1