### PR TITLE
Update hello-world exercise and add two-fer exercise

### DIFF
--- a/config.json
+++ b/config.json
@@ -15,6 +15,16 @@
       ]
     },
     {
+      "slug": "two-fer",
+      "uuid": "0118175a-761f-4d05-8857-fe93745f490f",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "strings"
+      ]
+    },
+    {
       "slug": "bob",
       "uuid": "11ce2a73-3f43-4b14-b755-6c52dc71bdda",
       "core": true,

--- a/exercises/hello-world/HelloWorld.elm
+++ b/exercises/hello-world/HelloWorld.elm
@@ -12,8 +12,8 @@ module HelloWorld exposing (helloWorld)
 -- It's good style to include any types at the top level of your modules.
 
 
-helloWorld : Maybe String -> String
-helloWorld name =
+helloWorld : String
+helloWorld =
     Debug.todo "Please implement this function"
 
 

--- a/exercises/hello-world/HelloWorld.example.elm
+++ b/exercises/hello-world/HelloWorld.example.elm
@@ -1,11 +1,6 @@
 module HelloWorld exposing (helloWorld)
 
 
-helloWorld : Maybe String -> String
-helloWorld name =
-    case name of
-        Just name_ ->
-            "Hello, " ++ name_ ++ "!"
-
-        Nothing ->
-            "Hello, World!"
+helloWorld : String
+helloWorld =
+    "Hello, World!"

--- a/exercises/hello-world/tests/Tests.elm
+++ b/exercises/hello-world/tests/Tests.elm
@@ -7,20 +7,6 @@ import Test exposing (..)
 
 tests : Test
 tests =
-    describe "Hello, World!"
-        [ test "Hello with no name" <|
-            \() ->
-                Expect.equal "Hello, World!" (helloWorld Nothing)
-
-        -- Once you get the first test passing, remove the
-        -- `skip <|` (just leave the comma) on the next two
-        -- lines to continue!
-        , skip <|
-            test "Hello to a sample name" <|
-                \() ->
-                    Expect.equal "Hello, Alice!" (helloWorld (Just "Alice"))
-        , skip <|
-            test "Hello to another sample name" <|
-                \() ->
-                    Expect.equal "Hello, Bob!" (helloWorld (Just "Bob"))
-        ]
+    test "Hello, World!" <|
+        \() ->
+            Expect.equal "Hello, World!" helloWorld

--- a/exercises/two-fer/README.md
+++ b/exercises/two-fer/README.md
@@ -1,0 +1,48 @@
+# Two Fer
+
+`Two-fer` or `2-fer` is short for two for one. One for you and one for me.
+
+```text
+"One for X, one for me."
+```
+
+When X is a name or "you".
+
+If the given name is "Alice", the result should be "One for Alice, one for me."
+If no name is given, the result should be "One for you, one for me."
+
+
+## Elm Installation
+
+Refer to the [Exercism help page](http://exercism.io/languages/elm) for Elm
+installation and learning resources.
+
+## Writing the Code
+
+The first time you start an exercise, you'll need to ensure you have the
+appropriate dependencies installed. Thankfully, Elm makes that easy for you and
+will install dependencies when you try to run tests or build the code.
+
+Execute the tests with:
+
+```bash
+$ elm-test
+```
+
+Automatically run tests again when you save changes:
+
+```bash
+$ elm-test --watch
+```
+
+As you work your way through the test suite, be sure to remove the `skip <|`
+calls from each test until you get them all passing!
+
+## Source
+
+[https://en.wikipedia.org/wiki/Two-fer](https://en.wikipedia.org/wiki/Two-fer)
+
+## Submitting Incomplete Solutions
+
+It is possible to submit an incomplete solution so you can see how others have
+completed the exercise.

--- a/exercises/two-fer/TwoFer.elm
+++ b/exercises/two-fer/TwoFer.elm
@@ -1,0 +1,11 @@
+module TwoFer exposing (twoFer)
+
+
+twoFer : Maybe String -> String
+twoFer name =
+    case name of
+        Just name_ ->
+            "One for " ++ name_ ++ ", one for me."
+
+        Nothing ->
+            "One for you, one for me."

--- a/exercises/two-fer/TwoFer.elm
+++ b/exercises/two-fer/TwoFer.elm
@@ -1,11 +1,5 @@
 module TwoFer exposing (twoFer)
 
 
-twoFer : Maybe String -> String
 twoFer name =
-    case name of
-        Just name_ ->
-            "One for " ++ name_ ++ ", one for me."
-
-        Nothing ->
-            "One for you, one for me."
+    Debug.todo "Please implement this function"

--- a/exercises/two-fer/TwoFer.elm
+++ b/exercises/two-fer/TwoFer.elm
@@ -1,5 +1,6 @@
 module TwoFer exposing (twoFer)
 
 
+twoFer : Maybe String -> String
 twoFer name =
     Debug.todo "Please implement this function"

--- a/exercises/two-fer/TwoFer.example.elm
+++ b/exercises/two-fer/TwoFer.example.elm
@@ -1,5 +1,8 @@
 module TwoFer exposing (twoFer)
 
 
+twoFer : Maybe String -> String
 twoFer name =
-    Debug.todo "Please implement this function"
+    "One for "
+        ++ Maybe.withDefault "you" name
+        ++ ", one for me."

--- a/exercises/two-fer/TwoFer.example.elm
+++ b/exercises/two-fer/TwoFer.example.elm
@@ -1,0 +1,5 @@
+module TwoFer exposing (twoFer)
+
+
+twoFer name =
+    Debug.todo "Please implement this function"

--- a/exercises/two-fer/elm.json
+++ b/exercises/two-fer/elm.json
@@ -6,14 +6,24 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "elm/core": "1.0.0"
+            "elm/browser": "1.0.0",
+            "elm/core": "1.0.0",
+            "elm/html": "1.0.0",
+            "elm/regex": "1.0.0"
         },
-        "indirect": {}
+        "indirect": {
+            "elm/json": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/url": "1.0.0",
+            "elm/virtual-dom": "1.0.0"
+        }
     },
     "test-dependencies": {
         "direct": {
-          "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.0.0"
         },
-        "indirect": {}
+        "indirect": {
+            "elm/random": "1.0.0"
+        }
     }
 }

--- a/exercises/two-fer/elm.json
+++ b/exercises/two-fer/elm.json
@@ -1,0 +1,19 @@
+{
+    "type": "application",
+    "source-directories": [
+        "."
+    ],
+    "elm-version": "0.19.0",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.0"
+        },
+        "indirect": {}
+    },
+    "test-dependencies": {
+        "direct": {
+          "elm-explorations/test": "1.0.0"
+        },
+        "indirect": {}
+    }
+}

--- a/exercises/two-fer/tests/Tests.elm
+++ b/exercises/two-fer/tests/Tests.elm
@@ -12,10 +12,6 @@ tests =
         [ test "No name given" <|
             \() ->
                 Expect.equal "One for you, one for me." (twoFer Nothing)
-
-        -- Once you get the first test passing, remove the
-        -- `skip <|` (just leave the comma) on the next two
-        -- lines to continue!
         , skip <|
             test "A name given" <|
                 \() ->

--- a/exercises/two-fer/tests/Tests.elm
+++ b/exercises/two-fer/tests/Tests.elm
@@ -1,0 +1,27 @@
+module Tests exposing (tests)
+
+import Expect
+import String
+import Test exposing (..)
+import TwoFer exposing (twoFer)
+
+
+tests : Test
+tests =
+    describe "Two-fer"
+        [ test "No name given" <|
+            \() ->
+                Expect.equal "One for you, one for me." (twoFer Nothing)
+
+        -- Once you get the first test passing, remove the
+        -- `skip <|` (just leave the comma) on the next two
+        -- lines to continue!
+        , skip <|
+            test "A name given" <|
+                \() ->
+                    Expect.equal "One for Alice, one for me." (twoFer (Just "Alice"))
+        , skip <|
+            test "Another name given" <|
+                \() ->
+                    Expect.equal "One for Bob, one for me." (twoFer (Just "Bob"))
+        ]


### PR DESCRIPTION
A decision was made [upstream](https://github.com/exercism/problem-specifications/issues/520) to simplify the hello-world exercise and implement a [new exercise](https://github.com/exercism/problem-specifications/issues/548) to take its place. This PR brings the elm track in line with these new changes.