### PR TITLE
rna-transcription: Add test for invalid input

### DIFF
--- a/exercises/rna-transcription/src/RNATranscription.elm
+++ b/exercises/rna-transcription/src/RNATranscription.elm
@@ -1,6 +1,6 @@
 module RNATranscription exposing (toRNA)
 
 
-toRNA : String -> Result Char String
+toRNA : String -> Result String String
 toRNA dna =
     Debug.todo "Please implement this function"

--- a/exercises/rna-transcription/src/RNATranscription.example.elm
+++ b/exercises/rna-transcription/src/RNATranscription.example.elm
@@ -3,7 +3,13 @@ module RNATranscription exposing (toRNA)
 import String
 
 
-toRNA : String -> Result Char String
+createErrorMessage : Char -> String
+createErrorMessage invalidNucleotide =
+    [ "'", String.fromChar invalidNucleotide, "' is not a valid nucleotide" ]
+        |> String.concat
+
+
+toRNA : String -> Result String String
 toRNA dna =
     dna
         |> String.toList
@@ -11,6 +17,7 @@ toRNA dna =
         |> resultExtraCombine
         |> Result.map (List.map String.fromChar)
         |> Result.map (String.join "")
+        |> Result.mapError createErrorMessage
 
 
 

--- a/exercises/rna-transcription/tests/Tests.elm
+++ b/exercises/rna-transcription/tests/Tests.elm
@@ -5,6 +5,16 @@ import RNATranscription exposing (toRNA)
 import Test exposing (..)
 
 
+isErr : Result error value -> Bool
+isErr result =
+    case result of
+        Ok _ ->
+            False
+
+        Err _ ->
+            True
+
+
 tests : Test
 tests =
     describe "RNATranscription"
@@ -22,4 +32,7 @@ tests =
         , skip <|
             test "complement" <|
                 \() -> Expect.equal (Ok "UGCACCAGAAUU") (toRNA "ACGTGGTCTTAA")
+        , skip <|
+            test "input \"INVALID\" should produce an error" <|
+                \() -> Expect.true "expected an error message output. For example `Err \"Invalid input\"`" (toRNA "INVALID" |> isErr)
         ]


### PR DESCRIPTION
Currently it is possible to pass all tests without producing an error result which makes it confusing why the return type is result.

This changes the error type to string and enforces that *some* error is produced for invalid input.

Example failing test:
![image](https://user-images.githubusercontent.com/8300052/81234299-68b77d00-8ff0-11ea-9790-cec1db0d4d09.png)

The example code produces the error suggested here https://github.com/exercism/elm/issues/174#issuecomment-361012095 `Result.Err "'I' is not a valid nucleotide"`

Since the task instructions do not mention any particular error message it only seems fair to accept any.

This is my first pull request here. Sorry for any issues.