### PR TITLE
phone-number: Remove extra function to match canonical tests

### DIFF
--- a/exercises/phone-number/PhoneNumber.elm
+++ b/exercises/phone-number/PhoneNumber.elm
@@ -1,11 +1,6 @@
-module PhoneNumber exposing (getNumber, prettyPrint)
+module PhoneNumber exposing (getNumber)
 
 
 getNumber : String -> Maybe String
 getNumber phoneNumber =
-    Debug.crash "Please implement this function"
-
-
-prettyPrint : String -> Maybe String
-prettyPrint input =
     Debug.crash "Please implement this function"

--- a/exercises/phone-number/tests/Tests.elm
+++ b/exercises/phone-number/tests/Tests.elm
@@ -1,67 +1,52 @@
 module Tests exposing (..)
 
 import Expect
-import PhoneNumber exposing (getNumber, prettyPrint)
+import PhoneNumber exposing (getNumber)
 import Test exposing (..)
 
 
 tests : Test
 tests =
     describe "PhoneNumber"
-        [ test "cleans number" <|
+        [ test "cleans the number" <|
             \() -> Expect.equal (Just "2234567890") (getNumber "(223) 456-7890")
         , skip <|
-            test "invalid when empty" <|
-                \() -> Expect.equal Nothing (getNumber "")
-        , skip <|
-            test "cleans number with dots" <|
+            test "cleans numbers with dots" <|
                 \() -> Expect.equal (Just "2234567890") (getNumber "223.456.7890")
+        , skip <|
+            test "cleans numbers with multiple spaces" <|
+                \() -> Expect.equal (Just "2234567890") (getNumber "223 456   7890   ")
         , skip <|
             test "invalid when 9 digits" <|
                 \() -> Expect.equal Nothing (getNumber "223456789")
         , skip <|
-            test "cleans number with multiple spaces" <|
-                \() -> Expect.equal (Just "2234567890") (getNumber "223 456   7890")
-        , skip <|
-            test "invalid when 12 digits" <|
-                \() -> Expect.equal Nothing (getNumber "223456789012")
-        , skip <|
-            test "valid when 11 digits and first is 1" <|
-                \() -> Expect.equal (Just "2234567890") (getNumber "12234567890")
-        , skip <|
-            test "invalid when 11 digits and first is not 1" <|
+            test "invalid when 11 digits does not start with a 1" <|
                 \() -> Expect.equal Nothing (getNumber "22234567890")
         , skip <|
-            test "valid when 11 digits and first is 1 with punctuation" <|
+            test "valid when 11 digits and starting with 1" <|
+                \() -> Expect.equal (Just "2234567890") (getNumber "12234567890")
+        , skip <|
+            test "valid when 11 digits and starting with 1 even with punctuation" <|
                 \() -> Expect.equal (Just "2234567890") (getNumber "+1 (223) 456-7890")
         , skip <|
+            test "invalid when more than 11 digits" <|
+                \() -> Expect.equal Nothing (getNumber "321234567890")
+        , skip <|
             test "invalid with letters" <|
-                \() -> Expect.equal Nothing (getNumber "223-abc-789012")
+                \() -> Expect.equal Nothing (getNumber "123-abc-7890")
         , skip <|
-            test "invalid with multiple punctuation marks" <|
-                \() -> Expect.equal Nothing (getNumber "223-@:!-789012")
+            test "invalid with punctuations" <|
+                \() -> Expect.equal Nothing (getNumber "123-@:!-7890")
         , skip <|
-            test "invalid when area code starts with 1" <|
-                \() -> Expect.equal Nothing (getNumber "(123) 456-7890")
-        , skip <|
-            test "invalid when area code starts with 0" <|
+            test "invalid if area code starts with 0" <|
                 \() -> Expect.equal Nothing (getNumber "(023) 456-7890")
         , skip <|
-            test "invalid when exchange code starts with 1" <|
-                \() -> Expect.equal Nothing (getNumber "(223) 156-7890")
+            test "invalid if area code starts with 1" <|
+                \() -> Expect.equal Nothing (getNumber "(123) 456-7890")
         , skip <|
-            test "invalid when exchange code starts with 0" <|
+            test "invalid if exchange code starts with 0" <|
                 \() -> Expect.equal Nothing (getNumber "(223) 056-7890")
         , skip <|
-            test "invalid when N in exchange code is 1" <|
-                \() -> Expect.equal Nothing (getNumber "2341567890")
-        , skip <|
-            test "invalid when no digits present" <|
-                \() -> Expect.equal Nothing (getNumber " (-) ")
-        , skip <|
-            test "pretty print" <|
-                \() -> Expect.equal (Just "(223) 456-7890") (prettyPrint "2234567890")
-        , skip <|
-            test "pretty print with full us phone number" <|
-                \() -> Expect.equal (Just "(223) 456-7890") (prettyPrint "12234567890")
+            test "invalid if exchange code starts with 1" <|
+                \() -> Expect.equal Nothing (getNumber "(223) 156-7890")
         ]


### PR DESCRIPTION
I noticed when starting the PhoneNumber exercise that the prettyPrint function is not part of the problem specification (I guess it used to be, in a previous version of the exercise). I thought that might be confusing since there is no mention of prettyPrint in the exercise instructions.

This commit removes prettyPrint and the tests that referred to it, as well as renaming & reordering the tests for PhoneNumber to match the current [canonical data](https://github.com/exercism/problem-specifications/blob/master/exercises/phone-number/canonical-data.json).