### PR TITLE
binary-search: return Nothing instead of -1

### DIFF
--- a/exercises/binary-search/BinarySearch.elm
+++ b/exercises/binary-search/BinarySearch.elm
@@ -3,6 +3,6 @@ module BinarySearch exposing (find)
 import Array exposing (Array)
 
 
-find : Int -> Array Int -> Int
+find : Int -> Array Int -> Maybe Int
 find target xs =
     Debug.todo "Please implement this function"

--- a/exercises/binary-search/BinarySearch.example.elm
+++ b/exercises/binary-search/BinarySearch.example.elm
@@ -3,34 +3,34 @@ module BinarySearch exposing (find)
 import Array exposing (Array)
 
 
-find : Int -> Array Int -> Int
+find : Int -> Array Int -> Maybe Int
 find target xs =
     find_ 0 (Array.length xs) target xs
 
 
-find_ : Int -> Int -> Int -> Array Int -> Int
-find_ i0 i1 target xs =
+find_ : Int -> Int -> Int -> Array Int -> Maybe Int
+find_ min max target xs =
     let
-        i =
-            (i1 + i0) // 2
+        middle =
+            (min + max) // 2
 
-        isEqual =
-            Array.get i xs
-                |> (==) (Just target)
-
-        isLessThan =
-            Array.get i xs
-                |> Maybe.map ((<) target)
+        middleComp =
+            Array.get middle xs
+                |> Maybe.map (compare target)
     in
-    case ( isEqual, isLessThan, i0 > i1 ) of
-        ( True, _, _ ) ->
-            i
+    if max < min then
+        Nothing
 
-        ( False, Just True, False ) ->
-            find_ i0 (i - 1) target xs
+    else
+        case middleComp of
+            Just LT ->
+                find_ min (middle - 1) target xs
 
-        ( False, Just False, False ) ->
-            find_ (i + 1) i1 target xs
+            Just GT ->
+                find_ (middle + 1) max target xs
 
-        _ ->
-            -1
+            Just EQ ->
+                Just middle
+
+            Nothing ->
+                Nothing

--- a/exercises/binary-search/tests/Tests.elm
+++ b/exercises/binary-search/tests/Tests.elm
@@ -14,53 +14,53 @@ tests =
             \() ->
                 Array.fromList [ 6 ]
                     |> find 6
-                    |> Expect.equal 0
+                    |> Expect.equal (Just 0)
         , skip <|
             test "finds a value in the middle of an array" <|
                 \() ->
                     Array.fromList [ 1, 3, 4, 6, 8, 9, 11 ]
                         |> find 6
-                        |> Expect.equal 3
+                        |> Expect.equal (Just 3)
         , skip <|
             test "finds a value at the beginning of an array" <|
                 \() ->
                     Array.fromList [ 1, 3, 4, 6, 8, 9, 11 ]
                         |> find 1
-                        |> Expect.equal 0
+                        |> Expect.equal (Just 0)
         , skip <|
             test "finds a value in an array of odd length" <|
                 \() ->
                     Array.fromList [ 1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 634 ]
                         |> find 144
-                        |> Expect.equal 9
+                        |> Expect.equal (Just 9)
         , skip <|
             test "finds a value in an array of even length" <|
                 \() ->
                     Array.fromList [ 1, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377 ]
                         |> find 21
-                        |> Expect.equal 5
+                        |> Expect.equal (Just 5)
         , skip <|
             test "identifies that a value is not included in the array" <|
                 \() ->
                     Array.fromList [ 1, 3, 4, 6, 8, 9, 11 ]
                         |> find 7
-                        |> Expect.equal -1
+                        |> Expect.equal Nothing
         , skip <|
             test "a value smaller than the array's smallest value is not included" <|
                 \() ->
                     Array.fromList [ 1, 3, 4, 6, 8, 9, 11 ]
                         |> find 0
-                        |> Expect.equal -1
+                        |> Expect.equal Nothing
         , skip <|
             test "a value larger than the array's largest value is not included" <|
                 \() ->
                     Array.fromList [ 1, 3, 4, 6, 8, 9, 11 ]
                         |> find 13
-                        |> Expect.equal -1
+                        |> Expect.equal Nothing
         , skip <|
             test "nothing is included in an empty array" <|
                 \() ->
                     Array.empty
                         |> find 1
-                        |> Expect.equal -1
+                        |> Expect.equal Nothing
         ]


### PR DESCRIPTION
I don't know if this warrants a upstream PR.

For the binary search algorithm, we have students returning `-1`. This leads to bad habits and can be harder to implement. This PR replaces `-1` with `Nothing`