### PR TITLE
space-age: add more tests, use problem specification data

### DIFF
--- a/exercises/space-age/tests/Tests.elm
+++ b/exercises/space-age/tests/Tests.elm
@@ -1,6 +1,6 @@
 module Tests exposing (tests)
 
-import Expect
+import Expect exposing (FloatingPointTolerance(..))
 import SpaceAge exposing (Planet(..), ageOn)
 import Test exposing (..)
 
@@ -9,74 +9,50 @@ tests : Test
 tests =
     describe "SpaceAge"
         [ test "age in earth years" <|
-            \() -> Expect.equal 32 (round (ageOn Earth 1000000000.0))
+            \() -> Expect.within (Absolute 0.01) 31.69 (ageOn Earth 1000000000.0)
         , skip <|
             test "age in mercury years" <|
-                \() -> Expect.equal 281 (round (ageOn Mercury 2134835688.0))
+                \() -> Expect.within (Absolute 0.01) 280.88 (ageOn Mercury 2134835688.0)
         , skip <|
             test "age in venus years" <|
-                \() -> Expect.equal 10 (round (ageOn Venus 189839836.0))
+                \() -> Expect.within (Absolute 0.01) 9.78 (ageOn Venus 189839836.0)
         , skip <|
             test "age on mars" <|
-                \() -> Expect.equal 39 (round (ageOn Mars 2329871239.0))
+                \() -> Expect.within (Absolute 0.01) 35.88 (ageOn Mars 2129871239.0)
         , skip <|
             test "age on jupiter" <|
-                \() -> Expect.equal 2 (round (ageOn Jupiter 901876382.0))
+                \() -> Expect.within (Absolute 0.01) 2.41 (ageOn Jupiter 901876382.0)
         , skip <|
             test "age on saturn" <|
-                \() -> Expect.equal 3 (round (ageOn Saturn 3000000000.0))
+                \() -> Expect.within (Absolute 0.01) 2.15 (ageOn Saturn 2000000000.0)
         , skip <|
             test "age on uranus" <|
-                \() -> Expect.equal 1 (round (ageOn Uranus 3210123456.0))
+                \() -> Expect.within (Absolute 0.01) 0.46 (ageOn Uranus 1210123456.0)
         , skip <|
             test "age on neptune" <|
-                \() -> Expect.equal 2 (round (ageOn Neptune 8210123456.0))
+                \() -> Expect.within (Absolute 0.01) 0.35 (ageOn Neptune 1821023456.0)
         , skip <|
             test "2 earth years in earth years" <|
-                \() -> Expect.equal 2 (round (ageOn Earth 63072000.0))
+                \() -> Expect.within (Absolute 0.01) 2 (ageOn Earth 63072000.0)
         , skip <|
             test "2 earth years in mercury years" <|
-                \() -> Expect.equal 8 (round (ageOn Mercury 63072000.0))
+                \() -> Expect.within (Absolute 0.01) 8.3 (ageOn Mercury 63072000.0)
         , skip <|
             test "2 earth years in venus years" <|
-                \() -> Expect.equal 3 (round (ageOn Venus 63072000.0))
+                \() -> Expect.within (Absolute 0.01) 3.25 (ageOn Venus 63072000.0)
         , skip <|
             test "2 earth years on mars" <|
-                \() -> Expect.equal 1 (round (ageOn Mars 63072000.0))
+                \() -> Expect.within (Absolute 0.01) 1.06 (ageOn Mars 63072000.0)
         , skip <|
             test "2 earth years on jupiter" <|
-                \() -> Expect.equal 0 (round (ageOn Jupiter 63072000.0))
+                \() -> Expect.within (Absolute 0.01) 0.17 (ageOn Jupiter 63072000.0)
         , skip <|
             test "2 earth years on saturn" <|
-                \() -> Expect.equal 0 (round (ageOn Saturn 63072000.0))
+                \() -> Expect.within (Absolute 0.01) 0.07 (ageOn Saturn 63072000.0)
         , skip <|
             test "2 earth years on uranus" <|
-                \() -> Expect.equal 0 (round (ageOn Uranus 63072000.0))
+                \() -> Expect.within (Absolute 0.01) 0.02 (ageOn Uranus 63072000.0)
         , skip <|
             test "2 earth years on neptune" <|
-                \() -> Expect.equal 0 (round (ageOn Neptune 63072000.0))
-        , skip <|
-            test "128 earth years in earth years" <|
-                \() -> Expect.equal 129 (round (ageOn Earth 4036608000.0))
-        , skip <|
-            test "128 earth years in mercury years" <|
-                \() -> Expect.equal 531 (round (ageOn Mercury 4036608000.0))
-        , skip <|
-            test "128 earth years in venus years" <|
-                \() -> Expect.equal 213 (round (ageOn Venus 4036608000.0))
-        , skip <|
-            test "128 earth years on mars" <|
-                \() -> Expect.equal 68 (round (ageOn Mars 4036608000.0))
-        , skip <|
-            test "128 earth years on jupiter" <|
-                \() -> Expect.equal 9 (round (ageOn Jupiter 4036608000.0))
-        , skip <|
-            test "128 earth years on saturn" <|
-                \() -> Expect.equal 4 (round (ageOn Saturn 4036608000.0))
-        , skip <|
-            test "128 earth years on uranus" <|
-                \() -> Expect.equal 1 (round (ageOn Uranus 4036608000.0))
-        , skip <|
-            test "128 earth years on neptune" <|
-                \() -> Expect.equal 1 (round (ageOn Neptune 4036608000.0))
+                \() -> Expect.within (Absolute 0.01) 0.01 (ageOn Neptune 63072000.0)
         ]

--- a/exercises/space-age/tests/Tests.elm
+++ b/exercises/space-age/tests/Tests.elm
@@ -10,34 +10,49 @@ tests =
     describe "SpaceAge"
         [ test "31.7 Earth years in Earth years" <|
             \() -> Expect.within (Absolute 0.01) 31.69 (ageOn Earth 1000000000.0)
-        , test "2 Earth years in Earth years" <|
-            \() -> Expect.within (Absolute 0.01) 2 (ageOn Earth 63115200.0)
-        , test "67.6 Earth years in Mercury years" <|
-            \() -> Expect.within (Absolute 0.01) 280.88 (ageOn Mercury 2134835688.0)
-        , test "2 Earth years in Mercury years" <|
-            \() -> Expect.within (Absolute 0.01) 8.3 (ageOn Mercury 63115200.0)
-        , test "6 Earth years  in Venus years" <|
-            \() -> Expect.within (Absolute 0.01) 9.78 (ageOn Venus 189839836.0)
-        , test "2 Earth years in Venus years" <|
-            \() -> Expect.within (Absolute 0.01) 3.25 (ageOn Venus 63115200.0)
-        , test "67.6 Earth years in Mars years" <|
-            \() -> Expect.within (Absolute 0.01) 35.88 (ageOn Mars 2129871239.0)
-        , test "2 Earth years in Mars years" <|
-            \() -> Expect.within (Absolute 0.01) 1.06 (ageOn Mars 63115200.0)
-        , test "28.6 Earth years in Jupiter years" <|
-            \() -> Expect.within (Absolute 0.01) 2.41 (ageOn Jupiter 901876382.0)
-        , test "2 Earth years in Jupiter years" <|
-            \() -> Expect.within (Absolute 0.01) 0.17 (ageOn Jupiter 63115200.0)
-        , test "63.5 Earth years in Saturn years" <|
-            \() -> Expect.within (Absolute 0.01) 2.15 (ageOn Saturn 2000000000.0)
-        , test "2 Earth years in saturn years" <|
-            \() -> Expect.within (Absolute 0.01) 0.07 (ageOn Saturn 63115200.0)
-        , test "38.3 Earth years in Uranus years" <|
-            \() -> Expect.within (Absolute 0.01) 0.46 (ageOn Uranus 1210123456.0)
-        , test "2 Earth years in uranus years" <|
-            \() -> Expect.within (Absolute 0.01) 0.02 (ageOn Uranus 63115200.0)
-        , test "57.7 Earth years in Neptune years" <|
-            \() -> Expect.within (Absolute 0.01) 0.35 (ageOn Neptune 1821023456.0)
-        , test "2 Earth years in Neptune years" <|
-            \() -> Expect.within (Absolute 0.01) 0.01 (ageOn Neptune 63115200.0)
+        , skip <|
+            test "2 Earth years in Earth years" <|
+                \() -> Expect.within (Absolute 0.01) 2 (ageOn Earth 63115200.0)
+        , skip <|
+            test "67.6 Earth years in Mercury years" <|
+                \() -> Expect.within (Absolute 0.01) 280.88 (ageOn Mercury 2134835688.0)
+        , skip <|
+            test "2 Earth years in Mercury years" <|
+                \() -> Expect.within (Absolute 0.01) 8.3 (ageOn Mercury 63115200.0)
+        , skip <|
+            test "6 Earth years in Venus years" <|
+                \() -> Expect.within (Absolute 0.01) 9.78 (ageOn Venus 189839836.0)
+        , skip <|
+            test "2 Earth years in Venus years" <|
+                \() -> Expect.within (Absolute 0.01) 3.25 (ageOn Venus 63115200.0)
+        , skip <|
+            test "67.6 Earth years in Mars years" <|
+                \() -> Expect.within (Absolute 0.01) 35.88 (ageOn Mars 2129871239.0)
+        , skip <|
+            test "2 Earth years in Mars years" <|
+                \() -> Expect.within (Absolute 0.01) 1.06 (ageOn Mars 63115200.0)
+        , skip <|
+            test "28.6 Earth years in Jupiter years" <|
+                \() -> Expect.within (Absolute 0.01) 2.41 (ageOn Jupiter 901876382.0)
+        , skip <|
+            test "2 Earth years in Jupiter years" <|
+                \() -> Expect.within (Absolute 0.01) 0.17 (ageOn Jupiter 63115200.0)
+        , skip <|
+            test "63.5 Earth years in Saturn years" <|
+                \() -> Expect.within (Absolute 0.01) 2.15 (ageOn Saturn 2000000000.0)
+        , skip <|
+            test "2 Earth years in saturn years" <|
+                \() -> Expect.within (Absolute 0.01) 0.07 (ageOn Saturn 63115200.0)
+        , skip <|
+            test "38.3 Earth years in Uranus years" <|
+                \() -> Expect.within (Absolute 0.01) 0.46 (ageOn Uranus 1210123456.0)
+        , skip <|
+            test "2 Earth years in uranus years" <|
+                \() -> Expect.within (Absolute 0.01) 0.02 (ageOn Uranus 63115200.0)
+        , skip <|
+            test "57.7 Earth years in Neptune years" <|
+                \() -> Expect.within (Absolute 0.01) 0.35 (ageOn Neptune 1821023456.0)
+        , skip <|
+            test "2 Earth years in Neptune years" <|
+                \() -> Expect.within (Absolute 0.01) 0.01 (ageOn Neptune 63115200.0)
         ]

--- a/exercises/space-age/tests/Tests.elm
+++ b/exercises/space-age/tests/Tests.elm
@@ -8,51 +8,36 @@ import Test exposing (..)
 tests : Test
 tests =
     describe "SpaceAge"
-        [ test "age in earth years" <|
+        [ test "31.7 Earth years in Earth years" <|
             \() -> Expect.within (Absolute 0.01) 31.69 (ageOn Earth 1000000000.0)
-        , skip <|
-            test "age in mercury years" <|
-                \() -> Expect.within (Absolute 0.01) 280.88 (ageOn Mercury 2134835688.0)
-        , skip <|
-            test "age in venus years" <|
-                \() -> Expect.within (Absolute 0.01) 9.78 (ageOn Venus 189839836.0)
-        , skip <|
-            test "age on mars" <|
-                \() -> Expect.within (Absolute 0.01) 35.88 (ageOn Mars 2129871239.0)
-        , skip <|
-            test "age on jupiter" <|
-                \() -> Expect.within (Absolute 0.01) 2.41 (ageOn Jupiter 901876382.0)
-        , skip <|
-            test "age on saturn" <|
-                \() -> Expect.within (Absolute 0.01) 2.15 (ageOn Saturn 2000000000.0)
-        , skip <|
-            test "age on uranus" <|
-                \() -> Expect.within (Absolute 0.01) 0.46 (ageOn Uranus 1210123456.0)
-        , skip <|
-            test "age on neptune" <|
-                \() -> Expect.within (Absolute 0.01) 0.35 (ageOn Neptune 1821023456.0)
-        , skip <|
-            test "2 earth years in earth years" <|
-                \() -> Expect.within (Absolute 0.01) 2 (ageOn Earth 63072000.0)
-        , skip <|
-            test "2 earth years in mercury years" <|
-                \() -> Expect.within (Absolute 0.01) 8.3 (ageOn Mercury 63072000.0)
-        , skip <|
-            test "2 earth years in venus years" <|
-                \() -> Expect.within (Absolute 0.01) 3.25 (ageOn Venus 63072000.0)
-        , skip <|
-            test "2 earth years on mars" <|
-                \() -> Expect.within (Absolute 0.01) 1.06 (ageOn Mars 63072000.0)
-        , skip <|
-            test "2 earth years on jupiter" <|
-                \() -> Expect.within (Absolute 0.01) 0.17 (ageOn Jupiter 63072000.0)
-        , skip <|
-            test "2 earth years on saturn" <|
-                \() -> Expect.within (Absolute 0.01) 0.07 (ageOn Saturn 63072000.0)
-        , skip <|
-            test "2 earth years on uranus" <|
-                \() -> Expect.within (Absolute 0.01) 0.02 (ageOn Uranus 63072000.0)
-        , skip <|
-            test "2 earth years on neptune" <|
-                \() -> Expect.within (Absolute 0.01) 0.01 (ageOn Neptune 63072000.0)
+        , test "2 Earth years in Earth years" <|
+            \() -> Expect.within (Absolute 0.01) 2 (ageOn Earth 63115200.0)
+        , test "67.6 Earth years in Mercury years" <|
+            \() -> Expect.within (Absolute 0.01) 280.88 (ageOn Mercury 2134835688.0)
+        , test "2 Earth years in Mercury years" <|
+            \() -> Expect.within (Absolute 0.01) 8.3 (ageOn Mercury 63115200.0)
+        , test "6 Earth years  in Venus years" <|
+            \() -> Expect.within (Absolute 0.01) 9.78 (ageOn Venus 189839836.0)
+        , test "2 Earth years in Venus years" <|
+            \() -> Expect.within (Absolute 0.01) 3.25 (ageOn Venus 63115200.0)
+        , test "67.6 Earth years in Mars years" <|
+            \() -> Expect.within (Absolute 0.01) 35.88 (ageOn Mars 2129871239.0)
+        , test "2 Earth years in Mars years" <|
+            \() -> Expect.within (Absolute 0.01) 1.06 (ageOn Mars 63115200.0)
+        , test "28.6 Earth years in Jupiter years" <|
+            \() -> Expect.within (Absolute 0.01) 2.41 (ageOn Jupiter 901876382.0)
+        , test "2 Earth years in Jupiter years" <|
+            \() -> Expect.within (Absolute 0.01) 0.17 (ageOn Jupiter 63115200.0)
+        , test "63.5 Earth years in Saturn years" <|
+            \() -> Expect.within (Absolute 0.01) 2.15 (ageOn Saturn 2000000000.0)
+        , test "2 Earth years in saturn years" <|
+            \() -> Expect.within (Absolute 0.01) 0.07 (ageOn Saturn 63115200.0)
+        , test "38.3 Earth years in Uranus years" <|
+            \() -> Expect.within (Absolute 0.01) 0.46 (ageOn Uranus 1210123456.0)
+        , test "2 Earth years in uranus years" <|
+            \() -> Expect.within (Absolute 0.01) 0.02 (ageOn Uranus 63115200.0)
+        , test "57.7 Earth years in Neptune years" <|
+            \() -> Expect.within (Absolute 0.01) 0.35 (ageOn Neptune 1821023456.0)
+        , test "2 Earth years in Neptune years" <|
+            \() -> Expect.within (Absolute 0.01) 0.01 (ageOn Neptune 63115200.0)
         ]

--- a/exercises/space-age/tests/Tests.elm
+++ b/exercises/space-age/tests/Tests.elm
@@ -31,4 +31,52 @@ tests =
         , skip <|
             test "age on neptune" <|
                 \() -> Expect.equal 2 (round (ageOn Neptune 8210123456.0))
+        , skip <|
+            test "2 earth years in earth years" <|
+                \() -> Expect.equal 2 (round (ageOn Earth 63072000.0))
+        , skip <|
+            test "2 earth years in mercury years" <|
+                \() -> Expect.equal 8 (round (ageOn Mercury 63072000.0))
+        , skip <|
+            test "2 earth years in venus years" <|
+                \() -> Expect.equal 3 (round (ageOn Venus 63072000.0))
+        , skip <|
+            test "2 earth years on mars" <|
+                \() -> Expect.equal 1 (round (ageOn Mars 63072000.0))
+        , skip <|
+            test "2 earth years on jupiter" <|
+                \() -> Expect.equal 0 (round (ageOn Jupiter 63072000.0))
+        , skip <|
+            test "2 earth years on saturn" <|
+                \() -> Expect.equal 0 (round (ageOn Saturn 63072000.0))
+        , skip <|
+            test "2 earth years on uranus" <|
+                \() -> Expect.equal 0 (round (ageOn Uranus 63072000.0))
+        , skip <|
+            test "2 earth years on neptune" <|
+                \() -> Expect.equal 0 (round (ageOn Neptune 63072000.0))
+        , skip <|
+            test "128 earth years in earth years" <|
+                \() -> Expect.equal 129 (round (ageOn Earth 4036608000.0))
+        , skip <|
+            test "128 earth years in mercury years" <|
+                \() -> Expect.equal 531 (round (ageOn Mercury 4036608000.0))
+        , skip <|
+            test "128 earth years in venus years" <|
+                \() -> Expect.equal 213 (round (ageOn Venus 4036608000.0))
+        , skip <|
+            test "128 earth years on mars" <|
+                \() -> Expect.equal 68 (round (ageOn Mars 4036608000.0))
+        , skip <|
+            test "128 earth years on jupiter" <|
+                \() -> Expect.equal 9 (round (ageOn Jupiter 4036608000.0))
+        , skip <|
+            test "128 earth years on saturn" <|
+                \() -> Expect.equal 4 (round (ageOn Saturn 4036608000.0))
+        , skip <|
+            test "128 earth years on uranus" <|
+                \() -> Expect.equal 1 (round (ageOn Uranus 4036608000.0))
+        , skip <|
+            test "128 earth years on neptune" <|
+                \() -> Expect.equal 1 (round (ageOn Neptune 4036608000.0))
         ]


### PR DESCRIPTION
1. this PR uses floating point comparison, so that we can bring in values from problem specification instead of rounded values

2. without more tests, you can hard code one age per planet