### PR TITLE
Add version test to triangle exercise

### DIFF
--- a/exercises/triangle/tests/Tests.elm
+++ b/exercises/triangle/tests/Tests.elm
@@ -2,7 +2,7 @@ module Tests exposing (..)
 
 import Test exposing (..)
 import Expect
-import Triangle exposing (triangleKind, Triangle(..))
+import Triangle exposing (triangleKind, Triangle(..), version)
 
 
 tests : Test

--- a/exercises/triangle/tests/Tests.elm
+++ b/exercises/triangle/tests/Tests.elm
@@ -8,7 +8,9 @@ import Triangle exposing (triangleKind, Triangle(..))
 tests : Test
 tests =
     describe "triangleKind"
-        [ test "equilateral triangles have equal sides" <|
+        [ test "the solution is for the correct version of the test" <|
+            \() -> Expect.equal 2 version
+        , test "equilateral triangles have equal sides" <|
             \() -> Expect.equal (Ok Equilateral) (triangleKind 2 2 2)
         , test "larger equilateral triangles also have equal sides" <|
             \() -> Expect.equal (Ok Equilateral) (triangleKind 10 10 10)


### PR DESCRIPTION
This follows the pattern set by some of the other exercises. I noticed it was missing from the triangle exercise.