### PR TITLE
[v3] Update Markdown files to latest spec

### DIFF
--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -1,4 +1,4 @@
-## Elm syntax basics
+# Elm syntax basics
 
 ### Constants and functions
 

--- a/concepts/basics/about.md
+++ b/concepts/basics/about.md
@@ -1,6 +1,6 @@
 # Elm syntax basics
 
-### Constants and functions
+## Constants and functions
 
 A constant value is defined with `name = expression`,
 where in Elm, everything except definitions are expressions.
@@ -34,7 +34,7 @@ six = add 2 (1 * 4)
 twelve = add 2 1 * 4
 ```
 
-### Indentation / significant whitespace
+## Indentation / significant whitespace
 
 Elm doesn't use syntactic markers such as curly brackets, parentheses, or semicolons to specify code boundaries. It uses whitespaces and indentations instead.
 
@@ -50,7 +50,7 @@ add number1 number2 =
 
 https://elmprogramming.com/indentation.html
 
-### Modules
+## Modules
 
 Each file in Elm is a module, and must contain a `module` statement before all other code.
 Module names must match their file name, so module `Calculator` must be in file Calculator.elm.
@@ -77,7 +77,7 @@ add number1 number2 = number1 + number2
 
 https://elm-lang.org/docs/syntax#modules
 
-### Comments
+## Comments
 
 A comment is some text within the Elm file that is not interpreted as code.
 It is mainly intented to be read by yourself and other programmers.
@@ -94,7 +94,7 @@ of opening and closing delimiters.
 -}
 ```
 
-### Formatting
+## Formatting
 
 There is a [style guide](https://elm-lang.org/docs/style-guide),
 and [elm-format](https://github.com/avh4/elm-format) can be used to automatically format code.

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ### Constants and functions
 
 A constant value is defined with `name = expression`,

--- a/concepts/basics/introduction.md
+++ b/concepts/basics/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-### Constants and functions
+## Constants and functions
 
 A constant value is defined with `name = expression`,
 where in Elm, everything except definitions are expressions.
@@ -34,7 +34,7 @@ six = add 2 (1 * 4)
 twelve = add 2 1 * 4
 ```
 
-### Indentation / significant whitespace
+## Indentation / significant whitespace
 
 Elm doesn't use syntactic markers such as curly brackets, parentheses, or semicolons to specify code boundaries. It uses whitespaces and indentations instead.
 
@@ -50,7 +50,7 @@ add number1 number2 =
 
 https://elmprogramming.com/indentation.html
 
-### Modules
+## Modules
 
 Each file in Elm is a module, and must contain a `module` statement before all other code.
 Module names must match their file name, so module `Calculator` must be in file Calculator.elm.
@@ -77,7 +77,7 @@ add number1 number2 = number1 + number2
 
 https://elm-lang.org/docs/syntax#modules
 
-### Comments
+## Comments
 
 A comment is some text within the Elm file that is not interpreted as code.
 It is mainly intented to be read by yourself and other programmers.
@@ -94,7 +94,7 @@ of opening and closing delimiters.
 -}
 ```
 
-### Formatting
+## Formatting
 
 There is a [style guide](https://elm-lang.org/docs/style-guide),
 and [elm-format](https://github.com/avh4/elm-format) can be used to automatically format code.

--- a/docs/ABOUT.md
+++ b/docs/ABOUT.md
@@ -1,3 +1,5 @@
+# About
+
 Elm describes itself as a "delightful language for reliable webapps".
 It aims at producing web applications with great performances and no runtime exception.
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,3 +1,5 @@
+# Installation
+
 The current version of elm is 0.19.1.
 Installation instructions change as the language evolves.
 For up-to-date installation instructions head to

--- a/docs/LEARNING.md
+++ b/docs/LEARNING.md
@@ -1,3 +1,5 @@
+# Learning
+
 ## Recommended Learning Resources
 
 The best place to start is the [official guide](https://guide.elm-lang.org/).

--- a/docs/RESOURCES.md
+++ b/docs/RESOURCES.md
@@ -1,3 +1,5 @@
+# Resources
+
 - [Elm official website](https://elm-lang.org/)
 - [Elm packages](https://package.elm-lang.org/):
   search and read documentation of Elm packages

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,3 +1,5 @@
+# Tests
+
 Tests for an Elm project live in the `tests/` subdirectory of that project.
 Each exercise tests suite can be run from that exercise root directory.
 

--- a/exercises/concept/lucians-luscious-lasagna/.docs/hints.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/hints.md
@@ -1,4 +1,4 @@
-## General
+# General
 
 - Basic numbers operators are described in elm [Basics module documentation][basics-doc].
 

--- a/exercises/concept/lucians-luscious-lasagna/.docs/instructions.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/instructions.md
@@ -1,3 +1,5 @@
+# Instructions
+
 In this exercise you're going to write some code to help you cook a brilliant lasagna from your favorite cooking book.
 
 You have four tasks, all related to the time spent cooking the lasagna.

--- a/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
@@ -1,3 +1,5 @@
+# Introduction
+
 ### Constants and functions
 
 A constant value is defined with `name = expression`,

--- a/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
@@ -1,6 +1,6 @@
 # Introduction
 
-### Constants and functions
+## Constants and functions
 
 A constant value is defined with `name = expression`,
 where in Elm, everything except definitions are expressions.
@@ -34,7 +34,7 @@ six = add 2 (1 * 4)
 twelve = add 2 1 * 4
 ```
 
-### Indentation / significant whitespace
+## Indentation / significant whitespace
 
 Elm doesn't use syntactic markers such as curly brackets, parentheses, or semicolons to specify code boundaries. It uses whitespaces and indentations instead.
 
@@ -50,7 +50,7 @@ add number1 number2 =
 
 https://elmprogramming.com/indentation.html
 
-### Modules
+## Modules
 
 Each file in Elm is a module, and must contain a `module` statement before all other code.
 Module names must match their file name, so module `Calculator` must be in file Calculator.elm.
@@ -77,7 +77,7 @@ add number1 number2 = number1 + number2
 
 https://elm-lang.org/docs/syntax#modules
 
-### Comments
+## Comments
 
 A comment is some text within the Elm file that is not interpreted as code.
 It is mainly intented to be read by yourself and other programmers.
@@ -94,7 +94,7 @@ of opening and closing delimiters.
 -}
 ```
 
-### Formatting
+## Formatting
 
 There is a [style guide](https://elm-lang.org/docs/style-guide),
 and [elm-format](https://github.com/avh4/elm-format) can be used to automatically format code.

--- a/exercises/concept/lucians-luscious-lasagna/.meta/design.md
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/design.md
@@ -1,3 +1,5 @@
+# Design
+
 ## Learning objectives
 
 - Know how to define an Elm module / Elm file.

--- a/exercises/practice/pangram/.meta/description.md
+++ b/exercises/practice/pangram/.meta/description.md
@@ -1,3 +1,5 @@
+# Description
+
 Determine if a sentence is a pangram. A pangram (Greek: παν γράμμα, pan gramma,
 "every letter") is a sentence using every letter of the alphabet at least once.
 The best known English pangram is: 

--- a/exercises/practice/wordy/.docs/instructions.append.md
+++ b/exercises/practice/wordy/.docs/instructions.append.md
@@ -1,3 +1,3 @@
-## Hints
+# Hints
 
 This is a perfect opportunity to learn `elm/parser` ([docs](https://package.elm-lang.org/packages/elm/parser/latest/))!


### PR DESCRIPTION
We've defined a [specification for Markdown files](https://github.com/exercism/docs/blob/main/contributing/standards/markdown.md) to be applied Exercism-wide. This standard includes, amongst others, the following two rules:

- All files must start start with a level-1 heading (`# Some heading text`)
- No heading may decend a level greater than one below the previous (e.g. `## may only be followed by ###, not ####`)

This PR applies the above two rules to the Markdown documents in this repo. 

## Tracking

https://github.com/exercism/v3-launch/issues/17
