### PR TITLE
Fix pangram README to state that some test input will include non-ASCII input

### DIFF
--- a/exercises/pangram/.meta/description.md
+++ b/exercises/pangram/.meta/description.md
@@ -1,0 +1,7 @@
+Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan gramma,
+"every letter") is a sentence using every letter of the alphabet at least once.
+The best known English pangram is: 
+> The quick brown fox jumps over the lazy dog.
+
+The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
+insensitive. Some input will contain non-ASCII symbols.

--- a/exercises/pangram/README.md
+++ b/exercises/pangram/README.md
@@ -6,7 +6,7 @@ The best known English pangram is:
 > The quick brown fox jumps over the lazy dog.
 
 The alphabet used consists of ASCII letters `a` to `z`, inclusive, and is case
-insensitive. Input will not contain non-ASCII symbols.
+insensitive. Some input will contain non-ASCII symbols.
 
 ## Elm Installation
 


### PR DESCRIPTION
The test suite for the pangram exercise [includes a test with non-ASCII input.](https://github.com/exercism/elm/blob/master/exercises/pangram/tests/Tests.elm#L56-L60)
However, the README states that no input will contain non-ASCII characters. 
This PR changes the README to state that some input will contain non-ASCII characters.