### PR TITLE
Update Elm/Space-Age tests to use Float literals

### DIFF
--- a/exercises/space-age/tests/Tests.elm
+++ b/exercises/space-age/tests/Tests.elm
@@ -9,26 +9,26 @@ tests : Test
 tests =
     describe "SpaceAge"
         [ test "age in earth years" <|
-            \() -> Expect.equal 32 (round (ageOn Earth 1000000000))
+            \() -> Expect.equal 32 (round (ageOn Earth 1000000000.0))
         , skip <|
             test "age in mercury years" <|
-                \() -> Expect.equal 281 (round (ageOn Mercury 2134835688))
+                \() -> Expect.equal 281 (round (ageOn Mercury 2134835688.0))
         , skip <|
             test "age in venus years" <|
-                \() -> Expect.equal 10 (round (ageOn Venus 189839836))
+                \() -> Expect.equal 10 (round (ageOn Venus 189839836.0))
         , skip <|
             test "age on mars" <|
-                \() -> Expect.equal 39 (round (ageOn Mars 2329871239))
+                \() -> Expect.equal 39 (round (ageOn Mars 2329871239.0))
         , skip <|
             test "age on jupiter" <|
-                \() -> Expect.equal 2 (round (ageOn Jupiter 901876382))
+                \() -> Expect.equal 2 (round (ageOn Jupiter 901876382.0))
         , skip <|
             test "age on saturn" <|
-                \() -> Expect.equal 3 (round (ageOn Saturn 3000000000))
+                \() -> Expect.equal 3 (round (ageOn Saturn 3000000000.0))
         , skip <|
             test "age on uranus" <|
-                \() -> Expect.equal 1 (round (ageOn Uranus 3210123456))
+                \() -> Expect.equal 1 (round (ageOn Uranus 3210123456.0))
         , skip <|
             test "age on neptune" <|
-                \() -> Expect.equal 2 (round (ageOn Neptune 8210123456))
+                \() -> Expect.equal 2 (round (ageOn Neptune 8210123456.0))
         ]


### PR DESCRIPTION
The large Int literals in some of these tests result in errors (see https://github.com/elm-lang/elm-compiler/issues/1246) that can only be resolved by editing the test file. Changing the Int literals to Floats solves the issue. I think it would be best to fix  it here even though it does make the exercise more interesting.