### PR TITLE
Update Installation to install elm-test for 0.19

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -7,7 +7,7 @@ it from [the official site](https://nodejs.org/). Once you have Node.js up and
 running, you can install elm and elm-test using 
 
 ```bash
-npm install -g elm elm-test
+npm install -g elm elm-test@beta
 ```
 
-which will install elm and place any tooling on `$PATH`.
+which will install Elm and place any tooling on `$PATH`.


### PR DESCRIPTION
Specifying what elm-test version to use for Elm 0.19, since the default install looks for `elm-package.json`, which is now `elm.json`. Should help people from encountering the error found in #232.