### PR TITLE
Update docs to install correct elm-test package

### DIFF
--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -7,7 +7,7 @@ it from [the official site](https://nodejs.org/). Once you have Node.js up and
 running, you can install elm and elm-test using 
 
 ```bash
-npm install -g elm elm-test
+npm install -g elm elm-test@beta
 ```
 
 which will install elm and place any tooling on `$PATH`.

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -7,7 +7,7 @@ it from [the official site](https://nodejs.org/). Once you have Node.js up and
 running, you can install elm and elm-test using 
 
 ```bash
-npm install -g elm elm-test@beta
+npm install -g elm@elm0.19.0 elm-test@elm0.19.0
 ```
 
 which will install elm and place any tooling on `$PATH`.


### PR DESCRIPTION
We need to install elm-test@beta with elm version 0.19.0 or the tests won't run.