### PR TITLE
Improve the error message in the Result

### DIFF
--- a/exercises/rna-transcription/RNATranscription.example.elm
+++ b/exercises/rna-transcription/RNATranscription.example.elm
@@ -3,7 +3,7 @@ module RNATranscription exposing (toRNA)
 import String
 
 
-toRNA : String -> Result Char String
+toRNA : String -> Result String String
 toRNA dna =
     dna
         |> String.toList
@@ -22,7 +22,7 @@ resultExtraCombine =
     List.foldr (Result.map2 (::)) (Ok [])
 
 
-toRNANucleotide : Char -> Result Char Char
+toRNANucleotide : Char -> Result String Char
 toRNANucleotide nuc =
     case nuc of
         'C' ->
@@ -38,4 +38,4 @@ toRNANucleotide nuc =
             Ok 'A'
 
         _ ->
-            Err nuc
+            Err (toString nuc ++ " is not a valid nucleotide")

--- a/exercises/rna-transcription/tests/Tests.elm
+++ b/exercises/rna-transcription/tests/Tests.elm
@@ -24,8 +24,8 @@ tests =
                 \() -> Expect.equal (Ok "UGCACCAGAAUU") (toRNA "ACGTGGTCTTAA")
         , skip <|
             test "correctly handles completely invalid input" <|
-                \() -> Expect.equal (Err 'X') (toRNA "XXX")
+                \() -> Expect.equal (Err "'X' is not a valid nucleotide") (toRNA "XXX")
         , skip <|
             test "correctly handles partially invalid input" <|
-                \() -> Expect.equal (Err 'U') (toRNA "UGAAXXXGACAUG")
+                \() -> Expect.equal (Err "'U' is not a valid nucleotide") (toRNA "UGAAXXXGACAUG")
         ]


### PR DESCRIPTION
Instead of just returning a Char, return a string including the first erroneous Char. Reference #174 