### PR TITLE
Add tests for Grains exercise

### DIFF
--- a/exercises/grains/Grains.elm
+++ b/exercises/grains/Grains.elm
@@ -1,6 +1,11 @@
-module Grains exposing (square)
+module Grains exposing (square, total)
 
 
 square : Int -> Maybe Int
 square n =
+    Debug.todo "Please implement this function"
+
+
+total : Int -> Maybe Int
+total n =
     Debug.todo "Please implement this function"

--- a/exercises/grains/Grains.example.elm
+++ b/exercises/grains/Grains.example.elm
@@ -1,4 +1,4 @@
-module Grains exposing (square)
+module Grains exposing (square, total)
 
 
 square : Int -> Maybe Int
@@ -8,3 +8,12 @@ square n =
 
     else
         Just <| 2 ^ (n - 1)
+
+
+total : Int -> Maybe Int
+total n =
+    if n < 1 then
+        Nothing
+
+    else
+        Just <| 2 ^ n - 1

--- a/exercises/grains/tests/Tests.elm
+++ b/exercises/grains/tests/Tests.elm
@@ -1,7 +1,7 @@
 module Tests exposing (tests)
 
 import Expect
-import Grains exposing (square)
+import Grains exposing (square, total)
 import Json.Encode exposing (Value)
 import Test exposing (..)
 
@@ -41,5 +41,31 @@ tests =
                to avoid the weirdness. A bit more information can be found
                here: https://github.com/elm-lang/elm-compiler/issues/1246
             -}
+            ]
+        , describe "total"
+            [ skip <|
+                test "of 1" <|
+                    \() -> Expect.equal (Just 1) (total 1)
+            , skip <|
+                test "of 2" <|
+                    \() -> Expect.equal (Just 3) (total 2)
+            , skip <|
+                test "of 3" <|
+                    \() -> Expect.equal (Just 7) (total 3)
+            , skip <|
+                test "of 4" <|
+                    \() -> Expect.equal (Just 15) (total 4)
+            , skip <|
+                test "of 16" <|
+                    \() -> Expect.equal (Just 65535) (total 16)
+            , skip <|
+                test "of 32" <|
+                    \() -> Expect.equal (Just 4294967295) (total 32)
+            , skip <|
+                test "total 0 raises an exception" <|
+                    \() -> Expect.equal Nothing (total 0)
+            , skip <|
+                test "negative total raises an exception" <|
+                    \() -> Expect.equal Nothing (total -1)
             ]
         ]


### PR DESCRIPTION
This addresses the changes proposed in #255:
- adds tests for "total number of grains" part
- adds stub code for `total` function
- adds example implementation for `total` function