### PR TITLE
Much faster bin/build.sh tests

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -27,37 +27,16 @@ fi
 
 # TEST
 
-declare -i TEST_RESULT=0
-FAILED_EXERCISES=''
-
+rm -rf build/tests/ build/*.elm
 mkdir -p build/tests
+cp template/elm.json build/
 
 for example_file in exercises/**/*.example.elm
 do
-  # clean up generated code from last run
-  rm -rf build/tests/elm-stuff/generated-code/
-
   exercise_dir=$(dirname $example_file)
   exercise_name=$(basename $example_file .example.elm)
-  cp "$exercise_dir/$exercise_name.example.elm" "build/$exercise_name.elm"
-  cp "$exercise_dir/elm.json" build/
-  cat "$exercise_dir/tests/Tests.elm" | sed 's/skip <|//g' > build/tests/Tests.elm
-
-  echo '-------------------------------------------------------'
-  echo "Testing $exercise_name"
-
-
-  npm test -- build/
-
-  # capture result from last command (elm-test)
-  if [ $? -ne 0 ]; then
-      TEST_RESULT=1
-      FAILED_EXERCISES+="$exercise_name\n"
-  fi
+  cp $example_file "build/$exercise_name.elm"
+  cat "$exercise_dir/tests/Tests.elm" | sed "s/module Tests/module Tests$exercise_name/" | sed 's/skip <|//g' > "build/tests/Tests$exercise_name.elm"
 done
 
-if [ $TEST_RESULT -ne 0 ]; then
-  echo "The following exercises failed"
-  printf $FAILED_EXERCISES
-  exit $TEST_RESULT
-fi
+npm test -- build/tests/

--- a/template/elm.json
+++ b/template/elm.json
@@ -6,14 +6,21 @@
     "elm-version": "0.19.0",
     "dependencies": {
         "direct": {
-            "elm/core": "1.0.0"
+            "elm/core": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
         "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-          "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.0.0",
+            "elm/parser": "1.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
-        "indirect": {}
+        "indirect": {
+            "elm/random": "1.0.0",
+            "elm/json": "1.1.3"
+        }
     }
 }


### PR DESCRIPTION
Copy each `Tests.elm` file with the exercise suffix `Tests$exercise_name.elm`. This enables running `elm-test` once instead of for every exercise and saves a looot of time when running `bin/build.sh`.