### PR TITLE
Generate static exercise README templates

### DIFF
--- a/config/exercise_readme.go.tmpl
+++ b/config/exercise_readme.go.tmpl
@@ -1,0 +1,16 @@
+# {{ .Spec.Name }}
+
+{{ .Spec.Description -}}
+{{- with .Hints }}
+{{ . }}
+{{ end }}
+{{- with .TrackInsert }}
+{{ . }}
+{{ end }}
+{{- with .Spec.Credits -}}
+## Source
+
+{{ . }}
+{{ end }}
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/accumulate/README.md
+++ b/exercises/accumulate/README.md
@@ -1,0 +1,65 @@
+# Accumulate
+
+Implement the `accumulate` operation, which, given a collection and an
+operation to perform on each element of the collection, returns a new
+collection containing the result of applying that operation to each element of
+the input collection.
+
+Given the collection of numbers:
+
+- 1, 2, 3, 4, 5
+
+And the operation:
+
+- square a number (`x => x * x`)
+
+Your code should be able to produce the collection of squares:
+
+- 1, 4, 9, 16, 25
+
+Check out the test suite to see the expected function signature.
+
+## Restrictions
+
+Keep your hands off that collect/map/fmap/whatchamacallit functionality
+provided by your standard library!
+Solve this one yourself using other basic tools instead.
+
+Lisp specific: it's perfectly fine to use `MAPCAR` or the equivalent,
+as this is idiomatic Lisp, not a library function.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Conversation with James Edward Gray II [https://twitter.com/jeg2](https://twitter.com/jeg2)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/allergies/README.md
+++ b/exercises/allergies/README.md
@@ -1,0 +1,67 @@
+# Allergies
+
+Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.
+
+An allergy test produces a single numeric score which contains the
+information about all the allergies the person has (that they were
+tested for).
+
+The list of items (and their value) that were tested are:
+
+* eggs (1)
+* peanuts (2)
+* shellfish (4)
+* strawberries (8)
+* tomatoes (16)
+* chocolate (32)
+* pollen (64)
+* cats (128)
+
+So if Tom is allergic to peanuts and chocolate, he gets a score of 34.
+
+Now, given just that score of 34, your program should be able to say:
+
+- Whether Tom is allergic to any one of those allergens listed above.
+- All the allergens Tom is allergic to.
+
+Note: a given score may include allergens **not** listed above (i.e.
+allergens that score 256, 512, 1024, etc.).  Your program should
+ignore those components of the score.  For example, if the allergy
+score is 257, your program should only report the eggs (1) allergy.
+
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Jumpstart Lab Warm-up [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/anagram/README.md
+++ b/exercises/anagram/README.md
@@ -1,0 +1,43 @@
+# Anagram
+
+Given a word and a list of possible anagrams, select the correct sublist.
+
+Given `"listen"` and a list of candidates like `"enlists" "google"
+"inlets" "banana"` the program should return a list containing
+`"inlets"`.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/atbash-cipher/README.md
+++ b/exercises/atbash-cipher/README.md
@@ -1,0 +1,64 @@
+# Atbash Cipher
+
+Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.
+
+The Atbash cipher is a simple substitution cipher that relies on
+transposing all the letters in the alphabet such that the resulting
+alphabet is backwards. The first letter is replaced with the last
+letter, the second with the second-last, and so on.
+
+An Atbash cipher for the Latin alphabet would be as follows:
+
+```plain
+Plain:  abcdefghijklmnopqrstuvwxyz
+Cipher: zyxwvutsrqponmlkjihgfedcba
+```
+
+It is a very weak cipher because it only has one possible key, and it is
+a simple monoalphabetic substitution cipher. However, this may not have
+been an issue in the cipher's time.
+
+Ciphertext is written out in groups of fixed length, the traditional group size
+being 5 letters, and punctuation is excluded. This is to make it harder to guess
+things based on word boundaries.
+
+## Examples
+- Encoding `test` gives `gvhg`
+- Decoding `gvhg` gives `test`
+- Decoding `gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt` gives `thequickbrownfoxjumpsoverthelazydog`
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Wikipedia [http://en.wikipedia.org/wiki/Atbash](http://en.wikipedia.org/wiki/Atbash)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/bob/README.md
+++ b/exercises/bob/README.md
@@ -1,0 +1,48 @@
+# Bob
+
+Bob is a lackadaisical teenager. In conversation, his responses are very limited.
+
+Bob answers 'Sure.' if you ask him a question.
+
+He answers 'Whoa, chill out!' if you yell at him.
+
+He says 'Fine. Be that way!' if you address him without actually saying
+anything.
+
+He answers 'Whatever.' to anything else.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Inspired by the 'Deaf Grandma' exercise in Chris Pine's Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=06](http://pine.fm/LearnToProgram/?Chapter=06)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/difference-of-squares/README.md
+++ b/exercises/difference-of-squares/README.md
@@ -1,0 +1,49 @@
+# Difference Of Squares
+
+Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.
+
+The square of the sum of the first ten natural numbers is
+(1 + 2 + ... + 10)² = 55² = 3025.
+
+The sum of the squares of the first ten natural numbers is
+1² + 2² + ... + 10² = 385.
+
+Hence the difference between the square of the sum of the first
+ten natural numbers and the sum of the squares of the first ten
+natural numbers is 3025 - 385 = 2640.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Problem 6 at Project Euler [http://projecteuler.net/problem=6](http://projecteuler.net/problem=6)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/etl/README.md
+++ b/exercises/etl/README.md
@@ -1,0 +1,81 @@
+# Etl
+
+We are going to do the `Transform` step of an Extract-Transform-Load.
+
+### ETL
+Extract-Transform-Load (ETL) is a fancy way of saying, "We have some crufty, legacy data over in this system, and now we need it in this shiny new system over here, so
+we're going to migrate this."
+
+(Typically, this is followed by, "We're only going to need to run this
+once." That's then typically followed by much forehead slapping and
+moaning about how stupid we could possibly be.)
+
+### The goal
+We're going to extract some scrabble scores from a legacy system.
+
+The old system stored a list of letters per score:
+
+- 1 point: "A", "E", "I", "O", "U", "L", "N", "R", "S", "T",
+- 2 points: "D", "G",
+- 3 points: "B", "C", "M", "P",
+- 4 points: "F", "H", "V", "W", "Y",
+- 5 points: "K",
+- 8 points: "J", "X",
+- 10 points: "Q", "Z",
+
+The shiny new scrabble system instead stores the score per letter, which
+makes it much faster and easier to calculate the score for a word. It
+also stores the letters in lower-case regardless of the case of the
+input letters:
+
+- "a" is worth 1 point.
+- "b" is worth 3 points.
+- "c" is worth 3 points.
+- "d" is worth 2 points.
+- Etc.
+
+Your mission, should you choose to accept it, is to transform the legacy data
+format to the shiny new format.
+
+### Notes
+
+A final note about scoring, Scrabble is played around the world in a
+variety of languages, each with its own unique scoring table. For
+example, an "E" is scored at 2 in the Māori-language version of the
+game while being scored at 4 in the Hawaiian-language version.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+The Jumpstart Lab team [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/gigasecond/README.md
+++ b/exercises/gigasecond/README.md
@@ -1,0 +1,41 @@
+# Gigasecond
+
+Calculate the moment when someone has lived for 10^9 seconds.
+
+A gigasecond is 10^9 (1,000,000,000) seconds.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Chapter 9 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=09](http://pine.fm/LearnToProgram/?Chapter=09)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grade-school/README.md
+++ b/exercises/grade-school/README.md
@@ -1,0 +1,72 @@
+# Grade School
+
+Given students' names along with the grade that they are in, create a roster
+for the school.
+
+In the end, you should be able to:
+
+- Add a student's name to the roster for a grade
+  - "Add Jim to grade 2."
+  - "OK."
+- Get a list of all students enrolled in a grade
+  - "Which students are in grade 2?"
+  - "We've only got Jim just now."
+- Get a sorted list of all students in all grades.  Grades should sort
+  as 1, 2, 3, etc., and students within a grade should be sorted
+  alphabetically by name.
+  - "Who all is enrolled in school right now?"
+  - "Grade 1: Anna, Barb, and Charlie. Grade 2: Alex, Peter, and Zoe.
+    Grade 3…"
+
+Note that all our students only have one name.  (It's a small town, what
+do you want?)
+
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+- If you're working in a language with mutable data structures and your
+  implementation allows outside code to mutate the school's internal DB
+  directly, see if you can prevent this. Feel free to introduce additional
+  tests.
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+A pairing session with Phil Battos at gSchool [http://gschool.it](http://gschool.it)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/grains/README.md
+++ b/exercises/grains/README.md
@@ -1,0 +1,64 @@
+# Grains
+
+Calculate the number of grains of wheat on a chessboard given that the number
+on each square doubles.
+
+There once was a wise servant who saved the life of a prince. The king
+promised to pay whatever the servant could dream up. Knowing that the
+king loved chess, the servant told the king he would like to have grains
+of wheat. One grain on the first square of a chess board. Two grains on
+the next. Four on the third, and so on.
+
+There are 64 squares on a chessboard.
+
+Write code that shows:
+- how many grains were on each square, and
+- the total number of grains
+
+
+## For bonus points
+
+Did you get the tests passing and the code clean? If you want to, these
+are some additional things you could try:
+
+- Optimize for speed.
+- Optimize for readability.
+
+Then please share your thoughts in a comment on the submission. Did this
+experiment make the code better? Worse? Did you learn anything from it?
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+JavaRanch Cattle Drive, exercise 6 [http://www.javaranch.com/grains.jsp](http://www.javaranch.com/grains.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hamming/README.md
+++ b/exercises/hamming/README.md
@@ -1,0 +1,72 @@
+# Hamming
+
+Calculate the Hamming difference between two DNA strands.
+
+A mutation is simply a mistake that occurs during the creation or
+copying of a nucleic acid, in particular DNA. Because nucleic acids are
+vital to cellular functions, mutations tend to cause a ripple effect
+throughout the cell. Although mutations are technically mistakes, a very
+rare mutation may equip the cell with a beneficial attribute. In fact,
+the macro effects of evolution are attributable by the accumulated
+result of beneficial microscopic mutations over many generations.
+
+The simplest and most common type of nucleic acid mutation is a point
+mutation, which replaces one base with another at a single nucleotide.
+
+By counting the number of differences between two homologous DNA strands
+taken from different genomes with a common ancestor, we get a measure of
+the minimum number of point mutations that could have occurred on the
+evolutionary path between the two strands.
+
+This is called the 'Hamming distance'.
+
+It is found by comparing two DNA strands and counting how many of the
+nucleotides are different from their equivalent in the other string.
+
+    GAGCCTACTAACGGGAT
+    CATCGTAATGACGGCCT
+    ^ ^ ^  ^ ^    ^^
+
+The Hamming distance between these two DNA strands is 7.
+
+# Implementation notes
+
+The Hamming distance is only defined for sequences of equal length. This means
+that based on the definition, each language could deal with getting sequences
+of equal length differently.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+The Calculating Point Mutations problem at Rosalind [http://rosalind.info/problems/hamm/](http://rosalind.info/problems/hamm/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/hello-world/README.md
+++ b/exercises/hello-world/README.md
@@ -1,0 +1,51 @@
+# Hello World
+
+The classical introductory exercise. Just say "Hello, World!".
+
+["Hello, World!"](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program) is
+the traditional first program for beginning programming in a new language
+or environment.
+
+The objectives are simple:
+
+- Write a function that returns the string "Hello, World!".
+- Run the test suite and make sure that it succeeds.
+- Submit your solution and check it at the website.
+
+If everything goes well, you will be ready to fetch your first real exercise.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+This is an exercise to introduce users to using Exercism [http://en.wikipedia.org/wiki/%22Hello,_world!%22_program](http://en.wikipedia.org/wiki/%22Hello,_world!%22_program)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/largest-series-product/README.md
+++ b/exercises/largest-series-product/README.md
@@ -1,0 +1,50 @@
+# Largest Series Product
+
+Given a string of digits, calculate the largest product for a contiguous
+substring of digits of length n.
+
+For example, for the input `'1027839564'`, the largest product for a
+series of 3 digits is 270 (9 * 5 * 6), and the largest product for a
+series of 5 digits is 7560 (7 * 8 * 3 * 9 * 5).
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.
+
+For the input `'73167176531330624919225119674426574742355349194934'`,
+the largest product for a series of 6 digits is 23520.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+A variation on Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/leap/README.md
+++ b/exercises/leap/README.md
@@ -1,0 +1,63 @@
+# Leap
+
+Given a year, report if it is a leap year.
+
+The tricky thing here is that a leap year in the Gregorian calendar occurs:
+
+```plain
+on every year that is evenly divisible by 4
+  except every year that is evenly divisible by 100
+    unless the year is also evenly divisible by 400
+```
+
+For example, 1997 is not a leap year, but 1996 is.  1900 is not a leap
+year, but 2000 is.
+
+If your language provides a method in the standard library that does
+this look-up, pretend it doesn't exist and implement it yourself.
+
+## Notes
+
+Though our exercise adopts some very simple rules, there is more to
+learn!
+
+For a delightful, four minute explanation of the whole leap year
+phenomenon, go watch [this youtube video][video].
+
+[video]: http://www.youtube.com/watch?v=xX96xng7sAE
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+JavaRanch Cattle Drive, exercise 3 [http://www.javaranch.com/leap.jsp](http://www.javaranch.com/leap.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/list-ops/README.md
+++ b/exercises/list-ops/README.md
@@ -1,0 +1,40 @@
+# List Ops
+
+Implement basic list operations.
+
+In functional languages list operations like `length`, `map`, and
+`reduce` are very common. Implement a series of basic list operations,
+without using existing functions.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/nucleotide-count/README.md
+++ b/exercises/nucleotide-count/README.md
@@ -1,0 +1,63 @@
+# Nucleotide Count
+
+Given a DNA string, compute how many times each nucleotide occurs in the string.
+
+DNA is represented by an alphabet of the following symbols: 'A', 'C',
+'G', and 'T'.
+
+Each symbol represents a nucleotide, which is a fancy name for the
+particular molecules that happen to make up a large part of DNA.
+
+Shortest intro to biochemistry EVAR:
+
+- twigs are to birds nests as
+- nucleotides are to DNA and RNA as
+- amino acids are to proteins as
+- sugar is to starch as
+- oh crap lipids
+
+I'm not going to talk about lipids because they're crazy complex.
+
+So back to nucleotides.
+
+DNA contains four types of them: adenine (`A`), cytosine (`C`), guanine
+(`G`), and thymine (`T`).
+
+RNA contains a slightly different set of nucleotides, but we don't care
+about that for now.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+The Calculating DNA Nucleotides_problem at Rosalind [http://rosalind.info/problems/dna/](http://rosalind.info/problems/dna/)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -1,0 +1,45 @@
+# Pangram
+
+Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan gramma,
+"every letter") is a sentence using every letter of the alphabet at least once.
+The best known English pangram is: 
+> The quick brown fox jumps over the lazy dog.
+
+The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
+insensitive. Input will not contain non-ASCII symbols.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Pangram](https://en.wikipedia.org/wiki/Pangram)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/phone-number/README.md
+++ b/exercises/phone-number/README.md
@@ -1,0 +1,64 @@
+# Phone Number
+
+Clean up user-entered phone numbers so that they can be sent SMS messages.
+
+The **North American Numbering Plan (NANP)** is a telephone numbering system used by many countries in North America like the United States, Canada or Bermuda. All NANP-countries share the same international country code: `1`.
+
+NANP numbers are ten-digit numbers consisting of a three-digit Numbering Plan Area code, commonly known as *area code*, followed by a seven-digit local number. The first three digits of the local number represent the *exchange code*, followed by the unique four-digit number which is the *subscriber number*.
+
+
+The format is usually represented as
+```
+(NXX)-NXX-XXXX
+```
+where `N` is any digit from 2 through 9 and `X` is any digit from 0 through 9.
+
+Your task is to clean up differently formated telephone numbers by removing punctuation and the country code (1) if present.
+
+For example, the inputs
+- `+1 (613)-995-0253`
+- `613-995-0253`
+- `1 613 995 0253`
+- `613.995.0253`
+
+should all produce the output
+
+`6139950253`
+
+**Note:** As this exercise only deals with telephone numbers used in NANP-countries, only 1 is considered a valid country code.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Event Manager by JumpstartLab [http://tutorials.jumpstartlab.com/projects/eventmanager.html](http://tutorials.jumpstartlab.com/projects/eventmanager.html)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/raindrops/README.md
+++ b/exercises/raindrops/README.md
@@ -1,0 +1,54 @@
+# Raindrops
+
+Convert a number to a string, the contents of which depend on the number's factors.
+
+- If the number has 3 as a factor, output 'Pling'.
+- If the number has 5 as a factor, output 'Plang'.
+- If the number has 7 as a factor, output 'Plong'.
+- If the number does not have 3, 5, or 7 as a factor,
+  just pass the number's digits straight through.
+
+## Examples
+
+- 28's factors are 1, 2, 4, **7**, 14, 28.
+  - In raindrop-speak, this would be a simple "Plong".
+- 30's factors are 1, 2, **3**, **5**, 6, 10, 15, 30.
+  - In raindrop-speak, this would be a "PlingPlang".
+- 34 has four factors: 1, 2, 17, and 34.
+  - In raindrop-speak, this would be "34".
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+A variation on a famous interview question intended to weed out potential candidates. [http://jumpstartlab.com](http://jumpstartlab.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/rna-transcription/README.md
+++ b/exercises/rna-transcription/README.md
@@ -1,0 +1,55 @@
+# Rna Transcription
+
+Given a DNA strand, return its RNA complement (per RNA transcription).
+
+Both DNA and RNA strands are a sequence of nucleotides.
+
+The four nucleotides found in DNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and thymine (**T**).
+
+The four nucleotides found in RNA are adenine (**A**), cytosine (**C**),
+guanine (**G**) and uracil (**U**).
+
+Given a DNA strand, its transcribed RNA strand is formed by replacing
+each nucleotide with its complement:
+
+* `G` -> `C`
+* `C` -> `G`
+* `T` -> `A`
+* `A` -> `U`
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Rosalind [http://rosalind.info/problems/rna](http://rosalind.info/problems/rna)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/robot-simulator/README.md
+++ b/exercises/robot-simulator/README.md
@@ -1,0 +1,64 @@
+# Robot Simulator
+
+Write a robot simulator.
+
+A robot factory's test facility needs a program to verify robot movements.
+
+The robots have three possible movements:
+
+- turn right
+- turn left
+- advance
+
+Robots are placed on a hypothetical infinite grid, facing a particular
+direction (north, east, south, or west) at a set of {x,y} coordinates,
+e.g., {3,8}, with coordinates increasing to the north and east.
+
+The robot then receives a number of instructions, at which point the
+testing facility verifies the robot's new position, and in which
+direction it is pointing.
+
+- The letter-string "RAALAL" means:
+  - Turn right
+  - Advance twice
+  - Turn left
+  - Advance once
+  - Turn left yet again
+- Say a robot starts at {7, 3} facing north. Then running this stream
+  of instructions should leave it at {9, 4} facing west.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Inspired by an interview question at a famous company.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/roman-numerals/README.md
+++ b/exercises/roman-numerals/README.md
@@ -1,0 +1,79 @@
+# Roman Numerals
+
+Write a function to convert from normal numbers to Roman Numerals.
+
+The Romans were a clever bunch. They conquered most of Europe and ruled
+it for hundreds of years. They invented concrete and straight roads and
+even bikinis. One thing they never discovered though was the number
+zero. This made writing and dating extensive histories of their exploits
+slightly more challenging, but the system of numbers they came up with
+is still in use today. For example the BBC uses Roman numerals to date
+their programmes.
+
+The Romans wrote numbers using letters - I, V, X, L, C, D, M. (notice
+these letters have lots of straight lines and are hence easy to hack
+into stone tablets).
+
+```
+ 1  => I
+10  => X
+ 7  => VII
+```
+
+There is no need to be able to convert numbers larger than about 3000.
+(The Romans themselves didn't tend to go any higher)
+
+Wikipedia says: Modern Roman numerals ... are written by expressing each
+digit separately starting with the left most digit and skipping any
+digit with a value of zero.
+
+To see this in practice, consider the example of 1990.
+
+In Roman numerals 1990 is MCMXC:
+
+1000=M
+900=CM
+90=XC
+
+2008 is written as MMVIII:
+
+2000=MM
+8=VIII
+
+See also: http://www.novaroma.org/via_romana/numbers.html
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+The Roman Numeral Kata [http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals](http://codingdojo.org/cgi-bin/index.pl?KataRomanNumerals)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/run-length-encoding/README.md
+++ b/exercises/run-length-encoding/README.md
@@ -1,0 +1,60 @@
+# Run Length Encoding
+
+Implement run-length encoding and decoding.
+
+Run-length encoding (RLE) is a simple form of data compression, where runs
+(consecutive data elements) are replaced by just one data value and count.
+
+For example we can represent the original 53 characters with only 13.
+
+```
+"WWWWWWWWWWWWBWWWWWWWWWWWWBBBWWWWWWWWWWWWWWWWWWWWWWWWB"  ->  "12WB12W3B24WB"
+```
+
+RLE allows the original data to be perfectly reconstructed from
+the compressed data, which makes it a lossless data compression.
+
+```
+"AABCCCDEEEE"  ->  "2AB3CD4E"  ->  "AABCCCDEEEE"
+```
+
+For simplicity, you can assume that the unencoded string will only contain
+the letters A through Z (either lower or upper case) and whitespace. This way 
+data to be encoded will never contain any numbers and numbers inside data to 
+be decoded always represent the count for the following character.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Wikipedia [https://en.wikipedia.org/wiki/Run-length_encoding](https://en.wikipedia.org/wiki/Run-length_encoding)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/say/README.md
+++ b/exercises/say/README.md
@@ -1,0 +1,99 @@
+# Say
+
+Given a number from 0 to 999,999,999,999, spell out that number in English.
+
+## Step 1
+
+Handle the basic case of 0 through 99.
+
+If the input to the program is `22`, then the output should be
+`'twenty-two'`.
+
+Your program should complain loudly if given a number outside the
+blessed range.
+
+Some good test cases for this program are:
+
+- 0
+- 14
+- 50
+- 98
+- -1
+- 100
+
+### Extension
+
+If you're on a Mac, shell out to Mac OS X's `say` program to talk out
+loud.
+
+## Step 2
+
+Implement breaking a number up into chunks of thousands.
+
+So `1234567890` should yield a list like 1, 234, 567, and 890, while the
+far simpler `1000` should yield just 1 and 0.
+
+The program must also report any values that are out of range.
+
+## Step 3
+
+Now handle inserting the appropriate scale word between those chunks.
+
+So `1234567890` should yield `'1 billion 234 million 567 thousand 890'`
+
+The program must also report any values that are out of range.  It's
+fine to stop at "trillion".
+
+## Step 4
+
+Put it all together to get nothing but plain English.
+
+`12345` should give `twelve thousand three hundred forty-five`.
+
+The program must also report any values that are out of range.
+
+### Extensions
+
+Use _and_ (correctly) when spelling out the number in English:
+
+- 14 becomes "fourteen".
+- 100 becomes "one hundred".
+- 120 becomes "one hundred and twenty".
+- 1002 becomes "one thousand and two".
+- 1323 becomes "one thousand three hundred and twenty-three".
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+A variation on JavaRanch CattleDrive, exercise 4a [http://www.javaranch.com/say.jsp](http://www.javaranch.com/say.jsp)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/scrabble-score/README.md
+++ b/exercises/scrabble-score/README.md
@@ -1,0 +1,74 @@
+# Scrabble Score
+
+Given a word, compute the scrabble score for that word.
+
+## Letter Values
+
+You'll need these:
+
+```plain
+Letter                           Value
+A, E, I, O, U, L, N, R, S, T       1
+D, G                               2
+B, C, M, P                         3
+F, H, V, W, Y                      4
+K                                  5
+J, X                               8
+Q, Z                               10
+```
+
+## Examples
+"cabbage" should be scored as worth 14 points:
+
+- 3 points for C
+- 1 point for A, twice
+- 3 points for B, twice
+- 2 points for G
+- 1 point for E
+
+And to total:
+
+- `3 + 2*1 + 2*3 + 2 + 1`
+- = `3 + 2 + 6 + 3`
+- = `5 + 9`
+- = 14
+
+## Extensions
+- You can play a double or a triple letter.
+- You can play a double or a triple word.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Inspired by the Extreme Startup game [https://github.com/rchatley/extreme_startup](https://github.com/rchatley/extreme_startup)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/series/README.md
+++ b/exercises/series/README.md
@@ -1,0 +1,57 @@
+# Series
+
+Given a string of digits, output all the contiguous substrings of length `n` in
+that string.
+
+For example, the string "49142" has the following 3-digit series:
+
+- 491
+- 914
+- 142
+
+And the following 4-digit series:
+
+- 4914
+- 9142
+
+And if you ask for a 6-digit series from a 5-digit string, you deserve
+whatever you get.
+
+Note that these series are only required to occupy *adjacent positions*
+in the input; the digits need not be *numerically consecutive*.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+A subset of the Problem 8 at Project Euler [http://projecteuler.net/problem=8](http://projecteuler.net/problem=8)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/space-age/README.md
+++ b/exercises/space-age/README.md
@@ -1,0 +1,54 @@
+# Space Age
+
+Given an age in seconds, calculate how old someone would be on:
+
+   - Earth: orbital period 365.25 Earth days, or 31557600 seconds
+   - Mercury: orbital period 0.2408467 Earth years
+   - Venus: orbital period 0.61519726 Earth years
+   - Mars: orbital period 1.8808158 Earth years
+   - Jupiter: orbital period 11.862615 Earth years
+   - Saturn: orbital period 29.447498 Earth years
+   - Uranus: orbital period 84.016846 Earth years
+   - Neptune: orbital period 164.79132 Earth years
+
+So if you were told someone were 1,000,000,000 seconds old, you should
+be able to say that they're 31 Earth-years old.
+
+If you're wondering why Pluto didn't make the cut, go watch [this
+youtube video](http://www.youtube.com/watch?v=Z_2gbGXzFbs).
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Partially inspired by Chapter 1 in Chris Pine's online Learn to Program tutorial. [http://pine.fm/LearnToProgram/?Chapter=01](http://pine.fm/LearnToProgram/?Chapter=01)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/strain/README.md
+++ b/exercises/strain/README.md
@@ -1,0 +1,70 @@
+# Strain
+
+Implement the `keep` and `discard` operation on collections. Given a collection
+and a predicate on the collection's elements, `keep` returns a new collection
+containing those elements where the predicate is true, while `discard` returns
+a new collection containing those elements where the predicate is false.
+
+For example, given the collection of numbers:
+
+- 1, 2, 3, 4, 5
+
+And the predicate:
+
+- is the number even?
+
+Then your keep operation should produce:
+
+- 2, 4
+
+While your discard operation should produce:
+
+- 1, 3, 5
+
+Note that the union of keep and discard is all the elements.
+
+The functions may be called `keep` and `discard`, or they may need different
+names in order to not clash with existing functions or concepts in your
+language.
+
+## Restrictions
+
+Keep your hands off that filter/reject/whatchamacallit functionality
+provided by your standard library!  Solve this one yourself using other
+basic tools instead.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+Conversation with James Edward Gray II [https://twitter.com/jeg2](https://twitter.com/jeg2)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sublist/README.md
+++ b/exercises/sublist/README.md
@@ -1,0 +1,51 @@
+# Sublist
+
+Given two lists determine if the first list is contained within the second
+list, if the second list is contained within the first list, if both lists are
+contained within each other or if none of these are true.
+
+Specifically, a list A is a sublist of list B if by dropping 0 or more elements
+from the front of B and 0 or more elements from the back of B you get a list
+that's completely equal to A.
+
+Examples:
+
+ * A = [1, 2, 3], B = [1, 2, 3, 4, 5], A is a sublist of B
+ * A = [3, 4, 5], B = [1, 2, 3, 4, 5], A is a sublist of B
+ * A = [3, 4], B = [1, 2, 3, 4, 5], A is a sublist of B
+ * A = [1, 2, 3], B = [1, 2, 3], A is equal to B
+ * A = [1, 2, 3, 4, 5], B = [2, 3, 4], A is a superlist of B
+ * A = [1, 2, 4], B = [1, 2, 3, 4, 5], A is not a superlist of, sublist of or equal to B
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/sum-of-multiples/README.md
+++ b/exercises/sum-of-multiples/README.md
@@ -1,0 +1,48 @@
+# Sum Of Multiples
+
+Given a number, find the sum of all the multiples of particular numbers up to
+but not including that number.
+
+If we list all the natural numbers up to but not including 20 that are
+multiples of either 3 or 5, we get 3, 5, 6 and 9, 10, 12, 15, and 18.
+
+The sum of these multiples is 78.
+
+Given a number, find the sum of the multiples of a given set of numbers,
+up to but not including that number.
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+A variation on Problem 1 at Project Euler [http://projecteuler.net/problem=1](http://projecteuler.net/problem=1)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/triangle/README.md
+++ b/exercises/triangle/README.md
@@ -1,0 +1,56 @@
+# Triangle
+
+Determine if a triangle is equilateral, isosceles, or scalene.
+
+An _equilateral_ triangle has all three sides the same length.<br/>
+An _isosceles_ triangle has at least two sides the same length. (It is sometimes
+specified as having exactly two sides the same length, but for the purposes of
+this exercise we'll say at least two.)<br/>
+A _scalene_ triangle has all sides of different lengths.
+
+## Note
+
+For a shape to be a triangle at all, all sides have to be of length > 0, and 
+the sum of the lengths of any two sides must be greater than or equal to the 
+length of the third side. See [Triangle Inequality](https://en.wikipedia.org/wiki/Triangle_inequality).
+
+## Dig Deeper
+
+The case where the sum of the lengths of two sides _equals_ that of the 
+third is known as a _degenerate_ triangle - it has zero area and looks like 
+a single line. Feel free to add your own code/tests to check for degenerate triangles.
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+The Ruby Koans triangle project, parts 1 & 2 [http://rubykoans.com](http://rubykoans.com)
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.

--- a/exercises/word-count/README.md
+++ b/exercises/word-count/README.md
@@ -1,0 +1,49 @@
+# Word Count
+
+Given a phrase, count the occurrences of each word in that phrase.
+
+For example for the input `"olly olly in come free"`
+
+```plain
+olly: 2
+in: 1
+come: 1
+free: 1
+```
+
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed.
+
+```bash
+$ npm install
+```
+
+Execute the tests with:
+
+```bash
+$ npm test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ npm run watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+This is a classic toy problem, but we were reminded of it by seeing it in the Go Tour.
+
+## Submitting Incomplete Solutions
+It's possible to submit an incomplete solution so you can see how others have completed the exercise.


### PR DESCRIPTION
We are working towards making exercises stand-alone. That is to say: no more generating READMEs on the fly.

This will give maintainers more control over each individual exercise README, and it will also make some of the backend logic for delivering exercises simpler.

The README template uses the Go text/template package, and the default templates generate the same READMEs as we have been generating on the fly.  See the documentation in [regenerating exercise readmes][regenerate-docs] for details.

The READMEs can be generated at any time using a new 'generate' command in configlet. This command has not yet landed in master or been released, but can be built from source in the generate-readmes branch on [configlet][].

[configlet]: https://github.com/exercism/configlet
[regenerate-docs]: https://github.com/exercism/docs/blob/master/maintaining-a-track/regenerating-exercise-readmes.md

See https://github.com/exercism/meta/issues/15