### PR TITLE
Skip all but first test of each example

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -41,7 +41,7 @@ do
   exercise_name=$(basename $example_file .example.elm)
   cp "$exercise_dir/$exercise_name.example.elm" "build/$exercise_name.elm"
   cp "$exercise_dir/tests/elm-package.json" build/tests/
-  cp "$exercise_dir/tests/Tests.elm" build/tests/
+  cat "$exercise_dir/tests/Tests.elm" | sed 's/skip <|//g' > build/tests/Tests.elm
 
   echo '-------------------------------------------------------'
   echo "Testing $exercise_name"

--- a/docs/EXERCISE_README_INSERT.md
+++ b/docs/EXERCISE_README_INSERT.md
@@ -17,3 +17,6 @@ Execute the tests with:
 ```bash
 $ npm test
 ```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!

--- a/exercises/accumulate/tests/Tests.elm
+++ b/exercises/accumulate/tests/Tests.elm
@@ -16,14 +16,17 @@ tests =
     describe "Accumulate"
         [ test "[] Accumulate" <|
             \() -> Expect.equal [] (accumulate square [])
-        , test "square Accumulate" <|
-            \() -> Expect.equal [ 1, 4, 9 ] (accumulate square [ 1, 2, 3 ])
-        , test "toUpper Accumulate" <|
-            \() ->
-                Expect.equal [ "HELLO", "WORLD" ]
-                    (accumulate String.toUpper [ "hello", "world" ])
-        , test "reverse Accumulate" <|
-            \() ->
-                Expect.equal [ "olleh", "dlrow" ]
-                    (accumulate String.reverse [ "hello", "world" ])
+        , skip <|
+            test "square Accumulate" <|
+                \() -> Expect.equal [ 1, 4, 9 ] (accumulate square [ 1, 2, 3 ])
+        , skip <|
+            test "toUpper Accumulate" <|
+                \() ->
+                    Expect.equal [ "HELLO", "WORLD" ]
+                        (accumulate String.toUpper [ "hello", "world" ])
+        , skip <|
+            test "reverse Accumulate" <|
+                \() ->
+                    Expect.equal [ "olleh", "dlrow" ]
+                        (accumulate String.reverse [ "hello", "world" ])
         ]

--- a/exercises/allergies/tests/Tests.elm
+++ b/exercises/allergies/tests/Tests.elm
@@ -13,36 +13,47 @@ tests =
             [ describe "no allergies means not allergic"
                 [ test "peanuts" <|
                     \() -> Expect.equal False (isAllergicTo "peanuts" 0)
-                , test "cats" <|
-                    \() -> Expect.equal False (isAllergicTo "cats" 0)
-                , test "strawberries" <|
-                    \() -> Expect.equal False (isAllergicTo "strawberries" 0)
+                , skip <|
+                    test "cats" <|
+                        \() -> Expect.equal False (isAllergicTo "cats" 0)
+                , skip <|
+                    test "strawberries" <|
+                        \() -> Expect.equal False (isAllergicTo "strawberries" 0)
                 ]
-            , test "is allergic to eggs" <|
-                \() -> Expect.equal True (isAllergicTo "eggs" 1)
+            , skip <|
+                test "is allergic to eggs" <|
+                    \() -> Expect.equal True (isAllergicTo "eggs" 1)
             , describe "has the right allergies"
-                [ test "eggs" <|
-                    \() -> Expect.equal True (isAllergicTo "eggs" 5)
-                , test "shellfish" <|
-                    \() -> Expect.equal True (isAllergicTo "shellfish" 5)
-                , test "strawberries" <|
-                    \() -> Expect.equal False (isAllergicTo "strawberries" 5)
+                [ skip <|
+                    test "eggs" <|
+                        \() -> Expect.equal True (isAllergicTo "eggs" 5)
+                , skip <|
+                    test "shellfish" <|
+                        \() -> Expect.equal True (isAllergicTo "shellfish" 5)
+                , skip <|
+                    test "strawberries" <|
+                        \() -> Expect.equal False (isAllergicTo "strawberries" 5)
                 ]
             ]
         , describe "toList"
-            [ test "no allergies at all" <|
-                \() -> Expect.equal [] (toList (0))
-            , test "allergic to just peanuts" <|
-                \() -> Expect.equal [ "peanuts" ] (toList (2))
-            , test "allergic to everything" <|
-                \() ->
-                    Expect.equal (List.sort [ "eggs", "peanuts", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats" ])
-                        (255 |> toList |> List.sort)
-            , test "ignore non allergen score parts" <|
-                \() -> Expect.equal [ "eggs" ] (toList 257)
-            , test "ignore all non allergen score parts" <|
-                \() ->
-                    Expect.equal (List.sort [ "eggs", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats" ])
-                        (509 |> toList |> List.sort)
+            [ skip <|
+                test "no allergies at all" <|
+                    \() -> Expect.equal [] (toList (0))
+            , skip <|
+                test "allergic to just peanuts" <|
+                    \() -> Expect.equal [ "peanuts" ] (toList (2))
+            , skip <|
+                test "allergic to everything" <|
+                    \() ->
+                        Expect.equal (List.sort [ "eggs", "peanuts", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats" ])
+                            (255 |> toList |> List.sort)
+            , skip <|
+                test "ignore non allergen score parts" <|
+                    \() -> Expect.equal [ "eggs" ] (toList 257)
+            , skip <|
+                test "ignore all non allergen score parts" <|
+                    \() ->
+                        Expect.equal (List.sort [ "eggs", "shellfish", "strawberries", "tomatoes", "chocolate", "pollen", "cats" ])
+                            (509 |> toList |> List.sort)
             ]
         ]

--- a/exercises/anagram/tests/Tests.elm
+++ b/exercises/anagram/tests/Tests.elm
@@ -12,80 +12,99 @@ tests =
             \() ->
                 Expect.equal []
                     (detect "diaper" [ "hello", "world", "zombies", "pants" ])
-        , test "detects simple anagram" <|
-            \() ->
-                Expect.equal [ "tan" ]
-                    (detect "ant" [ "tan", "stand", "at" ])
-        , test "does not detect false positives" <|
-            \() ->
-                Expect.equal []
-                    (detect "galea" [ "eagle" ])
-        , test "detects multiple anagrams" <|
-            \() ->
-                Expect.equal [ "stream", "maters" ]
-                    (detect "master" [ "stream", "pigeon", "maters" ])
-        , test "does not detect anagram subsets" <|
-            \() ->
-                Expect.equal []
-                    (detect "good" [ "dog", "goody" ])
-        , test "detects anagram" <|
-            \() ->
-                Expect.equal [ "inlets" ]
-                    (detect "listen" [ "enlists", "google", "inlets", "banana" ])
-        , test "detects even more anagrams" <|
-            \() ->
-                Expect.equal [ "gallery", "regally", "largely" ]
-                    (detect "allergy" [ "gallery", "ballerina", "regally", "clergy", "largely", "leading" ])
-        , test "does not detect indentical words" <|
-            \() ->
-                Expect.equal [ "cron" ]
-                    (detect "corn" [ "corn", "dark", "Corn", "rank", "CORN", "cron", "park" ])
-        , test "does not detect non-anagrams with identical checksum" <|
-            \() ->
-                Expect.equal []
-                    (detect "mass" [ "last" ])
-        , test "detects anagrams case-insensitively" <|
-            \() ->
-                Expect.equal [ "Carthorse" ]
-                    (detect "Orchestra" [ "cashregister", "Carthorse", "radishes" ])
-        , test "detects anagrams using case-insensitive subject" <|
-            \() ->
-                Expect.equal [ "carthorse" ]
-                    (detect "Orchestra" [ "cashregister", "carthorse", "radishes" ])
-        , test "detects anagrams using case-insensitve possible matches" <|
-            \() ->
-                Expect.equal [ "Carthorse" ]
-                    (detect "orchestra" [ "cashregister", "Carthorse", "radishes" ])
-        , test "does not detect a word as its own anagram" <|
-            \() ->
-                Expect.equal []
-                    (detect "banana" [ "Banana" ])
-        , test "does not detect a anagram if the original word is repeated" <|
-            \() ->
-                Expect.equal []
-                    (detect "go" [ "go Go GO" ])
-        , test "anagrams must use all letters exactly once (go)" <|
-            \() ->
-                Expect.equal []
-                    (detect "tapper" [ "patter" ])
-        , test "eliminates anagrams with the same checksum" <|
-            \() ->
-                Expect.equal []
-                    (detect "mass" [ "last" ])
-        , test "detects unicode anagrams" <|
-            \() ->
-                Expect.equal [ "ΒΓΑ", "γβα" ]
-                    (detect "ΑΒΓ" [ "ΒΓΑ", "ΒΓΔ", "γβα" ])
-        , test "eliminates misleading unicode anagrams" <|
-            \() ->
-                Expect.equal []
-                    (detect "ΑΒΓ" [ "ABΓ" ])
-        , test "capital word is not own anagram" <|
-            \() ->
-                Expect.equal []
-                    (detect "BANANA" [ "Banana" ])
-        , test "anagrams must use all letters exactly once (banana)" <|
-            \() ->
-                Expect.equal []
-                    (detect "patter" [ "tapper" ])
+        , skip <|
+            test "detects simple anagram" <|
+                \() ->
+                    Expect.equal [ "tan" ]
+                        (detect "ant" [ "tan", "stand", "at" ])
+        , skip <|
+            test "does not detect false positives" <|
+                \() ->
+                    Expect.equal []
+                        (detect "galea" [ "eagle" ])
+        , skip <|
+            test "detects multiple anagrams" <|
+                \() ->
+                    Expect.equal [ "stream", "maters" ]
+                        (detect "master" [ "stream", "pigeon", "maters" ])
+        , skip <|
+            test "does not detect anagram subsets" <|
+                \() ->
+                    Expect.equal []
+                        (detect "good" [ "dog", "goody" ])
+        , skip <|
+            test "detects anagram" <|
+                \() ->
+                    Expect.equal [ "inlets" ]
+                        (detect "listen" [ "enlists", "google", "inlets", "banana" ])
+        , skip <|
+            test "detects even more anagrams" <|
+                \() ->
+                    Expect.equal [ "gallery", "regally", "largely" ]
+                        (detect "allergy" [ "gallery", "ballerina", "regally", "clergy", "largely", "leading" ])
+        , skip <|
+            test "does not detect indentical words" <|
+                \() ->
+                    Expect.equal [ "cron" ]
+                        (detect "corn" [ "corn", "dark", "Corn", "rank", "CORN", "cron", "park" ])
+        , skip <|
+            test "does not detect non-anagrams with identical checksum" <|
+                \() ->
+                    Expect.equal []
+                        (detect "mass" [ "last" ])
+        , skip <|
+            test "detects anagrams case-insensitively" <|
+                \() ->
+                    Expect.equal [ "Carthorse" ]
+                        (detect "Orchestra" [ "cashregister", "Carthorse", "radishes" ])
+        , skip <|
+            test "detects anagrams using case-insensitive subject" <|
+                \() ->
+                    Expect.equal [ "carthorse" ]
+                        (detect "Orchestra" [ "cashregister", "carthorse", "radishes" ])
+        , skip <|
+            test "detects anagrams using case-insensitve possible matches" <|
+                \() ->
+                    Expect.equal [ "Carthorse" ]
+                        (detect "orchestra" [ "cashregister", "Carthorse", "radishes" ])
+        , skip <|
+            test "does not detect a word as its own anagram" <|
+                \() ->
+                    Expect.equal []
+                        (detect "banana" [ "Banana" ])
+        , skip <|
+            test "does not detect a anagram if the original word is repeated" <|
+                \() ->
+                    Expect.equal []
+                        (detect "go" [ "go Go GO" ])
+        , skip <|
+            test "anagrams must use all letters exactly once (go)" <|
+                \() ->
+                    Expect.equal []
+                        (detect "tapper" [ "patter" ])
+        , skip <|
+            test "eliminates anagrams with the same checksum" <|
+                \() ->
+                    Expect.equal []
+                        (detect "mass" [ "last" ])
+        , skip <|
+            test "detects unicode anagrams" <|
+                \() ->
+                    Expect.equal [ "ΒΓΑ", "γβα" ]
+                        (detect "ΑΒΓ" [ "ΒΓΑ", "ΒΓΔ", "γβα" ])
+        , skip <|
+            test "eliminates misleading unicode anagrams" <|
+                \() ->
+                    Expect.equal []
+                        (detect "ΑΒΓ" [ "ABΓ" ])
+        , skip <|
+            test "capital word is not own anagram" <|
+                \() ->
+                    Expect.equal []
+                        (detect "BANANA" [ "Banana" ])
+        , skip <|
+            test "anagrams must use all letters exactly once (banana)" <|
+                \() ->
+                    Expect.equal []
+                        (detect "patter" [ "tapper" ])
         ]

--- a/exercises/atbash-cipher/tests/Tests.elm
+++ b/exercises/atbash-cipher/tests/Tests.elm
@@ -10,26 +10,35 @@ tests =
     describe "AtbashCipher"
         [ test "encode no" <|
             \() -> Expect.equal "ml" (encode "no")
-        , test "encode yes" <|
-            \() -> Expect.equal "bvh" (encode "yes")
-        , test "encode OMG" <|
-            \() -> Expect.equal "lnt" (encode "OMG")
-        , test "encode O M G" <|
-            \() -> Expect.equal "lnt" (encode "O M G")
-        , test "encode long word" <|
-            \() -> Expect.equal "nrmwy oldrm tob" (encode "mindblowingly")
-        , test "encode numbers" <|
-            \() -> Expect.equal "gvhgr mt123 gvhgr mt" (encode "Testing, 1 2 3, testing.")
-        , test "encode sentence" <|
-            \() -> Expect.equal "gifgs rhurx grlm" (encode "Truth is fiction.")
-        , test "encode all things" <|
-            \() ->
-                Expect.equal "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
-                    (encode "The quick brown fox jumps over the lazy dog.")
-        , test "decode word" <|
-            \() -> Expect.equal "exercism" (decode "vcvix rhn")
-        , test "decode sentence" <|
-            \() ->
-                Expect.equal "anobstacleisoftenasteppingstone"
-                    (decode "zmlyh gzxov rhlug vmzhg vkkrm thglm v")
+        , skip <|
+            test "encode yes" <|
+                \() -> Expect.equal "bvh" (encode "yes")
+        , skip <|
+            test "encode OMG" <|
+                \() -> Expect.equal "lnt" (encode "OMG")
+        , skip <|
+            test "encode O M G" <|
+                \() -> Expect.equal "lnt" (encode "O M G")
+        , skip <|
+            test "encode long word" <|
+                \() -> Expect.equal "nrmwy oldrm tob" (encode "mindblowingly")
+        , skip <|
+            test "encode numbers" <|
+                \() -> Expect.equal "gvhgr mt123 gvhgr mt" (encode "Testing, 1 2 3, testing.")
+        , skip <|
+            test "encode sentence" <|
+                \() -> Expect.equal "gifgs rhurx grlm" (encode "Truth is fiction.")
+        , skip <|
+            test "encode all things" <|
+                \() ->
+                    Expect.equal "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
+                        (encode "The quick brown fox jumps over the lazy dog.")
+        , skip <|
+            test "decode word" <|
+                \() -> Expect.equal "exercism" (decode "vcvix rhn")
+        , skip <|
+            test "decode sentence" <|
+                \() ->
+                    Expect.equal "anobstacleisoftenasteppingstone"
+                        (decode "zmlyh gzxov rhlug vmzhg vkkrm thglm v")
         ]

--- a/exercises/bob/tests/Tests.elm
+++ b/exercises/bob/tests/Tests.elm
@@ -15,101 +15,120 @@ tests =
             \() ->
                 Expect.equal "Whatever."
                     (Bob.hey "Tom-ay-to, tom-aaaah-to.")
-        , test "shouting" <|
-            \() ->
-                Expect.equal
-                    "Whoa, chill out!"
-                    (Bob.hey "WATCH OUT!")
-        , test "shouting gibberish" <|
-            \() ->
-                Expect.equal
-                    "Whoa, chill out!"
-                    (Bob.hey (uppercaseGibberish 10))
-        , test "asking a question" <|
-            \() ->
-                Expect.equal
-                    "Sure."
-                    (Bob.hey "Does this cryogenic chamber make me look fat?")
-        , test "asking a numeric question" <|
-            \() ->
-                Expect.equal
-                    "Sure."
-                    (Bob.hey "You are, what, like 15?")
-        , test "asking gibberish" <|
-            \() ->
-                Expect.equal
-                    "Sure."
-                    (Bob.hey (gibberishQuestion 20))
-        , test "talking forcefully" <|
-            \() ->
-                Expect.equal
-                    "Whatever."
-                    (Bob.hey "Let's go make out behind the gym!")
-        , test "using acronyms in regular speech" <|
-            \() ->
-                Expect.equal
-                    "Whatever."
-                    (Bob.hey "It's OK if you don't want to go to the DMV.")
-        , test "forceful questions" <|
-            \() ->
-                Expect.equal
-                    "Whoa, chill out!"
-                    (Bob.hey "WHAT THE HELL WERE YOU THINKING?")
-        , test "shouting numbers" <|
-            \() ->
-                Expect.equal
-                    "Whoa, chill out!"
-                    (Bob.hey "1, 2, 3 GO!")
-        , test "only numbers" <|
-            \() ->
-                Expect.equal
-                    "Whatever."
-                    (Bob.hey "1, 2, 3")
-        , test "question with only numbers" <|
-            \() ->
-                Expect.equal
-                    "Sure."
-                    (Bob.hey "4?")
-        , test "shouting with special characters" <|
-            \() ->
-                Expect.equal
-                    "Whoa, chill out!"
-                    (Bob.hey "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!")
-        , test "shouting with no exclamation mark" <|
-            \() ->
-                Expect.equal
-                    "Whoa, chill out!"
-                    (Bob.hey "I HATE YOU")
-        , test "statement containing a question mark" <|
-            \() ->
-                Expect.equal
-                    "Whatever."
-                    (Bob.hey "Ending with ? means a question.")
-        , test "prattling on" <|
-            \() ->
-                Expect.equal
-                    "Sure."
-                    (Bob.hey "Wait! Hang on. Are you going to be OK?")
-        , test "silence" <|
-            \() ->
-                Expect.equal
-                    "Fine. Be that way!"
-                    (Bob.hey "")
-        , test "prolonged silence" <|
-            \() ->
-                Expect.equal
-                    "Fine. Be that way!"
-                    (Bob.hey "       ")
-        , test "alternate silences" <|
-            \() ->
-                Expect.equal
-                    "Fine. Be that way!"
-                    (Bob.hey "\t  \n  \t   ")
-        , test "on multiple line questions" <|
-            \() ->
-                Expect.equal
-                    "Whatever."
-                    (Bob.hey "\nDoes this cryogenic chamber make me look fat?\nno")
+        , skip <|
+            test "shouting" <|
+                \() ->
+                    Expect.equal
+                        "Whoa, chill out!"
+                        (Bob.hey "WATCH OUT!")
+        , skip <|
+            test "shouting gibberish" <|
+                \() ->
+                    Expect.equal
+                        "Whoa, chill out!"
+                        (Bob.hey (uppercaseGibberish 10))
+        , skip <|
+            test "asking a question" <|
+                \() ->
+                    Expect.equal
+                        "Sure."
+                        (Bob.hey "Does this cryogenic chamber make me look fat?")
+        , skip <|
+            test "asking a numeric question" <|
+                \() ->
+                    Expect.equal
+                        "Sure."
+                        (Bob.hey "You are, what, like 15?")
+        , skip <|
+            test "asking gibberish" <|
+                \() ->
+                    Expect.equal
+                        "Sure."
+                        (Bob.hey (gibberishQuestion 20))
+        , skip <|
+            test "talking forcefully" <|
+                \() ->
+                    Expect.equal
+                        "Whatever."
+                        (Bob.hey "Let's go make out behind the gym!")
+        , skip <|
+            test "using acronyms in regular speech" <|
+                \() ->
+                    Expect.equal
+                        "Whatever."
+                        (Bob.hey "It's OK if you don't want to go to the DMV.")
+        , skip <|
+            test "forceful questions" <|
+                \() ->
+                    Expect.equal
+                        "Whoa, chill out!"
+                        (Bob.hey "WHAT THE HELL WERE YOU THINKING?")
+        , skip <|
+            test "shouting numbers" <|
+                \() ->
+                    Expect.equal
+                        "Whoa, chill out!"
+                        (Bob.hey "1, 2, 3 GO!")
+        , skip <|
+            test "only numbers" <|
+                \() ->
+                    Expect.equal
+                        "Whatever."
+                        (Bob.hey "1, 2, 3")
+        , skip <|
+            test "question with only numbers" <|
+                \() ->
+                    Expect.equal
+                        "Sure."
+                        (Bob.hey "4?")
+        , skip <|
+            test "shouting with special characters" <|
+                \() ->
+                    Expect.equal
+                        "Whoa, chill out!"
+                        (Bob.hey "ZOMG THE %^*@#$(*^ ZOMBIES ARE COMING!!11!!1!")
+        , skip <|
+            test "shouting with no exclamation mark" <|
+                \() ->
+                    Expect.equal
+                        "Whoa, chill out!"
+                        (Bob.hey "I HATE YOU")
+        , skip <|
+            test "statement containing a question mark" <|
+                \() ->
+                    Expect.equal
+                        "Whatever."
+                        (Bob.hey "Ending with ? means a question.")
+        , skip <|
+            test "prattling on" <|
+                \() ->
+                    Expect.equal
+                        "Sure."
+                        (Bob.hey "Wait! Hang on. Are you going to be OK?")
+        , skip <|
+            test "silence" <|
+                \() ->
+                    Expect.equal
+                        "Fine. Be that way!"
+                        (Bob.hey "")
+        , skip <|
+            test "prolonged silence" <|
+                \() ->
+                    Expect.equal
+                        "Fine. Be that way!"
+                        (Bob.hey "       ")
+        , skip <|
+            test "alternate silences" <|
+                \() ->
+                    Expect.equal
+                        "Fine. Be that way!"
+                        (Bob.hey "\t  \n  \t   ")
+        , skip <|
+            test "on multiple line questions" <|
+                \() ->
+                    Expect.equal
+                        "Whatever."
+                        (Bob.hey "\nDoes this cryogenic chamber make me look fat?\nno")
         ]
 
 

--- a/exercises/difference-of-squares/tests/Tests.elm
+++ b/exercises/difference-of-squares/tests/Tests.elm
@@ -11,27 +11,36 @@ tests =
         [ describe "square the sum of the numbers up to the given number"
             [ test "square of sum 5" <|
                 \() -> Expect.equal 225 (squareOfSum 5)
-            , test "square of sum 10" <|
-                \() -> Expect.equal 3025 (squareOfSum 10)
-            , test "square of sum 100" <|
-                \() -> Expect.equal 25502500 (squareOfSum 100)
+            , skip <|
+                test "square of sum 10" <|
+                    \() -> Expect.equal 3025 (squareOfSum 10)
+            , skip <|
+                test "square of sum 100" <|
+                    \() -> Expect.equal 25502500 (squareOfSum 100)
             ]
         , describe "sum the squares of the numbers up to the given number"
-            [ test "sum of squares 5" <|
-                \() -> Expect.equal 55 (sumOfSquares 5)
-            , test "sum of squares 10" <|
-                \() -> Expect.equal 385 (sumOfSquares 10)
-            , test "sum of squares 100" <|
-                \() -> Expect.equal 338350 (sumOfSquares 100)
+            [ skip <|
+                test "sum of squares 5" <|
+                    \() -> Expect.equal 55 (sumOfSquares 5)
+            , skip <|
+                test "sum of squares 10" <|
+                    \() -> Expect.equal 385 (sumOfSquares 10)
+            , skip <|
+                test "sum of squares 100" <|
+                    \() -> Expect.equal 338350 (sumOfSquares 100)
             ]
         , describe "subtract sum of squares from square of sums"
-            [ test "difference of squares 0" <|
-                \() -> Expect.equal 0 (difference 0)
-            , test "difference of squares 5" <|
-                \() -> Expect.equal 170 (difference 5)
-            , test "difference of squares 10" <|
-                \() -> Expect.equal 2640 (difference 10)
-            , test "difference of squares 100" <|
-                \() -> Expect.equal 25164150 (difference 100)
+            [ skip <|
+                test "difference of squares 0" <|
+                    \() -> Expect.equal 0 (difference 0)
+            , skip <|
+                test "difference of squares 5" <|
+                    \() -> Expect.equal 170 (difference 5)
+            , skip <|
+                test "difference of squares 10" <|
+                    \() -> Expect.equal 2640 (difference 10)
+            , skip <|
+                test "difference of squares 100" <|
+                    \() -> Expect.equal 25164150 (difference 100)
             ]
         ]

--- a/exercises/gigasecond/tests/Tests.elm
+++ b/exercises/gigasecond/tests/Tests.elm
@@ -13,18 +13,22 @@ tests =
             [ test "2011-04-25" <|
                 \() ->
                     Expect.equal (date "2043-01-01T01:46:40") (Gigasecond.add (date "2011-04-25"))
-            , test "1977-06-13" <|
-                \() ->
-                    Expect.equal (date "2009-02-19T01:46:40") (Gigasecond.add (date "1977-06-13"))
-            , test "1959-07-19" <|
-                \() ->
-                    Expect.equal (date "1991-03-27T01:46:40") (Gigasecond.add (date "1959-07-19"))
-            , test "full time specified" <|
-                \() ->
-                    Expect.equal (date "2046-10-02T23:46:40") (Gigasecond.add (date "2015-01-24T22:00:00"))
-            , test "full time with day roll-over" <|
-                \() ->
-                    Expect.equal (date "2046-10-03T01:46:39") (Gigasecond.add (date "2015-01-24T23:59:59"))
+            , skip <|
+                test "1977-06-13" <|
+                    \() ->
+                        Expect.equal (date "2009-02-19T01:46:40") (Gigasecond.add (date "1977-06-13"))
+            , skip <|
+                test "1959-07-19" <|
+                    \() ->
+                        Expect.equal (date "1991-03-27T01:46:40") (Gigasecond.add (date "1959-07-19"))
+            , skip <|
+                test "full time specified" <|
+                    \() ->
+                        Expect.equal (date "2046-10-02T23:46:40") (Gigasecond.add (date "2015-01-24T22:00:00"))
+            , skip <|
+                test "full time with day roll-over" <|
+                    \() ->
+                        Expect.equal (date "2046-10-03T01:46:39") (Gigasecond.add (date "2015-01-24T23:59:59"))
             ]
         ]
 

--- a/exercises/grade-school/tests/Tests.elm
+++ b/exercises/grade-school/tests/Tests.elm
@@ -15,45 +15,50 @@ tests =
                         |> addStudent 2 "Aimee"
                         |> studentsInGrade 2
                     )
-        , test "add more students in same class" <|
-            \() ->
-                Expect.equal [ "Blair", "James", "Paul" ]
-                    (GradeSchool.empty
-                        |> addStudent 2 "James"
-                        |> addStudent 2 "Blair"
-                        |> addStudent 2 "Paul"
-                        |> studentsInGrade 2
-                    )
-        , test "add students to different grades" <|
-            \() ->
-                Expect.equal [ [ "Chelsea" ], [ "Logan" ] ]
-                    (let
-                        school =
-                            GradeSchool.empty
-                                |> addStudent 3 "Chelsea"
-                                |> addStudent 7 "Logan"
-                     in
-                        [ studentsInGrade 3 school, studentsInGrade 7 school ]
-                    )
-        , test "get students in a grade" <|
-            \() ->
-                Expect.equal [ "Bradley", "Franklin" ]
-                    (GradeSchool.empty
-                        |> addStudent 5 "Franklin"
-                        |> addStudent 5 "Bradley"
-                        |> addStudent 1 "Jeff"
-                        |> studentsInGrade 5
-                    )
-        , test "get all students in the school" <|
-            \() ->
-                Expect.equal [ ( 3, [ "Kyle" ] ), ( 4, [ "Christopher", "Jennifer" ] ), ( 6, [ "Kareem" ] ) ]
-                    (GradeSchool.empty
-                        |> addStudent 4 "Jennifer"
-                        |> addStudent 6 "Kareem"
-                        |> addStudent 4 "Christopher"
-                        |> addStudent 3 "Kyle"
-                        |> allStudents
-                    )
-        , test "get students in a non-existent grade" <|
-            \() -> Expect.equal [] (studentsInGrade 1 GradeSchool.empty)
+        , skip <|
+            test "add more students in same class" <|
+                \() ->
+                    Expect.equal [ "Blair", "James", "Paul" ]
+                        (GradeSchool.empty
+                            |> addStudent 2 "James"
+                            |> addStudent 2 "Blair"
+                            |> addStudent 2 "Paul"
+                            |> studentsInGrade 2
+                        )
+        , skip <|
+            test "add students to different grades" <|
+                \() ->
+                    Expect.equal [ [ "Chelsea" ], [ "Logan" ] ]
+                        (let
+                            school =
+                                GradeSchool.empty
+                                    |> addStudent 3 "Chelsea"
+                                    |> addStudent 7 "Logan"
+                         in
+                            [ studentsInGrade 3 school, studentsInGrade 7 school ]
+                        )
+        , skip <|
+            test "get students in a grade" <|
+                \() ->
+                    Expect.equal [ "Bradley", "Franklin" ]
+                        (GradeSchool.empty
+                            |> addStudent 5 "Franklin"
+                            |> addStudent 5 "Bradley"
+                            |> addStudent 1 "Jeff"
+                            |> studentsInGrade 5
+                        )
+        , skip <|
+            test "get all students in the school" <|
+                \() ->
+                    Expect.equal [ ( 3, [ "Kyle" ] ), ( 4, [ "Christopher", "Jennifer" ] ), ( 6, [ "Kareem" ] ) ]
+                        (GradeSchool.empty
+                            |> addStudent 4 "Jennifer"
+                            |> addStudent 6 "Kareem"
+                            |> addStudent 4 "Christopher"
+                            |> addStudent 3 "Kyle"
+                            |> allStudents
+                        )
+        , skip <|
+            test "get students in a non-existent grade" <|
+                \() -> Expect.equal [] (studentsInGrade 1 GradeSchool.empty)
         ]

--- a/exercises/grains/tests/Tests.elm
+++ b/exercises/grains/tests/Tests.elm
@@ -12,20 +12,27 @@ tests =
         [ describe "square"
             [ test "of 1" <|
                 \() -> Expect.equal (Just 1) (square 1)
-            , test "of 2" <|
-                \() -> Expect.equal (Just 2) (square 2)
-            , test "of 3" <|
-                \() -> Expect.equal (Just 4) (square 3)
-            , test "of 4" <|
-                \() -> Expect.equal (Just 8) (square 4)
-            , test "of 16" <|
-                \() -> Expect.equal (Just 32768) (square 16)
-            , test "of 32" <|
-                \() -> Expect.equal (Just 2147483648) (square 32)
-            , test "square 0 raises an exception" <|
-                \() -> Expect.equal Nothing (square 0)
-            , test "negative square raises an exception" <|
-                \() -> Expect.equal Nothing (square -1)
+            , skip <|
+                test "of 2" <|
+                    \() -> Expect.equal (Just 2) (square 2)
+            , skip <|
+                test "of 3" <|
+                    \() -> Expect.equal (Just 4) (square 3)
+            , skip <|
+                test "of 4" <|
+                    \() -> Expect.equal (Just 8) (square 4)
+            , skip <|
+                test "of 16" <|
+                    \() -> Expect.equal (Just 32768) (square 16)
+            , skip <|
+                test "of 32" <|
+                    \() -> Expect.equal (Just 2147483648) (square 32)
+            , skip <|
+                test "square 0 raises an exception" <|
+                    \() -> Expect.equal Nothing (square 0)
+            , skip <|
+                test "negative square raises an exception" <|
+                    \() -> Expect.equal Nothing (square -1)
 
             {-
                Where are the bigger test values?!? Because Javascript's numbers

--- a/exercises/hamming/tests/Tests.elm
+++ b/exercises/hamming/tests/Tests.elm
@@ -10,30 +10,43 @@ tests =
     describe "Hamming"
         [ test "identical strands" <|
             \() -> Expect.equal (Just 0) (distance "A" "A")
-        , test "long identical strands" <|
-            \() -> Expect.equal (Just 0) (distance "GGACTGA" "GGACTGA")
-        , test "complete distance in single nucleotide strands" <|
-            \() -> Expect.equal (Just 1) (distance "A" "G")
-        , test "complete distance in small strands" <|
-            \() -> Expect.equal (Just 2) (distance "AG" "CT")
-        , test "small distance in small strands" <|
-            \() -> Expect.equal (Just 1) (distance "AT" "CT")
-        , test "small distance" <|
-            \() -> Expect.equal (Just 1) (distance "GGACG" "GGTCG")
-        , test "small distance in long strands" <|
-            \() -> Expect.equal (Just 2) (distance "ACCAGGG" "ACTATGG")
-        , test "non-unique character in first strand" <|
-            \() -> Expect.equal (Just 1) (distance "AGA" "AGG")
-        , test "non-unique character in second strand" <|
-            \() -> Expect.equal (Just 1) (distance "AGG" "AGA")
-        , test "large distance" <|
-            \() -> Expect.equal (Just 4) (distance "GATACA" "GCATAA")
-        , test "large distance in off-by-one strand" <|
-            \() -> Expect.equal (Just 9) (distance "GGACGGATTCTG" "AGGACGGATTCT")
-        , test "empty strands" <|
-            \() -> Expect.equal (Just 0) (distance "" "")
-        , test "disallow first strand longer" <|
-            \() -> Expect.equal Nothing (distance "AATG" "AAA")
-        , test "disallow second strand longer" <|
-            \() -> Expect.equal Nothing (distance "ATA" "AGTG")
+        , skip <|
+            test "long identical strands" <|
+                \() -> Expect.equal (Just 0) (distance "GGACTGA" "GGACTGA")
+        , skip <|
+            test "complete distance in single nucleotide strands" <|
+                \() -> Expect.equal (Just 1) (distance "A" "G")
+        , skip <|
+            test "complete distance in small strands" <|
+                \() -> Expect.equal (Just 2) (distance "AG" "CT")
+        , skip <|
+            test "small distance in small strands" <|
+                \() -> Expect.equal (Just 1) (distance "AT" "CT")
+        , skip <|
+            test "small distance" <|
+                \() -> Expect.equal (Just 1) (distance "GGACG" "GGTCG")
+        , skip <|
+            test "small distance in long strands" <|
+                \() -> Expect.equal (Just 2) (distance "ACCAGGG" "ACTATGG")
+        , skip <|
+            test "non-unique character in first strand" <|
+                \() -> Expect.equal (Just 1) (distance "AGA" "AGG")
+        , skip <|
+            test "non-unique character in second strand" <|
+                \() -> Expect.equal (Just 1) (distance "AGG" "AGA")
+        , skip <|
+            test "large distance" <|
+                \() -> Expect.equal (Just 4) (distance "GATACA" "GCATAA")
+        , skip <|
+            test "large distance in off-by-one strand" <|
+                \() -> Expect.equal (Just 9) (distance "GGACGGATTCTG" "AGGACGGATTCT")
+        , skip <|
+            test "empty strands" <|
+                \() -> Expect.equal (Just 0) (distance "" "")
+        , skip <|
+            test "disallow first strand longer" <|
+                \() -> Expect.equal Nothing (distance "AATG" "AAA")
+        , skip <|
+            test "disallow second strand longer" <|
+                \() -> Expect.equal Nothing (distance "ATA" "AGTG")
         ]

--- a/exercises/hello-world/tests/Tests.elm
+++ b/exercises/hello-world/tests/Tests.elm
@@ -11,6 +11,10 @@ tests =
         [ test "Hello with no name" <|
             \() ->
                 Expect.equal "Hello, World!" (helloWorld Nothing)
+
+        -- Once you get the first test passing, remove the
+        -- `skip <|` (just leave the comma) on the next two
+        -- lines to continue!
         , skip <|
             test "Hello to a sample name" <|
                 \() ->

--- a/exercises/hello-world/tests/Tests.elm
+++ b/exercises/hello-world/tests/Tests.elm
@@ -11,10 +11,12 @@ tests =
         [ test "Hello with no name" <|
             \() ->
                 Expect.equal "Hello, World!" (helloWorld Nothing)
-        , test "Hello to a sample name" <|
-            \() ->
-                Expect.equal "Hello, Alice!" (helloWorld (Just "Alice"))
-        , test "Hello to another sample name" <|
-            \() ->
-                Expect.equal "Hello, Bob!" (helloWorld (Just "Bob"))
+        , skip <|
+            test "Hello to a sample name" <|
+                \() ->
+                    Expect.equal "Hello, Alice!" (helloWorld (Just "Alice"))
+        , skip <|
+            test "Hello to another sample name" <|
+                \() ->
+                    Expect.equal "Hello, Bob!" (helloWorld (Just "Bob"))
         ]

--- a/exercises/largest-series-product/tests/Tests.elm
+++ b/exercises/largest-series-product/tests/Tests.elm
@@ -10,36 +10,52 @@ tests =
     describe "largestProduct"
         [ test "can find the largest product of 2 with numbers in order" <|
             \() -> Expect.equal (Just 72) (largestProduct 2 "0123456789")
-        , test "can find the largest product of 2" <|
-            \() -> Expect.equal (Just 48) (largestProduct 2 "576802143")
-        , test "finds the largest product if span equals length" <|
-            \() -> Expect.equal (Just 18) (largestProduct 2 "29")
-        , test "can find the largest product of 3 with numbers in order" <|
-            \() -> Expect.equal (Just 504) (largestProduct 3 "0123456789")
-        , test "can find the largest product of 3" <|
-            \() -> Expect.equal (Just 270) (largestProduct 3 "1027839564")
-        , test "can find the largest product of 5 with numbers in order" <|
-            \() -> Expect.equal (Just 15120) (largestProduct 5 "0123456789")
-        , test "can get the largest product of a big number" <|
-            \() -> Expect.equal (Just 23520) (largestProduct 6 "73167176531330624919225119674426574742355349194934")
-        , test "can get the largest product of a big number II" <|
-            \() -> Expect.equal (Just 28350) (largestProduct 6 "52677741234314237566414902593461595376319419139427")
-        , test "can get the largest product of a big number (Project Euler)" <|
-            \() -> Expect.equal (Just 23514624000) (largestProduct 13 "7316717653133062491922511967442657474235534919493496983520312774506326239578318016984801869478851843858615607891129494954595017379583319528532088055111254069874715852386305071569329096329522744304355766896648950445244523161731856403098711121722383113622298934233803081353362766142828064444866452387493035890729629049156044077239071381051585930796086670172427121883998797908792274921901699720888093776657273330010533678812202354218097512545405947522435258490771167055601360483958644670632441572215539753697817977846174064955149290862569321978468622482839722413756570560574902614079729686524145351004748216637048440319989000889524345065854122758866688116427171479924442928230863465674813919123162824586178664583591245665294765456828489128831426076900422421902267105562632111110937054421750694165896040807198403850962455444362981230987879927244284909188845801561660979191338754992005240636899125607176060588611646710940507754100225698315520005593572972571636269561882670428252483600823257530420752963450")
-        , test "reports zero if the only digits are zero" <|
-            \() -> Expect.equal (Just 0) (largestProduct 2 "0000")
-        , test "reports zero if all spans include zero" <|
-            \() -> Expect.equal (Just 0) (largestProduct 3 "99099")
-        , test "rejects span longer than string length" <|
-            \() -> Expect.equal Nothing (largestProduct 4 "123")
-        , test "reports 1 for empty string and empty product (0 span)" <|
-            \() -> Expect.equal (Just 1) (largestProduct 0 "")
-        , test "reports 1 for nonempty string and empty product (0 span)" <|
-            \() -> Expect.equal (Just 1) (largestProduct 0 "123")
-        , test "rejects empty string and nonzero span" <|
-            \() -> Expect.equal Nothing (largestProduct 1 "")
-        , test "rejects invalid character in digits" <|
-            \() -> Expect.equal Nothing (largestProduct 2 "1234a5")
-        , test "rejects negative span" <|
-            \() -> Expect.equal Nothing (largestProduct -1 "12345")
+        , skip <|
+            test "can find the largest product of 2" <|
+                \() -> Expect.equal (Just 48) (largestProduct 2 "576802143")
+        , skip <|
+            test "finds the largest product if span equals length" <|
+                \() -> Expect.equal (Just 18) (largestProduct 2 "29")
+        , skip <|
+            test "can find the largest product of 3 with numbers in order" <|
+                \() -> Expect.equal (Just 504) (largestProduct 3 "0123456789")
+        , skip <|
+            test "can find the largest product of 3" <|
+                \() -> Expect.equal (Just 270) (largestProduct 3 "1027839564")
+        , skip <|
+            test "can find the largest product of 5 with numbers in order" <|
+                \() -> Expect.equal (Just 15120) (largestProduct 5 "0123456789")
+        , skip <|
+            test "can get the largest product of a big number" <|
+                \() -> Expect.equal (Just 23520) (largestProduct 6 "73167176531330624919225119674426574742355349194934")
+        , skip <|
+            test "can get the largest product of a big number II" <|
+                \() -> Expect.equal (Just 28350) (largestProduct 6 "52677741234314237566414902593461595376319419139427")
+        , skip <|
+            test "can get the largest product of a big number (Project Euler)" <|
+                \() -> Expect.equal (Just 23514624000) (largestProduct 13 "7316717653133062491922511967442657474235534919493496983520312774506326239578318016984801869478851843858615607891129494954595017379583319528532088055111254069874715852386305071569329096329522744304355766896648950445244523161731856403098711121722383113622298934233803081353362766142828064444866452387493035890729629049156044077239071381051585930796086670172427121883998797908792274921901699720888093776657273330010533678812202354218097512545405947522435258490771167055601360483958644670632441572215539753697817977846174064955149290862569321978468622482839722413756570560574902614079729686524145351004748216637048440319989000889524345065854122758866688116427171479924442928230863465674813919123162824586178664583591245665294765456828489128831426076900422421902267105562632111110937054421750694165896040807198403850962455444362981230987879927244284909188845801561660979191338754992005240636899125607176060588611646710940507754100225698315520005593572972571636269561882670428252483600823257530420752963450")
+        , skip <|
+            test "reports zero if the only digits are zero" <|
+                \() -> Expect.equal (Just 0) (largestProduct 2 "0000")
+        , skip <|
+            test "reports zero if all spans include zero" <|
+                \() -> Expect.equal (Just 0) (largestProduct 3 "99099")
+        , skip <|
+            test "rejects span longer than string length" <|
+                \() -> Expect.equal Nothing (largestProduct 4 "123")
+        , skip <|
+            test "reports 1 for empty string and empty product (0 span)" <|
+                \() -> Expect.equal (Just 1) (largestProduct 0 "")
+        , skip <|
+            test "reports 1 for nonempty string and empty product (0 span)" <|
+                \() -> Expect.equal (Just 1) (largestProduct 0 "123")
+        , skip <|
+            test "rejects empty string and nonzero span" <|
+                \() -> Expect.equal Nothing (largestProduct 1 "")
+        , skip <|
+            test "rejects invalid character in digits" <|
+                \() -> Expect.equal Nothing (largestProduct 2 "1234a5")
+        , skip <|
+            test "rejects negative span" <|
+                \() -> Expect.equal Nothing (largestProduct -1 "12345")
         ]

--- a/exercises/leap/tests/Tests.elm
+++ b/exercises/leap/tests/Tests.elm
@@ -10,16 +10,22 @@ tests =
     describe "Leap"
         [ test "leap year" <|
             \() -> Expect.equal True (Leap.isLeapYear 1996)
-        , test "non-leap year" <|
-            \() -> Expect.equal False (Leap.isLeapYear 1997)
-        , test "non-leap even year" <|
-            \() -> Expect.equal False (Leap.isLeapYear 1998)
-        , test "century" <|
-            \() -> Expect.equal False (Leap.isLeapYear 1900)
-        , test "second century" <|
-            \() -> Expect.equal False (Leap.isLeapYear 1800)
-        , test "fourth century" <|
-            \() -> Expect.equal True (Leap.isLeapYear 2400)
-        , test "y2k" <|
-            \() -> Expect.equal True (Leap.isLeapYear 2000)
+        , skip <|
+            test "non-leap year" <|
+                \() -> Expect.equal False (Leap.isLeapYear 1997)
+        , skip <|
+            test "non-leap even year" <|
+                \() -> Expect.equal False (Leap.isLeapYear 1998)
+        , skip <|
+            test "century" <|
+                \() -> Expect.equal False (Leap.isLeapYear 1900)
+        , skip <|
+            test "second century" <|
+                \() -> Expect.equal False (Leap.isLeapYear 1800)
+        , skip <|
+            test "fourth century" <|
+                \() -> Expect.equal True (Leap.isLeapYear 2400)
+        , skip <|
+            test "y2k" <|
+                \() -> Expect.equal True (Leap.isLeapYear 2000)
         ]

--- a/exercises/list-ops/tests/Tests.elm
+++ b/exercises/list-ops/tests/Tests.elm
@@ -11,57 +11,76 @@ tests =
         [ describe "length"
             [ test "empty list" <|
                 \() -> Expect.equal 0 (ListOps.length [])
-            , test "non-empty list" <|
-                \() -> Expect.equal 4 (ListOps.length (List.range 1 4))
+            , skip <|
+                test "non-empty list" <|
+                    \() -> Expect.equal 4 (ListOps.length (List.range 1 4))
             ]
         , describe "reverse"
-            [ test "empty list" <|
-                \() -> Expect.equal [] (ListOps.reverse [])
-            , test "non-empty list" <|
-                \() -> Expect.equal [ 4, 3, 2, 1 ] (ListOps.reverse (List.range 1 4))
+            [ skip <|
+                test "empty list" <|
+                    \() -> Expect.equal [] (ListOps.reverse [])
+            , skip <|
+                test "non-empty list" <|
+                    \() -> Expect.equal [ 4, 3, 2, 1 ] (ListOps.reverse (List.range 1 4))
             ]
         , describe "map"
-            [ test "empty list" <|
-                \() -> Expect.equal [] (ListOps.map ((+) 1) [])
-            , test "non-empty list" <|
-                \() -> Expect.equal (List.range 2 5) (ListOps.map ((+) 1) (List.range 1 4))
+            [ skip <|
+                test "empty list" <|
+                    \() -> Expect.equal [] (ListOps.map ((+) 1) [])
+            , skip <|
+                test "non-empty list" <|
+                    \() -> Expect.equal (List.range 2 5) (ListOps.map ((+) 1) (List.range 1 4))
             ]
         , describe "filter"
-            [ test "empty list" <|
-                \() -> Expect.equal [] (ListOps.filter (\_ -> True) [])
-            , test "non-empty list" <|
-                \() -> Expect.equal [ 2, 4 ] (ListOps.filter (\x -> x % 2 == 0) (List.range 1 4))
+            [ skip <|
+                test "empty list" <|
+                    \() -> Expect.equal [] (ListOps.filter (\_ -> True) [])
+            , skip <|
+                test "non-empty list" <|
+                    \() -> Expect.equal [ 2, 4 ] (ListOps.filter (\x -> x % 2 == 0) (List.range 1 4))
             ]
         , describe "foldl"
-            [ test "empty list" <|
-                \() -> Expect.equal 0 (ListOps.foldl (+) 0 [])
-            , test "non-empty list" <|
-                \() -> Expect.equal 10 (ListOps.foldl (+) 0 (List.range 1 4))
-            , test "direction" <|
-                \() -> Expect.equal [ 4, 3, 2, 1 ] (ListOps.foldl (::) [] (List.range 1 4))
+            [ skip <|
+                test "empty list" <|
+                    \() -> Expect.equal 0 (ListOps.foldl (+) 0 [])
+            , skip <|
+                test "non-empty list" <|
+                    \() -> Expect.equal 10 (ListOps.foldl (+) 0 (List.range 1 4))
+            , skip <|
+                test "direction" <|
+                    \() -> Expect.equal [ 4, 3, 2, 1 ] (ListOps.foldl (::) [] (List.range 1 4))
             ]
         , describe "foldr"
-            [ test "empty list" <|
-                \() -> Expect.equal 0 (ListOps.foldr (+) 0 [])
-            , test "non-empty list" <|
-                \() -> Expect.equal 10 (ListOps.foldr (+) 0 (List.range 1 4))
-            , test "direction" <|
-                \() -> Expect.equal (List.range 1 4) (ListOps.foldr (::) [] (List.range 1 4))
+            [ skip <|
+                test "empty list" <|
+                    \() -> Expect.equal 0 (ListOps.foldr (+) 0 [])
+            , skip <|
+                test "non-empty list" <|
+                    \() -> Expect.equal 10 (ListOps.foldr (+) 0 (List.range 1 4))
+            , skip <|
+                test "direction" <|
+                    \() -> Expect.equal (List.range 1 4) (ListOps.foldr (::) [] (List.range 1 4))
             ]
         , describe "append"
-            [ test "empty lists" <|
-                \() -> Expect.equal [] (ListOps.append [] [])
-            , test "empty and non-empty lists" <|
-                \() -> Expect.equal (List.range 1 4) (ListOps.append [] (List.range 1 4))
-            , test "non-empty and empty lists" <|
-                \() -> Expect.equal (List.range 1 4) (ListOps.append (List.range 1 4) [])
-            , test "non-empty lists" <|
-                \() -> Expect.equal (List.range 1 8) (ListOps.append (List.range 1 4) (List.range 5 8))
+            [ skip <|
+                test "empty lists" <|
+                    \() -> Expect.equal [] (ListOps.append [] [])
+            , skip <|
+                test "empty and non-empty lists" <|
+                    \() -> Expect.equal (List.range 1 4) (ListOps.append [] (List.range 1 4))
+            , skip <|
+                test "non-empty and empty lists" <|
+                    \() -> Expect.equal (List.range 1 4) (ListOps.append (List.range 1 4) [])
+            , skip <|
+                test "non-empty lists" <|
+                    \() -> Expect.equal (List.range 1 8) (ListOps.append (List.range 1 4) (List.range 5 8))
             ]
         , describe "concat"
-            [ test "empty list" <|
-                \() -> Expect.equal [] (ListOps.concat [])
-            , test "list of lists" <|
-                \() -> Expect.equal (List.range 1 10) (ListOps.concat [ List.range 1 3, [], List.range 4 7, List.range 8 10 ])
+            [ skip <|
+                test "empty list" <|
+                    \() -> Expect.equal [] (ListOps.concat [])
+            , skip <|
+                test "list of lists" <|
+                    \() -> Expect.equal (List.range 1 10) (ListOps.concat [ List.range 1 3, [], List.range 4 7, List.range 8 10 ])
             ]
         ]

--- a/exercises/nucleotide-count/tests/Tests.elm
+++ b/exercises/nucleotide-count/tests/Tests.elm
@@ -10,11 +10,10 @@ tests =
     describe "NucleotideCount"
         [ test "the solution is for the correct version of the test" <|
             \() -> Expect.equal 2 version
-        , skip <|
-            test "empty dna strand has no nucleotides" <|
-                \() ->
-                    Expect.equal { a = 0, t = 0, c = 0, g = 0 }
-                        (nucleotideCounts "")
+        , test "empty dna strand has no nucleotides" <|
+            \() ->
+                Expect.equal { a = 0, t = 0, c = 0, g = 0 }
+                    (nucleotideCounts "")
         , skip <|
             test "repetitive sequence has only guanine" <|
                 \() ->

--- a/exercises/nucleotide-count/tests/Tests.elm
+++ b/exercises/nucleotide-count/tests/Tests.elm
@@ -10,16 +10,19 @@ tests =
     describe "NucleotideCount"
         [ test "the solution is for the correct version of the test" <|
             \() -> Expect.equal 2 version
-        , test "empty dna strand has no nucleotides" <|
-            \() ->
-                Expect.equal { a = 0, t = 0, c = 0, g = 0 }
-                    (nucleotideCounts "")
-        , test "repetitive sequence has only guanine" <|
-            \() ->
-                Expect.equal { a = 0, t = 0, c = 0, g = 8 }
-                    (nucleotideCounts "GGGGGGGG")
-        , test "counts all nucleotides" <|
-            \() ->
-                Expect.equal { a = 20, t = 21, c = 12, g = 17 }
-                    (nucleotideCounts "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC")
+        , skip <|
+            test "empty dna strand has no nucleotides" <|
+                \() ->
+                    Expect.equal { a = 0, t = 0, c = 0, g = 0 }
+                        (nucleotideCounts "")
+        , skip <|
+            test "repetitive sequence has only guanine" <|
+                \() ->
+                    Expect.equal { a = 0, t = 0, c = 0, g = 8 }
+                        (nucleotideCounts "GGGGGGGG")
+        , skip <|
+            test "counts all nucleotides" <|
+                \() ->
+                    Expect.equal { a = 20, t = 21, c = 12, g = 17 }
+                        (nucleotideCounts "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC")
         ]

--- a/exercises/pangram/tests/Tests.elm
+++ b/exercises/pangram/tests/Tests.elm
@@ -12,40 +12,49 @@ tests =
             \() ->
                 Expect.equal False
                     (isPangram "")
-        , test "pangram with only lower case" <|
-            \() ->
-                Expect.equal True
-                    (isPangram "the quick brown fox jumps over the lazy dog")
-        , test "missing character 'x'" <|
-            \() ->
-                Expect.equal False
-                    (isPangram "a quick movement of the enemy will jeopardize five gunboats")
-        , test "missing character 'z'" <|
-            \() ->
-                Expect.equal False
-                    (isPangram "a quick movement of the enemy will jeopardixe five gunboats")
-        , test "another missing character 'x'" <|
-            \() ->
-                Expect.equal False
-                    (isPangram "the quick brown fish jumps over the lazy dog")
-        , test "pangram with underscores" <|
-            \() ->
-                Expect.equal True
-                    (isPangram "the_quick_brown_fox_jumps_over_the_lazy_dog")
-        , test "pangram with numbers" <|
-            \() ->
-                Expect.equal True
-                    (isPangram "the 1 quick brown fox jumps over the 2 lazy dogs")
-        , test "missing letters replaced by numbers" <|
-            \() ->
-                Expect.equal False
-                    (isPangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog")
-        , test "pangram with mixed case and punctuation" <|
-            \() ->
-                Expect.equal True
-                    (isPangram "\"Five quacking Zephyrs jolt my wax bed.\"")
-        , test "pangram with non ascii characters" <|
-            \() ->
-                Expect.equal True
-                    (isPangram "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.")
+        , skip <|
+            test "pangram with only lower case" <|
+                \() ->
+                    Expect.equal True
+                        (isPangram "the quick brown fox jumps over the lazy dog")
+        , skip <|
+            test "missing character 'x'" <|
+                \() ->
+                    Expect.equal False
+                        (isPangram "a quick movement of the enemy will jeopardize five gunboats")
+        , skip <|
+            test "missing character 'z'" <|
+                \() ->
+                    Expect.equal False
+                        (isPangram "a quick movement of the enemy will jeopardixe five gunboats")
+        , skip <|
+            test "another missing character 'x'" <|
+                \() ->
+                    Expect.equal False
+                        (isPangram "the quick brown fish jumps over the lazy dog")
+        , skip <|
+            test "pangram with underscores" <|
+                \() ->
+                    Expect.equal True
+                        (isPangram "the_quick_brown_fox_jumps_over_the_lazy_dog")
+        , skip <|
+            test "pangram with numbers" <|
+                \() ->
+                    Expect.equal True
+                        (isPangram "the 1 quick brown fox jumps over the 2 lazy dogs")
+        , skip <|
+            test "missing letters replaced by numbers" <|
+                \() ->
+                    Expect.equal False
+                        (isPangram "7h3 qu1ck brown fox jumps ov3r 7h3 lazy dog")
+        , skip <|
+            test "pangram with mixed case and punctuation" <|
+                \() ->
+                    Expect.equal True
+                        (isPangram "\"Five quacking Zephyrs jolt my wax bed.\"")
+        , skip <|
+            test "pangram with non ascii characters" <|
+                \() ->
+                    Expect.equal True
+                        (isPangram "Victor jagt zwölf Boxkämpfer quer über den großen Sylter Deich.")
         ]

--- a/exercises/phone-number/tests/Tests.elm
+++ b/exercises/phone-number/tests/Tests.elm
@@ -10,26 +10,37 @@ tests =
     describe "PhoneNumber"
         [ test "cleans number" <|
             \() -> Expect.equal (Just "1234567890") (getNumber "(123) 456-7890")
-        , test "cleans number with dots" <|
-            \() -> Expect.equal (Just "1234567890") (getNumber "123.456.7890")
-        , test "valid when 11 digits and first is 1" <|
-            \() -> Expect.equal (Just "1234567890") (getNumber "11234567890")
-        , test "invalid when 11 digits" <|
-            \() -> Expect.equal Nothing (getNumber "21234567890")
-        , test "invalid when 9 digits" <|
-            \() -> Expect.equal Nothing (getNumber "123456789")
-        , test "invalid when 12 digits" <|
-            \() -> Expect.equal Nothing (getNumber "123456789012")
-        , test "invalid when empty" <|
-            \() -> Expect.equal Nothing (getNumber "")
-        , test "invalid when no digits present" <|
-            \() -> Expect.equal Nothing (getNumber " (-) ")
-        , test "valid with leading characters" <|
-            \() -> Expect.equal (Just "1234567890") (getNumber "my number is 123 456 7890")
-        , test "valid with trailing characters" <|
-            \() -> Expect.equal (Just "1234567890") (getNumber "123 456 7890 - bob")
-        , test "pretty print" <|
-            \() -> Expect.equal (Just "(123) 456-7890") (prettyPrint "1234567890")
-        , test "pretty print with full us phone number" <|
-            \() -> Expect.equal (Just "(123) 456-7890") (prettyPrint "11234567890")
+        , skip <|
+            test "cleans number with dots" <|
+                \() -> Expect.equal (Just "1234567890") (getNumber "123.456.7890")
+        , skip <|
+            test "valid when 11 digits and first is 1" <|
+                \() -> Expect.equal (Just "1234567890") (getNumber "11234567890")
+        , skip <|
+            test "invalid when 11 digits" <|
+                \() -> Expect.equal Nothing (getNumber "21234567890")
+        , skip <|
+            test "invalid when 9 digits" <|
+                \() -> Expect.equal Nothing (getNumber "123456789")
+        , skip <|
+            test "invalid when 12 digits" <|
+                \() -> Expect.equal Nothing (getNumber "123456789012")
+        , skip <|
+            test "invalid when empty" <|
+                \() -> Expect.equal Nothing (getNumber "")
+        , skip <|
+            test "invalid when no digits present" <|
+                \() -> Expect.equal Nothing (getNumber " (-) ")
+        , skip <|
+            test "valid with leading characters" <|
+                \() -> Expect.equal (Just "1234567890") (getNumber "my number is 123 456 7890")
+        , skip <|
+            test "valid with trailing characters" <|
+                \() -> Expect.equal (Just "1234567890") (getNumber "123 456 7890 - bob")
+        , skip <|
+            test "pretty print" <|
+                \() -> Expect.equal (Just "(123) 456-7890") (prettyPrint "1234567890")
+        , skip <|
+            test "pretty print with full us phone number" <|
+                \() -> Expect.equal (Just "(123) 456-7890") (prettyPrint "11234567890")
         ]

--- a/exercises/raindrops/tests/Tests.elm
+++ b/exercises/raindrops/tests/Tests.elm
@@ -10,32 +10,46 @@ tests =
     describe "Raindrops"
         [ test "1" <|
             \() -> Expect.equal "1" (raindrops 1)
-        , test "3" <|
-            \() -> Expect.equal "Pling" (raindrops 3)
-        , test "5" <|
-            \() -> Expect.equal "Plang" (raindrops 5)
-        , test "7" <|
-            \() -> Expect.equal "Plong" (raindrops 7)
-        , test "6" <|
-            \() -> Expect.equal "Pling" (raindrops 6)
-        , test "9" <|
-            \() -> Expect.equal "Pling" (raindrops 9)
-        , test "10" <|
-            \() -> Expect.equal "Plang" (raindrops 10)
-        , test "14" <|
-            \() -> Expect.equal "Plong" (raindrops 14)
-        , test "15" <|
-            \() -> Expect.equal "PlingPlang" (raindrops 15)
-        , test "21" <|
-            \() -> Expect.equal "PlingPlong" (raindrops 21)
-        , test "25" <|
-            \() -> Expect.equal "Plang" (raindrops 25)
-        , test "35" <|
-            \() -> Expect.equal "PlangPlong" (raindrops 35)
-        , test "49" <|
-            \() -> Expect.equal "Plong" (raindrops 49)
-        , test "52" <|
-            \() -> Expect.equal "52" (raindrops 52)
-        , test "105" <|
-            \() -> Expect.equal "PlingPlangPlong" (raindrops 105)
+        , skip <|
+            test "3" <|
+                \() -> Expect.equal "Pling" (raindrops 3)
+        , skip <|
+            test "5" <|
+                \() -> Expect.equal "Plang" (raindrops 5)
+        , skip <|
+            test "7" <|
+                \() -> Expect.equal "Plong" (raindrops 7)
+        , skip <|
+            test "6" <|
+                \() -> Expect.equal "Pling" (raindrops 6)
+        , skip <|
+            test "9" <|
+                \() -> Expect.equal "Pling" (raindrops 9)
+        , skip <|
+            test "10" <|
+                \() -> Expect.equal "Plang" (raindrops 10)
+        , skip <|
+            test "14" <|
+                \() -> Expect.equal "Plong" (raindrops 14)
+        , skip <|
+            test "15" <|
+                \() -> Expect.equal "PlingPlang" (raindrops 15)
+        , skip <|
+            test "21" <|
+                \() -> Expect.equal "PlingPlong" (raindrops 21)
+        , skip <|
+            test "25" <|
+                \() -> Expect.equal "Plang" (raindrops 25)
+        , skip <|
+            test "35" <|
+                \() -> Expect.equal "PlangPlong" (raindrops 35)
+        , skip <|
+            test "49" <|
+                \() -> Expect.equal "Plong" (raindrops 49)
+        , skip <|
+            test "52" <|
+                \() -> Expect.equal "52" (raindrops 52)
+        , skip <|
+            test "105" <|
+                \() -> Expect.equal "PlingPlangPlong" (raindrops 105)
         ]

--- a/exercises/rna-transcription/tests/Tests.elm
+++ b/exercises/rna-transcription/tests/Tests.elm
@@ -10,16 +10,22 @@ tests =
     describe "RNATranscription"
         [ test "complement of cytosine is guanine" <|
             \() -> Expect.equal (Ok "G") (toRNA "C")
-        , test "complement of guanine is cytosine" <|
-            \() -> Expect.equal (Ok "C") (toRNA "G")
-        , test "complement of thymine is adenine" <|
-            \() -> Expect.equal (Ok "A") (toRNA "T")
-        , test "complement of adenine is uracil" <|
-            \() -> Expect.equal (Ok "U") (toRNA "A")
-        , test "complement" <|
-            \() -> Expect.equal (Ok "UGCACCAGAAUU") (toRNA "ACGTGGTCTTAA")
-        , test "correctly handles completely invalid input" <|
-            \() -> Expect.equal (Err 'X') (toRNA "XXX")
-        , test "correctly handles partially invalid input" <|
-            \() -> Expect.equal (Err 'U') (toRNA "UGAAXXXGACAUG")
+        , skip <|
+            test "complement of guanine is cytosine" <|
+                \() -> Expect.equal (Ok "C") (toRNA "G")
+        , skip <|
+            test "complement of thymine is adenine" <|
+                \() -> Expect.equal (Ok "A") (toRNA "T")
+        , skip <|
+            test "complement of adenine is uracil" <|
+                \() -> Expect.equal (Ok "U") (toRNA "A")
+        , skip <|
+            test "complement" <|
+                \() -> Expect.equal (Ok "UGCACCAGAAUU") (toRNA "ACGTGGTCTTAA")
+        , skip <|
+            test "correctly handles completely invalid input" <|
+                \() -> Expect.equal (Err 'X') (toRNA "XXX")
+        , skip <|
+            test "correctly handles partially invalid input" <|
+                \() -> Expect.equal (Err 'U') (toRNA "UGAAXXXGACAUG")
         ]

--- a/exercises/robot-simulator/tests/Tests.elm
+++ b/exercises/robot-simulator/tests/Tests.elm
@@ -33,21 +33,23 @@ tests =
                         \() -> Expect.equal South robot.bearing
                 ]
             )
-        , describe "turn right"
-            ((List.range 1 3)
-                |> List.scanl (\_ r -> turnRight r) defaultRobot
-                |> List.map .bearing
-                |> assertionList [ North, East, South, West ]
-                |> List.indexedMap (\i e -> skip <| test ("step " ++ toString i) (\() -> e))
-            )
-        , describe
-            "turn left"
-            ((List.range 1 3)
-                |> List.scanl (\_ r -> turnLeft r) defaultRobot
-                |> List.map .bearing
-                |> assertionList [ North, West, South, East ]
-                |> List.indexedMap (\i e -> skip <| test ("step " ++ toString i) (\() -> e))
-            )
+        , skip <|
+            describe "turn right"
+                ((List.range 1 3)
+                    |> List.scanl (\_ r -> turnRight r) defaultRobot
+                    |> List.map .bearing
+                    |> assertionList [ North, East, South, West ]
+                    |> List.indexedMap (\i e -> test ("step " ++ toString i) (\() -> e))
+                )
+        , skip <|
+            describe
+                "turn left"
+                ((List.range 1 3)
+                    |> List.scanl (\_ r -> turnLeft r) defaultRobot
+                    |> List.map .bearing
+                    |> assertionList [ North, West, South, East ]
+                    |> List.indexedMap (\i e -> test ("step " ++ toString i) (\() -> e))
+                )
         , describe "advance positive north"
             (let
                 robot =

--- a/exercises/robot-simulator/tests/Tests.elm
+++ b/exercises/robot-simulator/tests/Tests.elm
@@ -15,8 +15,9 @@ tests =
              in
                 [ test "coordinates" <|
                     \() -> Expect.equal { x = 0, y = 0 } robot.coordinates
-                , test "bearing" <|
-                    \() -> Expect.equal North robot.bearing
+                , skip <|
+                    test "bearing" <|
+                        \() -> Expect.equal North robot.bearing
                 ]
             )
         , describe "setup"
@@ -24,10 +25,12 @@ tests =
                 robot =
                     Robot South { x = -1, y = 1 }
              in
-                [ test "coordinates" <|
-                    \() -> Expect.equal { x = -1, y = 1 } robot.coordinates
-                , test "bearing" <|
-                    \() -> Expect.equal South robot.bearing
+                [ skip <|
+                    test "coordinates" <|
+                        \() -> Expect.equal { x = -1, y = 1 } robot.coordinates
+                , skip <|
+                    test "bearing" <|
+                        \() -> Expect.equal South robot.bearing
                 ]
             )
         , describe "turn right"
@@ -35,7 +38,7 @@ tests =
                 |> List.scanl (\_ r -> turnRight r) defaultRobot
                 |> List.map .bearing
                 |> assertionList [ North, East, South, West ]
-                |> List.indexedMap (\i e -> test ("step " ++ toString i) (\() -> e))
+                |> List.indexedMap (\i e -> skip <| test ("step " ++ toString i) (\() -> e))
             )
         , describe
             "turn left"
@@ -43,7 +46,7 @@ tests =
                 |> List.scanl (\_ r -> turnLeft r) defaultRobot
                 |> List.map .bearing
                 |> assertionList [ North, West, South, East ]
-                |> List.indexedMap (\i e -> test ("step " ++ toString i) (\() -> e))
+                |> List.indexedMap (\i e -> skip <| test ("step " ++ toString i) (\() -> e))
             )
         , describe "advance positive north"
             (let
@@ -51,10 +54,12 @@ tests =
                     Robot North { x = 0, y = 0 }
                         |> advance
              in
-                [ test "coordinates" <|
-                    \() -> Expect.equal { x = 0, y = 1 } robot.coordinates
-                , test "bearing" <|
-                    \() -> Expect.equal North robot.bearing
+                [ skip <|
+                    test "coordinates" <|
+                        \() -> Expect.equal { x = 0, y = 1 } robot.coordinates
+                , skip <|
+                    test "bearing" <|
+                        \() -> Expect.equal North robot.bearing
                 ]
             )
         , describe "advance positive east"
@@ -63,10 +68,12 @@ tests =
                     Robot East { x = 0, y = 0 }
                         |> advance
              in
-                [ test "coordinates" <|
-                    \() -> Expect.equal { x = 1, y = 0 } robot.coordinates
-                , test "bearing" <|
-                    \() -> Expect.equal East robot.bearing
+                [ skip <|
+                    test "coordinates" <|
+                        \() -> Expect.equal { x = 1, y = 0 } robot.coordinates
+                , skip <|
+                    test "bearing" <|
+                        \() -> Expect.equal East robot.bearing
                 ]
             )
         , describe "advance negative south"
@@ -75,10 +82,12 @@ tests =
                     Robot South { x = 0, y = 0 }
                         |> advance
              in
-                [ test "coordinates" <|
-                    \() -> Expect.equal { x = 0, y = -1 } robot.coordinates
-                , test "bearing" <|
-                    \() -> Expect.equal South robot.bearing
+                [ skip <|
+                    test "coordinates" <|
+                        \() -> Expect.equal { x = 0, y = -1 } robot.coordinates
+                , skip <|
+                    test "bearing" <|
+                        \() -> Expect.equal South robot.bearing
                 ]
             )
         , describe "advance positive west"
@@ -87,10 +96,12 @@ tests =
                     Robot West { x = 0, y = 0 }
                         |> advance
              in
-                [ test "coordinates" <|
-                    \() -> Expect.equal { x = -1, y = 0 } robot.coordinates
-                , test "bearing" <|
-                    \() -> Expect.equal West robot.bearing
+                [ skip <|
+                    test "coordinates" <|
+                        \() -> Expect.equal { x = -1, y = 0 } robot.coordinates
+                , skip <|
+                    test "bearing" <|
+                        \() -> Expect.equal West robot.bearing
                 ]
             )
         , describe "simulate prog 1"
@@ -99,10 +110,12 @@ tests =
                     Robot North { x = 0, y = 0 }
                         |> simulate "LAAARALA"
              in
-                [ test "coordinates" <|
-                    \() -> Expect.equal { x = -4, y = 1 } robot.coordinates
-                , test "bearing" <|
-                    \() -> Expect.equal West robot.bearing
+                [ skip <|
+                    test "coordinates" <|
+                        \() -> Expect.equal { x = -4, y = 1 } robot.coordinates
+                , skip <|
+                    test "bearing" <|
+                        \() -> Expect.equal West robot.bearing
                 ]
             )
         , describe "simulate prog 2"
@@ -111,8 +124,9 @@ tests =
                     Robot East { x = 2, y = -7 }
                         |> simulate "RRAAAAALA"
              in
-                [ test "coordinates" <|
-                    \() -> Expect.equal { x = -3, y = -8 } robot.coordinates
+                [ skip <|
+                    test "coordinates" <|
+                        \() -> Expect.equal { x = -3, y = -8 } robot.coordinates
                 , test "bearing" <|
                     \() -> Expect.equal South robot.bearing
                 ]
@@ -123,10 +137,12 @@ tests =
                     Robot South { x = 8, y = 4 }
                         |> simulate "LAAARRRALLLL"
              in
-                [ test "coordinates" <|
-                    \() -> Expect.equal { x = 11, y = 5 } robot.coordinates
-                , test "bearing" <|
-                    \() -> Expect.equal North robot.bearing
+                [ skip <|
+                    test "coordinates" <|
+                        \() -> Expect.equal { x = 11, y = 5 } robot.coordinates
+                , skip <|
+                    test "bearing" <|
+                        \() -> Expect.equal North robot.bearing
                 ]
             )
         ]

--- a/exercises/roman-numerals/tests/Tests.elm
+++ b/exercises/roman-numerals/tests/Tests.elm
@@ -12,72 +12,89 @@ tests =
             \() ->
                 Expect.equal ("I")
                     (toRoman 1)
-        , test "2" <|
-            \() ->
-                Expect.equal ("II")
-                    (toRoman 2)
-        , test "3" <|
-            \() ->
-                Expect.equal ("III")
-                    (toRoman 3)
-        , test "4" <|
-            \() ->
-                Expect.equal ("IV")
-                    (toRoman 4)
-        , test "5" <|
-            \() ->
-                Expect.equal ("V")
-                    (toRoman 5)
-        , test "6" <|
-            \() ->
-                Expect.equal ("VI")
-                    (toRoman 6)
-        , test "9" <|
-            \() ->
-                Expect.equal ("IX")
-                    (toRoman 9)
-        , test "27" <|
-            \() ->
-                Expect.equal ("XXVII")
-                    (toRoman 27)
-        , test "48" <|
-            \() ->
-                Expect.equal ("XLVIII")
-                    (toRoman 48)
-        , test "59" <|
-            \() ->
-                Expect.equal ("LIX")
-                    (toRoman 59)
-        , test "93" <|
-            \() ->
-                Expect.equal ("XCIII")
-                    (toRoman 93)
-        , test "141" <|
-            \() ->
-                Expect.equal ("CXLI")
-                    (toRoman 141)
-        , test "163" <|
-            \() ->
-                Expect.equal ("CLXIII")
-                    (toRoman 163)
-        , test "402" <|
-            \() ->
-                Expect.equal ("CDII")
-                    (toRoman 402)
-        , test "575" <|
-            \() ->
-                Expect.equal ("DLXXV")
-                    (toRoman 575)
-        , test "911" <|
-            \() ->
-                Expect.equal ("CMXI")
-                    (toRoman 911)
-        , test "1024" <|
-            \() ->
-                Expect.equal ("MXXIV")
-                    (toRoman 1024)
-        , test "3000" <|
-            \() ->
-                Expect.equal ("MMM")
-                    (toRoman 3000)
+        , skip <|
+            test "2" <|
+                \() ->
+                    Expect.equal ("II")
+                        (toRoman 2)
+        , skip <|
+            test "3" <|
+                \() ->
+                    Expect.equal ("III")
+                        (toRoman 3)
+        , skip <|
+            test "4" <|
+                \() ->
+                    Expect.equal ("IV")
+                        (toRoman 4)
+        , skip <|
+            test "5" <|
+                \() ->
+                    Expect.equal ("V")
+                        (toRoman 5)
+        , skip <|
+            test "6" <|
+                \() ->
+                    Expect.equal ("VI")
+                        (toRoman 6)
+        , skip <|
+            test "9" <|
+                \() ->
+                    Expect.equal ("IX")
+                        (toRoman 9)
+        , skip <|
+            test "27" <|
+                \() ->
+                    Expect.equal ("XXVII")
+                        (toRoman 27)
+        , skip <|
+            test "48" <|
+                \() ->
+                    Expect.equal ("XLVIII")
+                        (toRoman 48)
+        , skip <|
+            test "59" <|
+                \() ->
+                    Expect.equal ("LIX")
+                        (toRoman 59)
+        , skip <|
+            test "93" <|
+                \() ->
+                    Expect.equal ("XCIII")
+                        (toRoman 93)
+        , skip <|
+            test "141" <|
+                \() ->
+                    Expect.equal ("CXLI")
+                        (toRoman 141)
+        , skip <|
+            test "163" <|
+                \() ->
+                    Expect.equal ("CLXIII")
+                        (toRoman 163)
+        , skip <|
+            test "402" <|
+                \() ->
+                    Expect.equal ("CDII")
+                        (toRoman 402)
+        , skip <|
+            test "575" <|
+                \() ->
+                    Expect.equal ("DLXXV")
+                        (toRoman 575)
+        , skip <|
+            test "911" <|
+                \() ->
+                    Expect.equal ("CMXI")
+                        (toRoman 911)
+        , skip <|
+            test "1024" <|
+                \() ->
+                    Expect.equal ("MXXIV")
+                        (toRoman 1024)
+        , skip <|
+            test "3000" <|
+                \() ->
+                    Expect.equal ("MMM")
+                        (toRoman 3000)
         ]

--- a/exercises/run-length-encoding/tests/Tests.elm
+++ b/exercises/run-length-encoding/tests/Tests.elm
@@ -10,28 +10,36 @@ tests =
     describe "RunLengthEncoding"
         [ test "the solution is for the correct version of the test" <|
             \() -> Expect.equal 2 version
-        , test "encode simple" <|
-            \() -> Expect.equal "2A3B4C" (encode "AABBBCCCC")
-        , test "decode simple" <|
-            \() -> Expect.equal "AABBBCCCC" (decode "2A3B4C")
-        , test "encode with single values" <|
-            \() ->
-                Expect.equal "12WB12W3B24WB"
-                    (encode "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB")
-        , test "decode with single values" <|
-            \() ->
-                Expect.equal "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"
-                    (decode "12WB12W3B24WB")
-        , test "(decode (encode (...)) combination" <|
-            \() ->
-                Expect.equal "zzz ZZ  zZ"
-                    (decode (encode "zzz ZZ  zZ"))
-        , test "decode with a x10 value" <|
-            \() ->
-                Expect.equal "WWWWWWWWWW"
-                    (decode "10W")
-        , test "encode unicode" <|
-            \() -> Expect.equal "⏰3⚽2⭐⏰" (encode "⏰⚽⚽⚽⭐⭐⏰")
-        , test "decode unicode" <|
-            \() -> Expect.equal "⏰⚽⚽⚽⭐⭐⏰" (decode "⏰3⚽2⭐⏰")
+        , skip <|
+            test "encode simple" <|
+                \() -> Expect.equal "2A3B4C" (encode "AABBBCCCC")
+        , skip <|
+            test "decode simple" <|
+                \() -> Expect.equal "AABBBCCCC" (decode "2A3B4C")
+        , skip <|
+            test "encode with single values" <|
+                \() ->
+                    Expect.equal "12WB12W3B24WB"
+                        (encode "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB")
+        , skip <|
+            test "decode with single values" <|
+                \() ->
+                    Expect.equal "WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"
+                        (decode "12WB12W3B24WB")
+        , skip <|
+            test "(decode (encode (...)) combination" <|
+                \() ->
+                    Expect.equal "zzz ZZ  zZ"
+                        (decode (encode "zzz ZZ  zZ"))
+        , skip <|
+            test "decode with a x10 value" <|
+                \() ->
+                    Expect.equal "WWWWWWWWWW"
+                        (decode "10W")
+        , skip <|
+            test "encode unicode" <|
+                \() -> Expect.equal "⏰3⚽2⭐⏰" (encode "⏰⚽⚽⚽⭐⭐⏰")
+        , skip <|
+            test "decode unicode" <|
+                \() -> Expect.equal "⏰⚽⚽⚽⭐⭐⏰" (decode "⏰3⚽2⭐⏰")
         ]

--- a/exercises/run-length-encoding/tests/Tests.elm
+++ b/exercises/run-length-encoding/tests/Tests.elm
@@ -10,9 +10,8 @@ tests =
     describe "RunLengthEncoding"
         [ test "the solution is for the correct version of the test" <|
             \() -> Expect.equal 2 version
-        , skip <|
-            test "encode simple" <|
-                \() -> Expect.equal "2A3B4C" (encode "AABBBCCCC")
+        , test "encode simple" <|
+            \() -> Expect.equal "2A3B4C" (encode "AABBBCCCC")
         , skip <|
             test "decode simple" <|
                 \() -> Expect.equal "AABBBCCCC" (decode "2A3B4C")

--- a/exercises/say/tests/Tests.elm
+++ b/exercises/say/tests/Tests.elm
@@ -12,75 +12,91 @@ tests =
             \() ->
                 Expect.equal (Ok "one")
                     (say 1)
-        , test "fourteen" <|
-            \() ->
-                Expect.equal (Ok "fourteen")
-                    (say 14)
-        , test "twenty" <|
-            \() ->
-                Expect.equal (Ok "twenty")
-                    (say 20)
-        , test "twenty-two" <|
-            \() ->
-                Expect.equal (Ok "twenty-two")
-                    (say 22)
-        , test "one hundred" <|
-            \() ->
-                Expect.equal (Ok "one hundred")
-                    (say 100)
-        , test "one hundred twenty" <|
-            \() ->
-                Expect.equal (Ok "one hundred and twenty")
-                    (say 120)
-        , test "one hundred twenty-three" <|
-            \() ->
-                Expect.equal (Ok "one hundred and twenty-three")
-                    (say 123)
-        , test "one thousand" <|
-            \() ->
-                Expect.equal (Ok "one thousand")
-                    (say 1000)
-        , test "one thousand two hundred thirty-four" <|
-            \() ->
-                Expect.equal (Ok "one thousand two hundred and thirty-four")
-                    (say 1234)
-        , test "one million" <|
-            \() ->
-                Expect.equal (Ok "one million")
-                    (say 1000000)
-        , test "one million two" <|
-            \() ->
-                Expect.equal (Ok "one million and two")
-                    (say 1000002)
-        , test "1002345" <|
-            \() ->
-                Expect.equal (Ok "one million two thousand three hundred and forty-five")
-                    (say 1002345)
-        , test "one billion" <|
-            \() ->
-                Expect.equal (Ok "one billion")
-                    (say 1000000000)
-        , test "number too large" <|
-            \() ->
-                Expect.equal (Err TooLarge)
-                    (say 10000000000000000)
-        , test "negative number" <|
-            \() ->
-                Expect.equal (Err Negative)
-                    (say -42)
-        , test "zero" <|
-            \() ->
-                Expect.equal (Ok "zero")
-                    (say 0)
-        , test "987654321123" <|
-            \() ->
-                Expect.equal
-                    (Ok
-                        ("nine hundred and eighty-seven billion "
-                            ++ "six hundred and fifty-four million "
-                            ++ "three hundred and twenty-one thousand "
-                            ++ "one hundred and twenty-three"
+        , skip <|
+            test "fourteen" <|
+                \() ->
+                    Expect.equal (Ok "fourteen")
+                        (say 14)
+        , skip <|
+            test "twenty" <|
+                \() ->
+                    Expect.equal (Ok "twenty")
+                        (say 20)
+        , skip <|
+            test "twenty-two" <|
+                \() ->
+                    Expect.equal (Ok "twenty-two")
+                        (say 22)
+        , skip <|
+            test "one hundred" <|
+                \() ->
+                    Expect.equal (Ok "one hundred")
+                        (say 100)
+        , skip <|
+            test "one hundred twenty" <|
+                \() ->
+                    Expect.equal (Ok "one hundred and twenty")
+                        (say 120)
+        , skip <|
+            test "one hundred twenty-three" <|
+                \() ->
+                    Expect.equal (Ok "one hundred and twenty-three")
+                        (say 123)
+        , skip <|
+            test "one thousand" <|
+                \() ->
+                    Expect.equal (Ok "one thousand")
+                        (say 1000)
+        , skip <|
+            test "one thousand two hundred thirty-four" <|
+                \() ->
+                    Expect.equal (Ok "one thousand two hundred and thirty-four")
+                        (say 1234)
+        , skip <|
+            test "one million" <|
+                \() ->
+                    Expect.equal (Ok "one million")
+                        (say 1000000)
+        , skip <|
+            test "one million two" <|
+                \() ->
+                    Expect.equal (Ok "one million and two")
+                        (say 1000002)
+        , skip <|
+            test "1002345" <|
+                \() ->
+                    Expect.equal (Ok "one million two thousand three hundred and forty-five")
+                        (say 1002345)
+        , skip <|
+            test "one billion" <|
+                \() ->
+                    Expect.equal (Ok "one billion")
+                        (say 1000000000)
+        , skip <|
+            test "number too large" <|
+                \() ->
+                    Expect.equal (Err TooLarge)
+                        (say 10000000000000000)
+        , skip <|
+            test "negative number" <|
+                \() ->
+                    Expect.equal (Err Negative)
+                        (say -42)
+        , skip <|
+            test "zero" <|
+                \() ->
+                    Expect.equal (Ok "zero")
+                        (say 0)
+        , skip <|
+            test "987654321123" <|
+                \() ->
+                    Expect.equal
+                        (Ok
+                            ("nine hundred and eighty-seven billion "
+                                ++ "six hundred and fifty-four million "
+                                ++ "three hundred and twenty-one thousand "
+                                ++ "one hundred and twenty-three"
+                            )
                         )
-                    )
-                    (say 987654321123)
+                        (say 987654321123)
         ]

--- a/exercises/scrabble-score/tests/Tests.elm
+++ b/exercises/scrabble-score/tests/Tests.elm
@@ -10,24 +10,34 @@ tests =
     describe "Grains"
         [ test "lowercase letter" <|
             \() -> Expect.equal 1 (scoreWord "a")
-        , test "uppercase letter" <|
-            \() -> Expect.equal 1 (scoreWord "A")
-        , test "valuable letter" <|
-            \() -> Expect.equal 4 (scoreWord "f")
-        , test "short word" <|
-            \() -> Expect.equal 2 (scoreWord "at")
-        , test "short, valuable word" <|
-            \() -> Expect.equal 12 (scoreWord "zoo")
-        , test "medium word" <|
-            \() -> Expect.equal 6 (scoreWord "street")
-        , test "medium, valuable word" <|
-            \() -> Expect.equal 22 (scoreWord "quirky")
-        , test "long, mixed-case word" <|
-            \() -> Expect.equal 41 (scoreWord "OxyphenButazone")
-        , test "english-like word" <|
-            \() -> Expect.equal 8 (scoreWord "pinata")
-        , test "non-english letter is not scored" <|
-            \() -> Expect.equal 7 (scoreWord "piñata")
-        , test "empty input" <|
-            \() -> Expect.equal 0 (scoreWord "")
+        , skip <|
+            test "uppercase letter" <|
+                \() -> Expect.equal 1 (scoreWord "A")
+        , skip <|
+            test "valuable letter" <|
+                \() -> Expect.equal 4 (scoreWord "f")
+        , skip <|
+            test "short word" <|
+                \() -> Expect.equal 2 (scoreWord "at")
+        , skip <|
+            test "short, valuable word" <|
+                \() -> Expect.equal 12 (scoreWord "zoo")
+        , skip <|
+            test "medium word" <|
+                \() -> Expect.equal 6 (scoreWord "street")
+        , skip <|
+            test "medium, valuable word" <|
+                \() -> Expect.equal 22 (scoreWord "quirky")
+        , skip <|
+            test "long, mixed-case word" <|
+                \() -> Expect.equal 41 (scoreWord "OxyphenButazone")
+        , skip <|
+            test "english-like word" <|
+                \() -> Expect.equal 8 (scoreWord "pinata")
+        , skip <|
+            test "non-english letter is not scored" <|
+                \() -> Expect.equal 7 (scoreWord "piñata")
+        , skip <|
+            test "empty input" <|
+                \() -> Expect.equal 0 (scoreWord "")
         ]

--- a/exercises/series/tests/Tests.elm
+++ b/exercises/series/tests/Tests.elm
@@ -12,32 +12,39 @@ tests =
             \() ->
                 Expect.equal (Ok [ [ 0 ], [ 1 ], [ 2 ], [ 3 ], [ 4 ] ])
                     (slices 1 "01234")
-        , test "slices of two" <|
-            \() ->
-                Expect.equal (Ok [ [ 9, 7 ], [ 7, 8 ], [ 8, 6 ], [ 6, 7 ], [ 7, 5 ], [ 5, 6 ], [ 6, 4 ] ])
-                    (slices 2 "97867564")
-        , test "slices of three" <|
-            \() ->
-                Expect.equal (Ok [ [ 9, 7, 8 ], [ 7, 8, 6 ], [ 8, 6, 7 ], [ 6, 7, 5 ], [ 7, 5, 6 ], [ 5, 6, 4 ] ])
-                    (slices 3 "97867564")
-        , test "slices of four" <|
-            \() ->
-                Expect.equal (Ok [ [ 0, 1, 2, 3 ], [ 1, 2, 3, 4 ] ])
-                    (slices 4 "01234")
-        , test "slices of five" <|
-            \() ->
-                Expect.equal (Ok [ [ 0, 1, 2, 3, 4 ] ])
-                    (slices 5 "01234")
-        , test "overly long slice" <|
-            \() ->
-                Expect.equal (Ok [])
-                    (slices 4 "012")
-        , test "overly short slice" <|
-            \() ->
-                Expect.equal (Err ("Invalid size: 0"))
-                    (slices 0 "01234")
-        , test "input has non numbers" <|
-            \() ->
-                Expect.equal (Err "could not convert string 'a' to an Int")
-                    (slices 2 "0123abc")
+        , skip <|
+            test "slices of two" <|
+                \() ->
+                    Expect.equal (Ok [ [ 9, 7 ], [ 7, 8 ], [ 8, 6 ], [ 6, 7 ], [ 7, 5 ], [ 5, 6 ], [ 6, 4 ] ])
+                        (slices 2 "97867564")
+        , skip <|
+            test "slices of three" <|
+                \() ->
+                    Expect.equal (Ok [ [ 9, 7, 8 ], [ 7, 8, 6 ], [ 8, 6, 7 ], [ 6, 7, 5 ], [ 7, 5, 6 ], [ 5, 6, 4 ] ])
+                        (slices 3 "97867564")
+        , skip <|
+            test "slices of four" <|
+                \() ->
+                    Expect.equal (Ok [ [ 0, 1, 2, 3 ], [ 1, 2, 3, 4 ] ])
+                        (slices 4 "01234")
+        , skip <|
+            test "slices of five" <|
+                \() ->
+                    Expect.equal (Ok [ [ 0, 1, 2, 3, 4 ] ])
+                        (slices 5 "01234")
+        , skip <|
+            test "overly long slice" <|
+                \() ->
+                    Expect.equal (Ok [])
+                        (slices 4 "012")
+        , skip <|
+            test "overly short slice" <|
+                \() ->
+                    Expect.equal (Err ("Invalid size: 0"))
+                        (slices 0 "01234")
+        , skip <|
+            test "input has non numbers" <|
+                \() ->
+                    Expect.equal (Err "could not convert string 'a' to an Int")
+                        (slices 2 "0123abc")
         ]

--- a/exercises/space-age/tests/Tests.elm
+++ b/exercises/space-age/tests/Tests.elm
@@ -10,18 +10,25 @@ tests =
     describe "SpaceAge"
         [ test "age in earth years" <|
             \() -> Expect.equal 32 (round (ageOn Earth 1000000000))
-        , test "age in mercury years" <|
-            \() -> Expect.equal 281 (round (ageOn Mercury 2134835688))
-        , test "age in venus years" <|
-            \() -> Expect.equal 10 (round (ageOn Venus 189839836))
-        , test "age on mars" <|
-            \() -> Expect.equal 39 (round (ageOn Mars 2329871239))
-        , test "age on jupiter" <|
-            \() -> Expect.equal 2 (round (ageOn Jupiter 901876382))
-        , test "age on saturn" <|
-            \() -> Expect.equal 3 (round (ageOn Saturn 3000000000))
-        , test "age on uranus" <|
-            \() -> Expect.equal 1 (round (ageOn Uranus 3210123456))
-        , test "age on neptune" <|
-            \() -> Expect.equal 2 (round (ageOn Neptune 8210123456))
+        , skip <|
+            test "age in mercury years" <|
+                \() -> Expect.equal 281 (round (ageOn Mercury 2134835688))
+        , skip <|
+            test "age in venus years" <|
+                \() -> Expect.equal 10 (round (ageOn Venus 189839836))
+        , skip <|
+            test "age on mars" <|
+                \() -> Expect.equal 39 (round (ageOn Mars 2329871239))
+        , skip <|
+            test "age on jupiter" <|
+                \() -> Expect.equal 2 (round (ageOn Jupiter 901876382))
+        , skip <|
+            test "age on saturn" <|
+                \() -> Expect.equal 3 (round (ageOn Saturn 3000000000))
+        , skip <|
+            test "age on uranus" <|
+                \() -> Expect.equal 1 (round (ageOn Uranus 3210123456))
+        , skip <|
+            test "age on neptune" <|
+                \() -> Expect.equal 2 (round (ageOn Neptune 8210123456))
         ]

--- a/exercises/strain/tests/Tests.elm
+++ b/exercises/strain/tests/Tests.elm
@@ -33,48 +33,59 @@ tests =
             \() ->
                 Expect.equal []
                     (keep lessThanTen [])
-        , test "keep everything" <|
-            \() ->
-                Expect.equal [ 1, 2, 3 ]
-                    (keep lessThanTen [ 1, 2, 3 ])
-        , test "keep first and last" <|
-            \() ->
-                Expect.equal [ 1, 3 ]
-                    (keep odd [ 1, 2, 3 ])
-        , test "keep nothing" <|
-            \() ->
-                Expect.equal []
-                    (keep even [ 1, 3, 5, 7 ])
-        , test "keep neither first nor last" <|
-            \() ->
-                Expect.equal [ 2 ]
-                    (keep even [ 1, 2, 3 ])
-        , test "keep strings" <|
-            \() ->
-                Expect.equal [ "zebra", "zombies", "zealot" ]
-                    (keep (isFirstLetter "z") [ "apple", "zebra", "banana", "zombies", "cherimoya", "zealot" ])
-        , test "empty discard" <|
-            \() ->
-                Expect.equal []
-                    (discard lessThanTen [])
-        , test "discard everything" <|
-            \() ->
-                Expect.equal []
-                    (discard lessThanTen [ 1, 2, 3 ])
-        , test "discard first and last" <|
-            \() ->
-                Expect.equal [ 2 ]
-                    (discard odd [ 1, 2, 3 ])
-        , test "discard nothing" <|
-            \() ->
-                Expect.equal [ 1, 3, 5, 7 ]
-                    (discard even [ 1, 3, 5, 7 ])
-        , test "discard neither first nor last" <|
-            \() ->
-                Expect.equal [ 1, 3 ]
-                    (discard even [ 1, 2, 3 ])
-        , test "discard strings" <|
-            \() ->
-                Expect.equal [ "apple", "banana", "cherimoya" ]
-                    (discard (isFirstLetter "z") [ "apple", "zebra", "banana", "zombies", "cherimoya", "zealot" ])
+        , skip <|
+            test "keep everything" <|
+                \() ->
+                    Expect.equal [ 1, 2, 3 ]
+                        (keep lessThanTen [ 1, 2, 3 ])
+        , skip <|
+            test "keep first and last" <|
+                \() ->
+                    Expect.equal [ 1, 3 ]
+                        (keep odd [ 1, 2, 3 ])
+        , skip <|
+            test "keep nothing" <|
+                \() ->
+                    Expect.equal []
+                        (keep even [ 1, 3, 5, 7 ])
+        , skip <|
+            test "keep neither first nor last" <|
+                \() ->
+                    Expect.equal [ 2 ]
+                        (keep even [ 1, 2, 3 ])
+        , skip <|
+            test "keep strings" <|
+                \() ->
+                    Expect.equal [ "zebra", "zombies", "zealot" ]
+                        (keep (isFirstLetter "z") [ "apple", "zebra", "banana", "zombies", "cherimoya", "zealot" ])
+        , skip <|
+            test "empty discard" <|
+                \() ->
+                    Expect.equal []
+                        (discard lessThanTen [])
+        , skip <|
+            test "discard everything" <|
+                \() ->
+                    Expect.equal []
+                        (discard lessThanTen [ 1, 2, 3 ])
+        , skip <|
+            test "discard first and last" <|
+                \() ->
+                    Expect.equal [ 2 ]
+                        (discard odd [ 1, 2, 3 ])
+        , skip <|
+            test "discard nothing" <|
+                \() ->
+                    Expect.equal [ 1, 3, 5, 7 ]
+                        (discard even [ 1, 3, 5, 7 ])
+        , skip <|
+            test "discard neither first nor last" <|
+                \() ->
+                    Expect.equal [ 1, 3 ]
+                        (discard even [ 1, 2, 3 ])
+        , skip <|
+            test "discard strings" <|
+                \() ->
+                    Expect.equal [ "apple", "banana", "cherimoya" ]
+                        (discard (isFirstLetter "z") [ "apple", "zebra", "banana", "zombies", "cherimoya", "zealot" ])
         ]

--- a/exercises/sublist/tests/Tests.elm
+++ b/exercises/sublist/tests/Tests.elm
@@ -10,9 +10,8 @@ tests =
     describe "Sublist"
         [ test "the solution is for the correct version of the test" <|
             \() -> Expect.equal 2 version
-        , skip <|
-            test "empty equals empty" <|
-                \() -> Expect.equal Equal (sublist [] [])
+        , test "empty equals empty" <|
+            \() -> Expect.equal Equal (sublist [] [])
         , skip <|
             test "empty is a sublist of anything" <|
                 \() -> Expect.equal Sublist (sublist [] [ 1, 2 ])

--- a/exercises/sublist/tests/Tests.elm
+++ b/exercises/sublist/tests/Tests.elm
@@ -10,40 +10,58 @@ tests =
     describe "Sublist"
         [ test "the solution is for the correct version of the test" <|
             \() -> Expect.equal 2 version
-        , test "empty equals empty" <|
-            \() -> Expect.equal Equal (sublist [] [])
-        , test "empty is a sublist of anything" <|
-            \() -> Expect.equal Sublist (sublist [] [ 1, 2 ])
-        , test "anything is a superlist of empty" <|
-            \() -> Expect.equal Superlist (sublist [ 1, 2 ] [])
-        , test "1 is not 2" <|
-            \() -> Expect.equal Unequal (sublist [ 1 ] [ 2 ])
-        , test "compare larger equal lists" <|
-            \() -> Expect.equal Equal (sublist [ 1, 1, 1 ] [ 1, 1, 1 ])
-        , test "sublist at start" <|
-            \() -> Expect.equal Sublist (sublist [ 1, 2, 3 ] [ 1, 2, 3, 4, 5 ])
-        , test "sublist in the middle" <|
-            \() -> Expect.equal Sublist (sublist [ 4, 3, 2 ] [ 5, 4, 3, 2, 1 ])
-        , test "sublist at end" <|
-            \() -> Expect.equal Sublist (sublist [ 3, 4, 5 ] [ 1, 2, 3, 4, 5 ])
-        , test "partially matching sublist at start" <|
-            \() -> Expect.equal Sublist (sublist [ 1, 1, 2 ] [ 1, 1, 1, 2 ])
-        , test "sublist early in huge list" <|
-            \() -> Expect.equal Sublist (sublist [ 3, 4, 5 ] (List.range 1 100000))
-        , test "huge sublist not in list" <|
-            \() -> Expect.equal Unequal (sublist (List.range 10 5001) (List.range 1 5000))
-        , test "superlist at start" <|
-            \() -> Expect.equal Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 1, 2, 3 ])
-        , test "superlist in middle" <|
-            \() -> Expect.equal Superlist (sublist [ 5, 4, 3, 2, 1 ] [ 4, 3, 2 ])
-        , test "superlist at end" <|
-            \() -> Expect.equal Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 3, 4, 5 ])
-        , test "partially matching superlist at start" <|
-            \() -> Expect.equal Superlist (sublist [ 1, 1, 1, 2 ] [ 1, 1, 2 ])
-        , test "superlist early in huge list" <|
-            \() -> Expect.equal Superlist (sublist (List.range 1 100000) [ 3, 4, 5 ])
-        , test "recurring values sublist" <|
-            \() -> Expect.equal Sublist (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 1, 2, 3, 2, 1 ])
-        , test "recurring values unequal" <|
-            \() -> Expect.equal Unequal (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 3, 2, 3, 2, 1 ])
+        , skip <|
+            test "empty equals empty" <|
+                \() -> Expect.equal Equal (sublist [] [])
+        , skip <|
+            test "empty is a sublist of anything" <|
+                \() -> Expect.equal Sublist (sublist [] [ 1, 2 ])
+        , skip <|
+            test "anything is a superlist of empty" <|
+                \() -> Expect.equal Superlist (sublist [ 1, 2 ] [])
+        , skip <|
+            test "1 is not 2" <|
+                \() -> Expect.equal Unequal (sublist [ 1 ] [ 2 ])
+        , skip <|
+            test "compare larger equal lists" <|
+                \() -> Expect.equal Equal (sublist [ 1, 1, 1 ] [ 1, 1, 1 ])
+        , skip <|
+            test "sublist at start" <|
+                \() -> Expect.equal Sublist (sublist [ 1, 2, 3 ] [ 1, 2, 3, 4, 5 ])
+        , skip <|
+            test "sublist in the middle" <|
+                \() -> Expect.equal Sublist (sublist [ 4, 3, 2 ] [ 5, 4, 3, 2, 1 ])
+        , skip <|
+            test "sublist at end" <|
+                \() -> Expect.equal Sublist (sublist [ 3, 4, 5 ] [ 1, 2, 3, 4, 5 ])
+        , skip <|
+            test "partially matching sublist at start" <|
+                \() -> Expect.equal Sublist (sublist [ 1, 1, 2 ] [ 1, 1, 1, 2 ])
+        , skip <|
+            test "sublist early in huge list" <|
+                \() -> Expect.equal Sublist (sublist [ 3, 4, 5 ] (List.range 1 100000))
+        , skip <|
+            test "huge sublist not in list" <|
+                \() -> Expect.equal Unequal (sublist (List.range 10 5001) (List.range 1 5000))
+        , skip <|
+            test "superlist at start" <|
+                \() -> Expect.equal Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 1, 2, 3 ])
+        , skip <|
+            test "superlist in middle" <|
+                \() -> Expect.equal Superlist (sublist [ 5, 4, 3, 2, 1 ] [ 4, 3, 2 ])
+        , skip <|
+            test "superlist at end" <|
+                \() -> Expect.equal Superlist (sublist [ 1, 2, 3, 4, 5 ] [ 3, 4, 5 ])
+        , skip <|
+            test "partially matching superlist at start" <|
+                \() -> Expect.equal Superlist (sublist [ 1, 1, 1, 2 ] [ 1, 1, 2 ])
+        , skip <|
+            test "superlist early in huge list" <|
+                \() -> Expect.equal Superlist (sublist (List.range 1 100000) [ 3, 4, 5 ])
+        , skip <|
+            test "recurring values sublist" <|
+                \() -> Expect.equal Sublist (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 1, 2, 3, 2, 1 ])
+        , skip <|
+            test "recurring values unequal" <|
+                \() -> Expect.equal Unequal (sublist [ 1, 2, 1, 2, 3 ] [ 1, 2, 3, 1, 2, 3, 2, 3, 2, 1 ])
         ]

--- a/exercises/sum-of-multiples/tests/Tests.elm
+++ b/exercises/sum-of-multiples/tests/Tests.elm
@@ -10,14 +10,19 @@ tests =
     describe "Sum Of Multiples"
         [ test "[3, 5] 15" <|
             \() -> Expect.equal 45 (sumOfMultiples [ 3, 5 ] 15)
-        , test "[7, 13, 17] 20" <|
-            \() -> Expect.equal 51 (sumOfMultiples [ 7, 13, 17 ] 20)
-        , test "[4, 6] 15" <|
-            \() -> Expect.equal 30 (sumOfMultiples [ 4, 6 ] 15)
-        , test "[5, 6, 8] 150" <|
-            \() -> Expect.equal 4419 (sumOfMultiples [ 5, 6, 8 ] 150)
-        , test "[43, 47] 10000" <|
-            \() -> Expect.equal 2203160 (sumOfMultiples [ 43, 47 ] 10000)
-        , test "[5, 25] 51" <|
-            \() -> Expect.equal 275 (sumOfMultiples [ 5, 25 ] 51)
+        , skip <|
+            test "[7, 13, 17] 20" <|
+                \() -> Expect.equal 51 (sumOfMultiples [ 7, 13, 17 ] 20)
+        , skip <|
+            test "[4, 6] 15" <|
+                \() -> Expect.equal 30 (sumOfMultiples [ 4, 6 ] 15)
+        , skip <|
+            test "[5, 6, 8] 150" <|
+                \() -> Expect.equal 4419 (sumOfMultiples [ 5, 6, 8 ] 150)
+        , skip <|
+            test "[43, 47] 10000" <|
+                \() -> Expect.equal 2203160 (sumOfMultiples [ 43, 47 ] 10000)
+        , skip <|
+            test "[5, 25] 51" <|
+                \() -> Expect.equal 275 (sumOfMultiples [ 5, 25 ] 51)
         ]

--- a/exercises/triangle/tests/Tests.elm
+++ b/exercises/triangle/tests/Tests.elm
@@ -10,30 +10,43 @@ tests =
     describe "triangleKind"
         [ test "equilateral triangles have equal sides" <|
             \() -> Expect.equal (Ok Equilateral) (triangleKind 2 2 2)
-        , test "larger equilateral triangles also have equal sides" <|
-            \() -> Expect.equal (Ok Equilateral) (triangleKind 10 10 10)
-        , test "isosceles triangles have last two sides equal" <|
-            \() -> Expect.equal (Ok Isosceles) (triangleKind 3 4 4)
-        , test "isosceles triangles have first and last sides equal" <|
-            \() -> Expect.equal (Ok Isosceles) (triangleKind 4 3 4)
-        , test "isosceles triangles have two first sides equal" <|
-            \() -> Expect.equal (Ok Isosceles) (triangleKind 4 4 3)
-        , test "isosceles triangles have in fact exactly two sides equal" <|
-            \() -> Expect.equal (Ok Isosceles) (triangleKind 10 10 2)
-        , test "scalene triangles have no equal sides" <|
-            \() -> Expect.equal (Ok Scalene) (triangleKind 3 4 5)
-        , test "scalene triangles have no equal sides at a larger scale too" <|
-            \() -> Expect.equal (Ok Scalene) (triangleKind 10 11 12)
-        , test "scalene triangles have no equal sides at a larger scale too 2" <|
-            \() -> Expect.equal (Ok Scalene) (triangleKind 5 4 2)
-        , test "very small triangles are legal" <|
-            \() -> Expect.equal (Ok Scalene) (triangleKind 0.4 0.6 0.3)
-        , test "triangles with no size are illegal" <|
-            \() -> Expect.equal (Err "Invalid lengths") (triangleKind 0 0 0)
-        , test "triangles with negative sides are illegal" <|
-            \() -> Expect.equal (Err "Invalid lengths") (triangleKind 3 4 -5)
-        , test "triangles violating triangle inequality are illegal 1" <|
-            \() -> Expect.equal (Err "Violates inequality") (triangleKind 1 1 3)
-        , test "triangles violating triangle inequality are illegal 2" <|
-            \() -> Expect.equal (Err "Violates inequality") (triangleKind 7 3 2)
+        , skip <|
+            test "larger equilateral triangles also have equal sides" <|
+                \() -> Expect.equal (Ok Equilateral) (triangleKind 10 10 10)
+        , skip <|
+            test "isosceles triangles have last two sides equal" <|
+                \() -> Expect.equal (Ok Isosceles) (triangleKind 3 4 4)
+        , skip <|
+            test "isosceles triangles have first and last sides equal" <|
+                \() -> Expect.equal (Ok Isosceles) (triangleKind 4 3 4)
+        , skip <|
+            test "isosceles triangles have two first sides equal" <|
+                \() -> Expect.equal (Ok Isosceles) (triangleKind 4 4 3)
+        , skip <|
+            test "isosceles triangles have in fact exactly two sides equal" <|
+                \() -> Expect.equal (Ok Isosceles) (triangleKind 10 10 2)
+        , skip <|
+            test "scalene triangles have no equal sides" <|
+                \() -> Expect.equal (Ok Scalene) (triangleKind 3 4 5)
+        , skip <|
+            test "scalene triangles have no equal sides at a larger scale too" <|
+                \() -> Expect.equal (Ok Scalene) (triangleKind 10 11 12)
+        , skip <|
+            test "scalene triangles have no equal sides at a larger scale too 2" <|
+                \() -> Expect.equal (Ok Scalene) (triangleKind 5 4 2)
+        , skip <|
+            test "very small triangles are legal" <|
+                \() -> Expect.equal (Ok Scalene) (triangleKind 0.4 0.6 0.3)
+        , skip <|
+            test "triangles with no size are illegal" <|
+                \() -> Expect.equal (Err "Invalid lengths") (triangleKind 0 0 0)
+        , skip <|
+            test "triangles with negative sides are illegal" <|
+                \() -> Expect.equal (Err "Invalid lengths") (triangleKind 3 4 -5)
+        , skip <|
+            test "triangles violating triangle inequality are illegal 1" <|
+                \() -> Expect.equal (Err "Violates inequality") (triangleKind 1 1 3)
+        , skip <|
+            test "triangles violating triangle inequality are illegal 2" <|
+                \() -> Expect.equal (Err "Violates inequality") (triangleKind 7 3 2)
         ]

--- a/exercises/word-count/tests/Tests.elm
+++ b/exercises/word-count/tests/Tests.elm
@@ -13,24 +13,29 @@ tests =
             \() ->
                 Expect.equal [ ( "word", 1 ) ]
                     (wordCount "word" |> Dict.toList)
-        , test "count one of each word" <|
-            \() ->
-                Expect.equal [ ( "each", 1 ), ( "of", 1 ), ( "one", 1 ) ]
-                    (wordCount "one of each" |> Dict.toList)
-        , test "multiple occurrences of a word" <|
-            \() ->
-                Expect.equal [ ( "blue", 1 ), ( "fish", 4 ), ( "one", 1 ), ( "red", 1 ), ( "two", 1 ) ]
-                    (wordCount "one fish two fish red fish blue fish" |> Dict.toList)
-        , test "ignore punctuation" <|
-            \() ->
-                Expect.equal [ ( "as", 1 ), ( "car", 1 ), ( "carpet", 1 ), ( "java", 1 ), ( "javascript", 1 ) ]
-                    (wordCount "car : carpet as java : javascript!!&@$%^&" |> Dict.toList)
-        , test "include numbers" <|
-            \() ->
-                Expect.equal [ ( "1", 1 ), ( "2", 1 ), ( "testing", 2 ) ]
-                    (wordCount "testing, 1, 2 testing" |> Dict.toList)
-        , test "normalize case" <|
-            \() ->
-                Expect.equal [ ( "go", 3 ), ( "stop", 2 ) ]
-                    (wordCount "go Go GO Stop stop" |> Dict.toList)
+        , skip <|
+            test "count one of each word" <|
+                \() ->
+                    Expect.equal [ ( "each", 1 ), ( "of", 1 ), ( "one", 1 ) ]
+                        (wordCount "one of each" |> Dict.toList)
+        , skip <|
+            test "multiple occurrences of a word" <|
+                \() ->
+                    Expect.equal [ ( "blue", 1 ), ( "fish", 4 ), ( "one", 1 ), ( "red", 1 ), ( "two", 1 ) ]
+                        (wordCount "one fish two fish red fish blue fish" |> Dict.toList)
+        , skip <|
+            test "ignore punctuation" <|
+                \() ->
+                    Expect.equal [ ( "as", 1 ), ( "car", 1 ), ( "carpet", 1 ), ( "java", 1 ), ( "javascript", 1 ) ]
+                        (wordCount "car : carpet as java : javascript!!&@$%^&" |> Dict.toList)
+        , skip <|
+            test "include numbers" <|
+                \() ->
+                    Expect.equal [ ( "1", 1 ), ( "2", 1 ), ( "testing", 2 ) ]
+                        (wordCount "testing, 1, 2 testing" |> Dict.toList)
+        , skip <|
+            test "normalize case" <|
+                \() ->
+                    Expect.equal [ ( "go", 3 ), ( "stop", 2 ) ]
+                        (wordCount "go Go GO Stop stop" |> Dict.toList)
         ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "scripts": {
-    "postinstall": "elm package install -y",
     "test": "elm-test"
   },
   "dependencies": {


### PR DESCRIPTION
This allows learners to gradually approach exercise. However, unlike commented tests, the Elm compiler is still able to infer type information from the skipped tests.

Note: I made this change very mechanically, it's quite possible that the very first test is not the ideal starting point for learners. I'd really appreciate some review of the changes here before merge.

Thank you! ❤️ 

[Closes #151]