### PR TITLE
Update Phone-Number Tests.elm

### DIFF
--- a/exercises/phone-number/PhoneNumber.example.elm
+++ b/exercises/phone-number/PhoneNumber.example.elm
@@ -1,44 +1,60 @@
 module PhoneNumber exposing (..)
 
-import String
+import Regex exposing (Regex, regex, find, HowMany(..))
+import String exposing (concat, startsWith, length, slice)
+import List exposing (map, head)
+import Maybe exposing (andThen)
 
 
-nums =
-    [ '1', '2', '3', '4', '5', '6', '7', '8', '9', '0' ]
+matchesFormat : Regex -> String -> Bool
+matchesFormat regex string =
+    case find (AtMost 1) regex string |> head of
+        Just found ->
+            True
+
+        Nothing ->
+            False
 
 
 getNumber : String -> Maybe String
-getNumber text =
-    getValidNum (String.filter isDigit text)
+getNumber phoneNumber =
+    let
+        numberFormat =
+            regex "^\\D*(\\+?1[\\-\\s\\.]?)?((\\([2-9]\\d{2}\\))|([2-9]\\d{2}))[\\-\\s\\.]?[2-9]\\d{2}[\\-\\s\\.]?\\d{4}\\D*$"
 
+        numbers =
+            regex "\\d"
 
-isDigit : Char -> Bool
-isDigit char =
-    List.any (\n -> n == char) nums
+        dropCountryCode matchedNumbers =
+            case matchedNumbers of
+                "1" :: nums ->
+                    nums
 
+                _ ->
+                    matchedNumbers
 
-getValidNum : String -> Maybe String
-getValidNum num =
-    if String.length num == 10 then
-        Just num
-    else if (String.length num == 11) && (String.left 1 num == "1") then
-        Just (String.dropLeft 1 num)
-    else
-        Nothing
+        stripNumber =
+            concat << dropCountryCode << map .match << find All numbers
+    in
+        if phoneNumber |> matchesFormat numberFormat then
+            Just <| stripNumber <| phoneNumber
+        else
+            Nothing
 
 
 prettyPrint : String -> Maybe String
-prettyPrint input =
-    Maybe.map formatNumber (getNumber input)
+prettyPrint phoneNumber =
+    let
+        numberFormat =
+            regex "^1?[2-9]\\d{2}[2-9]\\d{2}\\d{4}$"
 
-
-formatNumber : String -> String
-formatNumber input =
-    String.concat
-        [ "("
-        , (String.slice 0 3 input)
-        , ") "
-        , (String.slice 3 6 input)
-        , "-"
-        , (String.slice 6 10 input)
-        ]
+        prettyNumber =
+            if phoneNumber |> startsWith "1" then
+                "(" ++ (slice 1 4 phoneNumber) ++ ") " ++ (slice 4 7 phoneNumber) ++ "-" ++ (slice 7 11 phoneNumber)
+            else
+                "(" ++ (slice 0 3 phoneNumber) ++ ") " ++ (slice 3 6 phoneNumber) ++ "-" ++ (slice 6 10 phoneNumber)
+    in
+        if phoneNumber |> matchesFormat numberFormat then
+            Just prettyNumber
+        else
+            Nothing

--- a/exercises/phone-number/PhoneNumber.example.elm
+++ b/exercises/phone-number/PhoneNumber.example.elm
@@ -20,7 +20,7 @@ getNumber : String -> Maybe String
 getNumber phoneNumber =
     let
         numberFormat =
-            regex "^\\D*(\\+?1[\\-\\s\\.]?)?((\\([2-9]\\d{2}\\))|([2-9]\\d{2}))[\\-\\s\\.]?[2-9]\\d{2}[\\-\\s\\.]?\\d{4}\\D*$"
+            regex "^\\D*(\\+?1\\s*[\\-\\.]?\\s*)?((\\([2-9]\\d{2}\\))|([2-9]\\d{2}))\\s*[\\-\\.]?\\s*[2-9]\\d{2}\\s*[\\-\\.]?\\s*\\d{4}\\D*$"
 
         numbers =
             regex "\\d"

--- a/exercises/phone-number/tests/Tests.elm
+++ b/exercises/phone-number/tests/Tests.elm
@@ -9,13 +9,13 @@ tests : Test
 tests =
     describe "PhoneNumber"
         [ test "cleans number" <|
-            \() -> Expect.equal (Just "1234567890") (getNumber "(123) 456-7890")
+            \() -> Expect.equal (Just "2234567890") (getNumber "(223) 456-7890")
         , skip <|
             test "cleans number with dots" <|
-                \() -> Expect.equal (Just "1234567890") (getNumber "123.456.7890")
+                \() -> Expect.equal (Just "2234567890") (getNumber "223.456.7890")
         , skip <|
             test "valid when 11 digits and first is 1" <|
-                \() -> Expect.equal (Just "1234567890") (getNumber "11234567890")
+                \() -> Expect.equal (Just "2234567890") (getNumber "12234567890")
         , skip <|
             test "invalid when 11 digits" <|
                 \() -> Expect.equal Nothing (getNumber "21234567890")
@@ -26,6 +26,12 @@ tests =
             test "invalid when 12 digits" <|
                 \() -> Expect.equal Nothing (getNumber "123456789012")
         , skip <|
+            test "invalid when N in area code is 1" <|
+                \() -> Expect.equal Nothing (getNumber "1234567890")
+        , skip <|
+            test "invalid when N in exchange code is 1" <|
+                \() -> Expect.equal Nothing (getNumber "2341567890")
+        , skip <|
             test "invalid when empty" <|
                 \() -> Expect.equal Nothing (getNumber "")
         , skip <|
@@ -33,14 +39,14 @@ tests =
                 \() -> Expect.equal Nothing (getNumber " (-) ")
         , skip <|
             test "valid with leading characters" <|
-                \() -> Expect.equal (Just "1234567890") (getNumber "my number is 123 456 7890")
+                \() -> Expect.equal (Just "2234567890") (getNumber "my number is 223 456 7890")
         , skip <|
             test "valid with trailing characters" <|
-                \() -> Expect.equal (Just "1234567890") (getNumber "123 456 7890 - bob")
+                \() -> Expect.equal (Just "2234567890") (getNumber "223 456 7890 - bob")
         , skip <|
             test "pretty print" <|
-                \() -> Expect.equal (Just "(123) 456-7890") (prettyPrint "1234567890")
+                \() -> Expect.equal (Just "(223) 456-7890") (prettyPrint "2234567890")
         , skip <|
             test "pretty print with full us phone number" <|
-                \() -> Expect.equal (Just "(123) 456-7890") (prettyPrint "11234567890")
+                \() -> Expect.equal (Just "(223) 456-7890") (prettyPrint "12234567890")
         ]

--- a/exercises/phone-number/tests/Tests.elm
+++ b/exercises/phone-number/tests/Tests.elm
@@ -11,26 +11,29 @@ tests =
         [ test "cleans number" <|
             \() -> Expect.equal (Just "2234567890") (getNumber "(223) 456-7890")
         , skip <|
+            test "invalid when empty" <|
+                \() -> Expect.equal Nothing (getNumber "")
+        , skip <|
             test "cleans number with dots" <|
                 \() -> Expect.equal (Just "2234567890") (getNumber "223.456.7890")
-        , skip <|
-            test "cleans number with multiple spaces" <|
-                \() -> Expect.equal (Just "2234567890") (getNumber "223 456   7890")
-        , skip <|
-            test "valid when 11 digits and first is 1" <|
-                \() -> Expect.equal (Just "2234567890") (getNumber "12234567890")
-        , skip <|
-            test "valid when 11 digits and first is 1 with punctuation" <|
-                \() -> Expect.equal (Just "2234567890") (getNumber "+1 (223) 456-7890")
-        , skip <|
-            test "invalid when 11 digits and first is not 1" <|
-                \() -> Expect.equal Nothing (getNumber "22234567890")
         , skip <|
             test "invalid when 9 digits" <|
                 \() -> Expect.equal Nothing (getNumber "223456789")
         , skip <|
+            test "cleans number with multiple spaces" <|
+                \() -> Expect.equal (Just "2234567890") (getNumber "223 456   7890")
+        , skip <|
             test "invalid when 12 digits" <|
                 \() -> Expect.equal Nothing (getNumber "223456789012")
+        , skip <|
+            test "valid when 11 digits and first is 1" <|
+                \() -> Expect.equal (Just "2234567890") (getNumber "12234567890")
+        , skip <|
+            test "invalid when 11 digits and first is not 1" <|
+                \() -> Expect.equal Nothing (getNumber "22234567890")
+        , skip <|
+            test "valid when 11 digits and first is 1 with punctuation" <|
+                \() -> Expect.equal (Just "2234567890") (getNumber "+1 (223) 456-7890")
         , skip <|
             test "invalid with letters" <|
                 \() -> Expect.equal Nothing (getNumber "223-abc-789012")
@@ -53,17 +56,8 @@ tests =
             test "invalid when N in exchange code is 1" <|
                 \() -> Expect.equal Nothing (getNumber "2341567890")
         , skip <|
-            test "invalid when empty" <|
-                \() -> Expect.equal Nothing (getNumber "")
-        , skip <|
             test "invalid when no digits present" <|
                 \() -> Expect.equal Nothing (getNumber " (-) ")
-        , skip <|
-            test "valid with leading characters" <|
-                \() -> Expect.equal (Just "2234567890") (getNumber "my number is 223 456 7890")
-        , skip <|
-            test "valid with trailing characters" <|
-                \() -> Expect.equal (Just "2234567890") (getNumber "223 456 7890 - bob")
         , skip <|
             test "pretty print" <|
                 \() -> Expect.equal (Just "(223) 456-7890") (prettyPrint "2234567890")

--- a/exercises/phone-number/tests/Tests.elm
+++ b/exercises/phone-number/tests/Tests.elm
@@ -14,20 +14,41 @@ tests =
             test "cleans number with dots" <|
                 \() -> Expect.equal (Just "2234567890") (getNumber "223.456.7890")
         , skip <|
+            test "cleans number with multiple spaces" <|
+                \() -> Expect.equal (Just "2234567890") (getNumber "223 456   7890")
+        , skip <|
             test "valid when 11 digits and first is 1" <|
                 \() -> Expect.equal (Just "2234567890") (getNumber "12234567890")
         , skip <|
-            test "invalid when 11 digits" <|
-                \() -> Expect.equal Nothing (getNumber "21234567890")
+            test "valid when 11 digits and first is 1 with punctuation" <|
+                \() -> Expect.equal (Just "2234567890") (getNumber "+1 (223) 456-7890")
+        , skip <|
+            test "invalid when 11 digits and first is not 1" <|
+                \() -> Expect.equal Nothing (getNumber "22234567890")
         , skip <|
             test "invalid when 9 digits" <|
-                \() -> Expect.equal Nothing (getNumber "123456789")
+                \() -> Expect.equal Nothing (getNumber "223456789")
         , skip <|
             test "invalid when 12 digits" <|
-                \() -> Expect.equal Nothing (getNumber "123456789012")
+                \() -> Expect.equal Nothing (getNumber "223456789012")
         , skip <|
-            test "invalid when N in area code is 1" <|
-                \() -> Expect.equal Nothing (getNumber "1234567890")
+            test "invalid with letters" <|
+                \() -> Expect.equal Nothing (getNumber "223-abc-789012")
+        , skip <|
+            test "invalid with multiple punctuation marks" <|
+                \() -> Expect.equal Nothing (getNumber "223-@:!-789012")
+        , skip <|
+            test "invalid when area code starts with 1" <|
+                \() -> Expect.equal Nothing (getNumber "(123) 456-7890")
+        , skip <|
+            test "invalid when area code starts with 0" <|
+                \() -> Expect.equal Nothing (getNumber "(023) 456-7890")
+        , skip <|
+            test "invalid when exchange code starts with 1" <|
+                \() -> Expect.equal Nothing (getNumber "(223) 156-7890")
+        , skip <|
+            test "invalid when exchange code starts with 0" <|
+                \() -> Expect.equal Nothing (getNumber "(223) 056-7890")
         , skip <|
             test "invalid when N in exchange code is 1" <|
                 \() -> Expect.equal Nothing (getNumber "2341567890")


### PR DESCRIPTION
The format of _NANP_ phone numbers is described in the [README](https://github.com/exercism/elm/edit/master/exercises/phone-number/README.md) as 

`````
(NXX)-NXX-XXXX
`````

where `N` is a digit from 2 through 9, but all the tests for valid phone numbers test for `Just "1234567890"`.
That means the first digit of the _area code_, `N`, would be 1 there every time, for which a correct implementation should return `Nothing`.

My change would simply increment those 1s to 2, as i believe the intention is to test for valid numbers here.

Additionally I introduced two new test cases, expecting `Nothing`, when either digit `N` in the format is equal to 1.