### PR TITLE
Expand "Useful Elm Resources"

### DIFF
--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,10 +1,52 @@
-## Interactive Examples
+## Documentation
 
-[Try Elm](http://elm-lang.org/try) provides a number of interactive Elm examples you can edit live in your browser.
+- [Introduction](https://guide.elm-lang.org)
+- [Installation and Getting Started](https://guide.elm-lang.org/install.html)
+- [Syntax](https://guide.elm-lang.org/core_language.html)
+- [Comparison to JavaScript](http://elm-lang.org/docs/from-javascript)
+- [Core Library API](http://package.elm-lang.org/packages/elm-lang/core/latest/)
+- [The Elm Architecture](https://guide.elm-lang.org/architecture/)
+
+
+## Examples
+
+[Try Elm](http://elm-lang.org/try) provides a number of interactive Elm examples you can edit live in your browser:
+
+- [Math](http://elm-lang.org/examples/math)
+- [Strings]()
+- [Functions](http://elm-lang.org/examples/define-functions)
+- [Types](http://elm-lang.org/examples/types)
+- [List length](http://elm-lang.org/examples/length)
+- [Zip](http://elm-lang.org/examples/zip)
+- [Quick sort](http://elm-lang.org/examples/quick-sort)
+- [Boolean expressions](http://elm-lang.org/examples/boolean-expressions)
+
+More at the [official language site](elm-lang.org/examples).
+
+
+## Tools
+
+- [Ellie](https://ellie-app.com/new) is a tool for creating and
+  sharing snippets of Elm-code. For example, if you've got some code
+  that's not working the way you expect, you could put it in Ellie to
+  post to the StackOverflow or the [Elm Slack
+  channel](https://elmlang.herokuapp.com/).
+
+- [Awesome Elm](https://github.com/isRuslan/awesome-elm) is a long
+  list of articles, videos, editor plugins, packages, and other
+  resources.
+
 
 ## Videos
 
-- [Let's be mainstream! User focused design in Elm](https://www.youtube.com/watch?v=oYk8CKH7OhE) ([transcript](http://www.elmbark.com/2016/03/16/mainstream-elm-user-focused-design)) *Evan Czaplicki*
-- [Controlling Time and Space: understanding the many formulations of FRP](https://www.youtube.com/watch?v=Agu6jipKfYw) *Evan Czaplicki*
+About using Elm:
+
 - [Effects as Data](https://www.youtube.com/watch?v=6EdXaWfoslc) *Richard Feldman*
 - [Elm: Building Reactive Web Apps](https://pragmaticstudio.com/elm) *The Pragmatic Studio*
+- [Making Impossible States Impossible](https://www.youtube.com/watch?v=IcgmSRJHu_8) *Richard Feldman*
+
+About how Elm is developed, and why it is the way it is:
+
+- [Controlling Time and Space: understanding the many formulations of FRP](https://www.youtube.com/watch?v=Agu6jipKfYw) *Evan Czaplicki*
+- [Let's be mainstream! User focused design in Elm](https://www.youtube.com/watch?v=oYk8CKH7OhE) ([transcript](http://www.elmbark.com/2016/03/16/mainstream-elm-user-focused-design)) *Evan Czaplicki*
+- [The life of a file](https://www.youtube.com/watch?v=XpDsk374LDE) *Evan Czaplicki*


### PR DESCRIPTION
This commit expands the Useful Elm Resources section of Elm's Exercism
page to include:

- A collection of links into the Elm documentation

- A selection of examples that are useful for the kind of exercises a
  learner might encounter in Exercism

- Links to tools, videos, and more resources

This should close #197. I didn't include the Daily Drip link in that issue because it's a paid service; I'm reluctant to add it to Exercism as I'm not familiar with it, and I'm uncomfortable endorsing it. It's linked in the Awesome Elm list, which is included.

Some of the links here are redundant with the Installation or Learning Elm pages, which I don't think is a problem but am happy to change if it is.