### PR TITLE
Adjust core track to help ease bottlenecks

### DIFF
--- a/config.json
+++ b/config.json
@@ -37,6 +37,72 @@
       ]
     },
     {
+      "slug": "leap",
+      "uuid": "e943e3bf-920e-4541-95c3-be7bf6024afe",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "conditionals",
+        "integers"
+      ]
+    },
+    {
+      "slug": "space-age",
+      "uuid": "2ce5bcba-c708-4da0-ae11-4654b3e0d0a5",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "floating_point_numbers"
+      ]
+    },
+    {
+      "slug": "grade-school",
+      "uuid": "c7749c5a-529e-4e46-8bdb-e33519f6d176",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "maps",
+        "sorting"
+      ]
+    },
+    {
+      "slug": "raindrops",
+      "uuid": "e3e73171-c3d1-49f7-9511-d1f4a08e7a69",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 2,
+      "topics": [
+        "filtering",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "robot-simulator",
+      "uuid": "6b8f952e-94ea-4264-accf-cdb28b3b4529",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 3,
+      "topics": [
+        "records",
+        "tuples"
+      ]
+    },
+    {
+      "slug": "allergies",
+      "uuid": "29b5a28a-417a-4cee-ba6f-9dd942ceffaa",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 4,
+      "topics": [
+        "bitwise_operations",
+        "enumerations",
+        "filtering"
+      ]
+    },
+    {
       "slug": "difference-of-squares",
       "uuid": "646c7164-cfa4-42c3-9af5-2f672e6ec81e",
       "core": false,
@@ -58,17 +124,6 @@
       ]
     },
     {
-      "slug": "leap",
-      "uuid": "e943e3bf-920e-4541-95c3-be7bf6024afe",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "conditionals",
-        "integers"
-      ]
-    },
-    {
       "slug": "rna-transcription",
       "uuid": "3af96d19-87d7-4d8b-aecb-f63122815501",
       "core": false,
@@ -77,16 +132,6 @@
       "topics": [
         "strings",
         "transforming"
-      ]
-    },
-    {
-      "slug": "space-age",
-      "uuid": "2ce5bcba-c708-4da0-ae11-4654b3e0d0a5",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "floating_point_numbers"
       ]
     },
     {
@@ -134,17 +179,6 @@
       ]
     },
     {
-      "slug": "grade-school",
-      "uuid": "c7749c5a-529e-4e46-8bdb-e33519f6d176",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "maps",
-        "sorting"
-      ]
-    },
-    {
       "slug": "grains",
       "uuid": "41518694-4293-49f6-8af5-1cdad84acf78",
       "core": false,
@@ -185,17 +219,6 @@
       "topics": [
         "booleans",
         "strings"
-      ]
-    },
-    {
-      "slug": "raindrops",
-      "uuid": "e3e73171-c3d1-49f7-9511-d1f4a08e7a69",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 2,
-      "topics": [
-        "filtering",
-        "text_formatting"
       ]
     },
     {
@@ -251,17 +274,6 @@
       ]
     },
     {
-      "slug": "robot-simulator",
-      "uuid": "6b8f952e-94ea-4264-accf-cdb28b3b4529",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 3,
-      "topics": [
-        "records",
-        "tuples"
-      ]
-    },
-    {
       "slug": "scrabble-score",
       "uuid": "16ccc1fa-34b0-4a7e-b3cf-33a711e857ea",
       "core": false,
@@ -311,18 +323,6 @@
         "integers",
         "math",
         "transforming"
-      ]
-    },
-    {
-      "slug": "allergies",
-      "uuid": "29b5a28a-417a-4cee-ba6f-9dd942ceffaa",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 4,
-      "topics": [
-        "bitwise_operations",
-        "enumerations",
-        "filtering"
       ]
     },
     {

--- a/config.json
+++ b/config.json
@@ -213,6 +213,10 @@
     {
       "slug": "binary-search-dupicate",
       "uuid": "939e71ab-38fb-4d39-97f1-c7d2f12922fe",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 0,
+      "topics": null,
       "deprecated": true
     },
     {
@@ -229,6 +233,10 @@
     {
       "slug": "isogram-duplicate",
       "uuid": "7b03583a-fa85-4bd0-af30-0b84968d35f9",
+      "core": false,
+      "unlocked_by": null,
+      "difficulty": 0,
+      "topics": null,
       "deprecated": true
     },
     {

--- a/config.json
+++ b/config.json
@@ -92,7 +92,7 @@
     {
       "slug": "sum-of-multiples",
       "uuid": "75859d00-8772-4471-97a7-d6fe432edc5e",
-      "core": true,
+      "core": false,
       "unlocked_by": null,
       "difficulty": 1,
       "topics": [
@@ -104,7 +104,7 @@
     {
       "slug": "accumulate",
       "uuid": "0b4561f3-59a7-4463-a733-c7fa8f9f332a",
-      "core": true,
+      "core": false,
       "unlocked_by": null,
       "difficulty": 2,
       "topics": [
@@ -116,7 +116,7 @@
       "slug": "collatz-conjecture",
       "uuid": "0edd5fa2-f1db-4572-9810-55a2c6729753",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "difficulty": 2,
       "topics": [
         "math"
@@ -202,7 +202,7 @@
       "slug": "binary-search",
       "uuid": "1F9FE5BC-8213-44FD-B7D1-5D4CC7F3A475",
       "core": false,
-      "unlocked_by": "sum-of-multiples",
+      "unlocked_by": null,
       "difficulty": 3,
       "topics": [
         "algorithms",
@@ -353,7 +353,7 @@
       "slug": "list-ops",
       "uuid": "114b5717-0d82-459e-90c4-f00d8b6beb5b",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "lists",
@@ -364,7 +364,7 @@
       "slug": "pascals-triangle",
       "uuid": "b7e456d7-e383-4e03-9126-c9b57c1287e1",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 4,
       "topics": [
         "lists",
@@ -436,7 +436,7 @@
       "slug": "roman-numerals",
       "uuid": "c1461035-6abe-4f17-a818-7a3ac6642c18",
       "core": false,
-      "unlocked_by": "accumulate",
+      "unlocked_by": null,
       "difficulty": 5,
       "topics": [
         "recursion",

--- a/config.json
+++ b/config.json
@@ -25,29 +25,6 @@
       ]
     },
     {
-      "slug": "bob",
-      "uuid": "11ce2a73-3f43-4b14-b755-6c52dc71bdda",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "conditionals",
-        "strings",
-        "text_formatting"
-      ]
-    },
-    {
-      "slug": "leap",
-      "uuid": "e943e3bf-920e-4541-95c3-be7bf6024afe",
-      "core": true,
-      "unlocked_by": null,
-      "difficulty": 1,
-      "topics": [
-        "conditionals",
-        "integers"
-      ]
-    },
-    {
       "slug": "space-age",
       "uuid": "2ce5bcba-c708-4da0-ae11-4654b3e0d0a5",
       "core": true,
@@ -69,14 +46,26 @@
       ]
     },
     {
-      "slug": "raindrops",
-      "uuid": "e3e73171-c3d1-49f7-9511-d1f4a08e7a69",
+      "slug": "allergies",
+      "uuid": "29b5a28a-417a-4cee-ba6f-9dd942ceffaa",
       "core": true,
       "unlocked_by": null,
-      "difficulty": 2,
+      "difficulty": 4,
       "topics": [
-        "filtering",
-        "text_formatting"
+        "bitwise_operations",
+        "enumerations",
+        "filtering"
+      ]
+    },
+    {
+      "slug": "leap",
+      "uuid": "e943e3bf-920e-4541-95c3-be7bf6024afe",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "conditionals",
+        "integers"
       ]
     },
     {
@@ -91,15 +80,26 @@
       ]
     },
     {
-      "slug": "allergies",
-      "uuid": "29b5a28a-417a-4cee-ba6f-9dd942ceffaa",
+      "slug": "raindrops",
+      "uuid": "e3e73171-c3d1-49f7-9511-d1f4a08e7a69",
       "core": true,
       "unlocked_by": null,
-      "difficulty": 4,
+      "difficulty": 2,
       "topics": [
-        "bitwise_operations",
-        "enumerations",
-        "filtering"
+        "filtering",
+        "text_formatting"
+      ]
+    },
+    {
+      "slug": "bob",
+      "uuid": "11ce2a73-3f43-4b14-b755-6c52dc71bdda",
+      "core": true,
+      "unlocked_by": null,
+      "difficulty": 1,
+      "topics": [
+        "conditionals",
+        "strings",
+        "text_formatting"
       ]
     },
     {


### PR DESCRIPTION
**TL;DR:**
This PR reorders the core exercises; see the end for the new ordering.
Please read the full thing before replying!

---

I wrote a script that takes some data points into account to move certain core exercises to be optional side exercises, and which reorders the remaining exercises.

This is not meant to be the "be all end all" of perfection :-)
This is an attempt to make some simple changes in the short term. In the longer term, over the next 12 months, the product team will be doing a bunch of work to dig into what makes great Exercism exercises, and how to structure tracks to provide a better experience for both learners and mentors.

**Once this goes live** we will continue to monitor the continuation rate, the median wait time, and a few other stats as well, to help decide whether or not we need to take any other immediate steps. That said, if you see anything weird or worrying once the change is out, please ping us on Slack (or here) so we can discuss a fix posthaste!

**The most helpful thing you can do in reviewing this** is to look at the results and tell me whether anything is obviously terrible or suspiciously weird. I know very little about the Elm track (or the language, for that matter), so I could easily have missed something.

I'd also appreciate it if you posted this to the mentors as a heads up, and also because mentors tend to have a great gut sense about the core exercises.

## Bottleneck detection and fixes
### Removal from core:

The following exercises were moved out of the core track:

- sum-of-multiples
- accumulate

This is a list of exercises that typically are unappealing to students and not very interesting to mentor. They tend to be math problems or implementations of CS algorithms and the like.

**Worth considering:** Are any of these exercises particularly valuable in the Elm track? If so, we should keep it. Let me know and I can regenerate the PR.

### Reordering:

The data that I based the reordering on was taken from the production database, and is based on the last 6 months.

I reordered by taking the original order, and then giving "penalty points" for two different things

- low continuation rates (percentage)
- long wait times in the mentor queue (median wait time in minutes)

"Continuation" is when someone completes an exercise, but then does not submit the following exercise. We have other interesting numbers that we may use to adjust things in the future, but this one seemed like our best bet for now for the bottlenecks. I somewhat arbitrarily chose 75% as the cutoff for whether or not to give penalty points, i.e. continuation rate < 75% gets penalized. The only exercise I did not penalize based on this rate was the exercise directly following `hello-world`, since `hello-world` is basically just a taste test, and it is natural to assume that many people will decide that Exercism is not really for them.

<details>
 <summary>Continuation rates</summary>

```
- hello-world (100%)
- two-fer (95%)
- bob (57%)
- leap (43%)
- space-age (90%)
- sum-of-multiples (82%)
- accumulate (90%)
- grade-school (88%)
- raindrops (100%)
- robot-simulator (35%)
- allergies (100%)
```

</details>

Long wait times in the mentor queue is an indication that mentors don't enjoy mentoring the exercise, or put it off. This could be for a number of reasons, which we have not explicitly identified, but we've observed that sometimes the exercise is simply too difficult in the current position, which means that mentors have to go back and forth a whole bunch with students to get something right, and the discussions can be quite frustrating. Also sometimes the exercise is just not very interesting to mentor. Or if the exercise is too early in the track sometimes people will submit lots of really complicated solutions rather than a small handful of mostly reasonable solutions, also making it harder to mentor.

So this pushes exercises with long wait times further back in the core track. We may decide that we need to remove some exercises from core altogether, if wait times continue to be bad.

<details>
 <summary>Wait times</summary>

```
- hello-world (0 min)
- two-fer (1640 min)
- bob (14573 min)
- leap (1326 min)
- space-age (1886 min)
- sum-of-multiples (3000 min)
- accumulate (3728 min)
- grade-school (0 min)
- raindrops (15165 min)
- robot-simulator (0 min)
- allergies (0 min)
```
</details>

### Outcome

#### Before
```
- hello-world
- two-fer
- bob
- leap
- space-age
- sum-of-multiples
- accumulate
- grade-school
- raindrops
- robot-simulator
- allergies
```

#### After

_Note: the numbers indicate the position in the core track, as defined by the index of the array. Minus means that it moved earlier, plus means that it moved later._

```
- hello-world
- two-fer
- space-age (-2)
- grade-school (-2)
- allergies (-4)
- leap (+2)
- robot-simulator (-1)
- raindrops (+1)
- bob (+6)
```

I have to say that I was surprised that raindrops and leap moved to later in the track, because in other tracks these tend to be great earlier... but leap has a poor continuation rate, and raindrops has a poor wait time. If you have any thoughts about those exercise I'd love to hear them!
