### PR TITLE
🤖 Update tests.toml files to latest spec

### DIFF
--- a/exercises/practice/acronym/.meta/tests.toml
+++ b/exercises/practice/acronym/.meta/tests.toml
@@ -1,28 +1,39 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# basic
-"1e22cceb-c5e4-4562-9afe-aef07ad1eaf4" = true
+[1e22cceb-c5e4-4562-9afe-aef07ad1eaf4]
+description = "basic"
+include = true
 
-# lowercase words
-"79ae3889-a5c0-4b01-baf0-232d31180c08" = true
+[79ae3889-a5c0-4b01-baf0-232d31180c08]
+description = "lowercase words"
+include = true
 
-# punctuation
-"ec7000a7-3931-4a17-890e-33ca2073a548" = true
+[ec7000a7-3931-4a17-890e-33ca2073a548]
+description = "punctuation"
+include = true
 
-# all caps word
-"32dd261c-0c92-469a-9c5c-b192e94a63b0" = true
+[32dd261c-0c92-469a-9c5c-b192e94a63b0]
+description = "all caps word"
+include = true
 
-# punctuation without whitespace
-"ae2ac9fa-a606-4d05-8244-3bcc4659c1d4" = true
+[ae2ac9fa-a606-4d05-8244-3bcc4659c1d4]
+description = "punctuation without whitespace"
+include = true
 
-# very long abbreviation
-"0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9" = true
+[0e4b1e7c-1a6d-48fb-81a7-bf65eb9e69f9]
+description = "very long abbreviation"
+include = true
 
-# consecutive delimiters
-"6a078f49-c68d-4b7b-89af-33a1a98c28cc" = true
+[6a078f49-c68d-4b7b-89af-33a1a98c28cc]
+description = "consecutive delimiters"
+include = true
 
-# apostrophes
-"5118b4b1-4572-434c-8d57-5b762e57973e" = true
+[5118b4b1-4572-434c-8d57-5b762e57973e]
+description = "apostrophes"
+include = true
 
-# underscore emphasis
-"adc12eab-ec2d-414f-b48c-66a4fc06cdef" = true
+[adc12eab-ec2d-414f-b48c-66a4fc06cdef]
+description = "underscore emphasis"
+include = true

--- a/exercises/practice/all-your-base/.meta/tests.toml
+++ b/exercises/practice/all-your-base/.meta/tests.toml
@@ -1,64 +1,87 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# single bit one to decimal
-"5ce422f9-7a4b-4f44-ad29-49c67cb32d2c" = true
+[5ce422f9-7a4b-4f44-ad29-49c67cb32d2c]
+description = "single bit one to decimal"
+include = true
 
-# binary to single decimal
-"0cc3fea8-bb79-46ac-a2ab-5a2c93051033" = true
+[0cc3fea8-bb79-46ac-a2ab-5a2c93051033]
+description = "binary to single decimal"
+include = true
 
-# single decimal to binary
-"f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8" = true
+[f12db0f9-0d3d-42c2-b3ba-e38cb375a2b8]
+description = "single decimal to binary"
+include = true
 
-# binary to multiple decimal
-"2c45cf54-6da3-4748-9733-5a3c765d925b" = true
+[2c45cf54-6da3-4748-9733-5a3c765d925b]
+description = "binary to multiple decimal"
+include = true
 
-# decimal to binary
-"65ddb8b4-8899-4fcc-8618-181b2cf0002d" = true
+[65ddb8b4-8899-4fcc-8618-181b2cf0002d]
+description = "decimal to binary"
+include = true
 
-# trinary to hexadecimal
-"8d418419-02a7-4824-8b7a-352d33c6987e" = true
+[8d418419-02a7-4824-8b7a-352d33c6987e]
+description = "trinary to hexadecimal"
+include = true
 
-# hexadecimal to trinary
-"d3901c80-8190-41b9-bd86-38d988efa956" = true
+[d3901c80-8190-41b9-bd86-38d988efa956]
+description = "hexadecimal to trinary"
+include = true
 
-# 15-bit integer
-"5d42f85e-21ad-41bd-b9be-a3e8e4258bbf" = true
+[5d42f85e-21ad-41bd-b9be-a3e8e4258bbf]
+description = "15-bit integer"
+include = true
 
-# empty list
-"d68788f7-66dd-43f8-a543-f15b6d233f83" = true
+[d68788f7-66dd-43f8-a543-f15b6d233f83]
+description = "empty list"
+include = true
 
-# single zero
-"5e27e8da-5862-4c5f-b2a9-26c0382b6be7" = true
+[5e27e8da-5862-4c5f-b2a9-26c0382b6be7]
+description = "single zero"
+include = true
 
-# multiple zeros
-"2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2" = true
+[2e1c2573-77e4-4b9c-8517-6c56c5bcfdf2]
+description = "multiple zeros"
+include = true
 
-# leading zeros
-"3530cd9f-8d6d-43f5-bc6e-b30b1db9629b" = true
+[3530cd9f-8d6d-43f5-bc6e-b30b1db9629b]
+description = "leading zeros"
+include = true
 
-# input base is one
-"a6b476a1-1901-4f2a-92c4-4d91917ae023" = true
+[a6b476a1-1901-4f2a-92c4-4d91917ae023]
+description = "input base is one"
+include = true
 
-# input base is zero
-"e21a693a-7a69-450b-b393-27415c26a016" = true
+[e21a693a-7a69-450b-b393-27415c26a016]
+description = "input base is zero"
+include = true
 
-# input base is negative
-"54a23be5-d99e-41cc-88e0-a650ffe5fcc2" = true
+[54a23be5-d99e-41cc-88e0-a650ffe5fcc2]
+description = "input base is negative"
+include = true
 
-# negative digit
-"9eccf60c-dcc9-407b-95d8-c37b8be56bb6" = true
+[9eccf60c-dcc9-407b-95d8-c37b8be56bb6]
+description = "negative digit"
+include = true
 
-# invalid positive digit
-"232fa4a5-e761-4939-ba0c-ed046cd0676a" = true
+[232fa4a5-e761-4939-ba0c-ed046cd0676a]
+description = "invalid positive digit"
+include = true
 
-# output base is one
-"14238f95-45da-41dc-95ce-18f860b30ad3" = true
+[14238f95-45da-41dc-95ce-18f860b30ad3]
+description = "output base is one"
+include = true
 
-# output base is zero
-"73dac367-da5c-4a37-95fe-c87fad0a4047" = true
+[73dac367-da5c-4a37-95fe-c87fad0a4047]
+description = "output base is zero"
+include = true
 
-# output base is negative
-"13f81f42-ff53-4e24-89d9-37603a48ebd9" = true
+[13f81f42-ff53-4e24-89d9-37603a48ebd9]
+description = "output base is negative"
+include = true
 
-# both bases are negative
-"0e6c895d-8a5d-4868-a345-309d094cfe8d" = true
+[0e6c895d-8a5d-4868-a345-309d094cfe8d]
+description = "both bases are negative"
+include = true

--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -1,148 +1,199 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# not allergic to anything
-"17fc7296-2440-4ac4-ad7b-d07c321bc5a0" = true
+[17fc7296-2440-4ac4-ad7b-d07c321bc5a0]
+description = "not allergic to anything"
+include = true
 
-# allergic only to eggs
-"07ced27b-1da5-4c2e-8ae2-cb2791437546" = true
+[07ced27b-1da5-4c2e-8ae2-cb2791437546]
+description = "allergic only to eggs"
+include = true
 
-# allergic to eggs and something else
-"5035b954-b6fa-4b9b-a487-dae69d8c5f96" = true
+[5035b954-b6fa-4b9b-a487-dae69d8c5f96]
+description = "allergic to eggs and something else"
+include = true
 
-# allergic to something, but not eggs
-"64a6a83a-5723-4b5b-a896-663307403310" = true
+[64a6a83a-5723-4b5b-a896-663307403310]
+description = "allergic to something, but not eggs"
+include = true
 
-# allergic to everything
-"90c8f484-456b-41c4-82ba-2d08d93231c6" = true
+[90c8f484-456b-41c4-82ba-2d08d93231c6]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"d266a59a-fccc-413b-ac53-d57cb1f0db9d" = true
+[d266a59a-fccc-413b-ac53-d57cb1f0db9d]
+description = "not allergic to anything"
+include = true
 
-# allergic only to peanuts
-"ea210a98-860d-46b2-a5bf-50d8995b3f2a" = true
+[ea210a98-860d-46b2-a5bf-50d8995b3f2a]
+description = "allergic only to peanuts"
+include = true
 
-# allergic to peanuts and something else
-"eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b" = true
+[eac69ae9-8d14-4291-ac4b-7fd2c73d3a5b]
+description = "allergic to peanuts and something else"
+include = true
 
-# allergic to something, but not peanuts
-"9152058c-ce39-4b16-9b1d-283ec6d25085" = true
+[9152058c-ce39-4b16-9b1d-283ec6d25085]
+description = "allergic to something, but not peanuts"
+include = true
 
-# allergic to everything
-"d2d71fd8-63d5-40f9-a627-fbdaf88caeab" = true
+[d2d71fd8-63d5-40f9-a627-fbdaf88caeab]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"b948b0a1-cbf7-4b28-a244-73ff56687c80" = true
+[b948b0a1-cbf7-4b28-a244-73ff56687c80]
+description = "not allergic to anything"
+include = true
 
-# allergic only to shellfish
-"9ce9a6f3-53e9-4923-85e0-73019047c567" = true
+[9ce9a6f3-53e9-4923-85e0-73019047c567]
+description = "allergic only to shellfish"
+include = true
 
-# allergic to shellfish and something else
-"b272fca5-57ba-4b00-bd0c-43a737ab2131" = true
+[b272fca5-57ba-4b00-bd0c-43a737ab2131]
+description = "allergic to shellfish and something else"
+include = true
 
-# allergic to something, but not shellfish
-"21ef8e17-c227-494e-8e78-470a1c59c3d8" = true
+[21ef8e17-c227-494e-8e78-470a1c59c3d8]
+description = "allergic to something, but not shellfish"
+include = true
 
-# allergic to everything
-"cc789c19-2b5e-4c67-b146-625dc8cfa34e" = true
+[cc789c19-2b5e-4c67-b146-625dc8cfa34e]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"651bde0a-2a74-46c4-ab55-02a0906ca2f5" = true
+[651bde0a-2a74-46c4-ab55-02a0906ca2f5]
+description = "not allergic to anything"
+include = true
 
-# allergic only to strawberries
-"b649a750-9703-4f5f-b7f7-91da2c160ece" = true
+[b649a750-9703-4f5f-b7f7-91da2c160ece]
+description = "allergic only to strawberries"
+include = true
 
-# allergic to strawberries and something else
-"50f5f8f3-3bac-47e6-8dba-2d94470a4bc6" = true
+[50f5f8f3-3bac-47e6-8dba-2d94470a4bc6]
+description = "allergic to strawberries and something else"
+include = true
 
-# allergic to something, but not strawberries
-"23dd6952-88c9-48d7-a7d5-5d0343deb18d" = true
+[23dd6952-88c9-48d7-a7d5-5d0343deb18d]
+description = "allergic to something, but not strawberries"
+include = true
 
-# allergic to everything
-"74afaae2-13b6-43a2-837a-286cd42e7d7e" = true
+[74afaae2-13b6-43a2-837a-286cd42e7d7e]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"c49a91ef-6252-415e-907e-a9d26ef61723" = true
+[c49a91ef-6252-415e-907e-a9d26ef61723]
+description = "not allergic to anything"
+include = true
 
-# allergic only to tomatoes
-"b69c5131-b7d0-41ad-a32c-e1b2cc632df8" = true
+[b69c5131-b7d0-41ad-a32c-e1b2cc632df8]
+description = "allergic only to tomatoes"
+include = true
 
-# allergic to tomatoes and something else
-"1ca50eb1-f042-4ccf-9050-341521b929ec" = true
+[1ca50eb1-f042-4ccf-9050-341521b929ec]
+description = "allergic to tomatoes and something else"
+include = true
 
-# allergic to something, but not tomatoes
-"e9846baa-456b-4eff-8025-034b9f77bd8e" = true
+[e9846baa-456b-4eff-8025-034b9f77bd8e]
+description = "allergic to something, but not tomatoes"
+include = true
 
-# allergic to everything
-"b2414f01-f3ad-4965-8391-e65f54dad35f" = true
+[b2414f01-f3ad-4965-8391-e65f54dad35f]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"978467ab-bda4-49f7-b004-1d011ead947c" = true
+[978467ab-bda4-49f7-b004-1d011ead947c]
+description = "not allergic to anything"
+include = true
 
-# allergic only to chocolate
-"59cf4e49-06ea-4139-a2c1-d7aad28f8cbc" = true
+[59cf4e49-06ea-4139-a2c1-d7aad28f8cbc]
+description = "allergic only to chocolate"
+include = true
 
-# allergic to chocolate and something else
-"b0a7c07b-2db7-4f73-a180-565e07040ef1" = true
+[b0a7c07b-2db7-4f73-a180-565e07040ef1]
+description = "allergic to chocolate and something else"
+include = true
 
-# allergic to something, but not chocolate
-"f5506893-f1ae-482a-b516-7532ba5ca9d2" = true
+[f5506893-f1ae-482a-b516-7532ba5ca9d2]
+description = "allergic to something, but not chocolate"
+include = true
 
-# allergic to everything
-"02debb3d-d7e2-4376-a26b-3c974b6595c6" = true
+[02debb3d-d7e2-4376-a26b-3c974b6595c6]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"17f4a42b-c91e-41b8-8a76-4797886c2d96" = true
+[17f4a42b-c91e-41b8-8a76-4797886c2d96]
+description = "not allergic to anything"
+include = true
 
-# allergic only to pollen
-"7696eba7-1837-4488-882a-14b7b4e3e399" = true
+[7696eba7-1837-4488-882a-14b7b4e3e399]
+description = "allergic only to pollen"
+include = true
 
-# allergic to pollen and something else
-"9a49aec5-fa1f-405d-889e-4dfc420db2b6" = true
+[9a49aec5-fa1f-405d-889e-4dfc420db2b6]
+description = "allergic to pollen and something else"
+include = true
 
-# allergic to something, but not pollen
-"3cb8e79f-d108-4712-b620-aa146b1954a9" = true
+[3cb8e79f-d108-4712-b620-aa146b1954a9]
+description = "allergic to something, but not pollen"
+include = true
 
-# allergic to everything
-"1dc3fe57-7c68-4043-9d51-5457128744b2" = true
+[1dc3fe57-7c68-4043-9d51-5457128744b2]
+description = "allergic to everything"
+include = true
 
-# not allergic to anything
-"d3f523d6-3d50-419b-a222-d4dfd62ce314" = true
+[d3f523d6-3d50-419b-a222-d4dfd62ce314]
+description = "not allergic to anything"
+include = true
 
-# allergic only to cats
-"eba541c3-c886-42d3-baef-c048cb7fcd8f" = true
+[eba541c3-c886-42d3-baef-c048cb7fcd8f]
+description = "allergic only to cats"
+include = true
 
-# allergic to cats and something else
-"ba718376-26e0-40b7-bbbe-060287637ea5" = true
+[ba718376-26e0-40b7-bbbe-060287637ea5]
+description = "allergic to cats and something else"
+include = true
 
-# allergic to something, but not cats
-"3c6dbf4a-5277-436f-8b88-15a206f2d6c4" = true
+[3c6dbf4a-5277-436f-8b88-15a206f2d6c4]
+description = "allergic to something, but not cats"
+include = true
 
-# allergic to everything
-"1faabb05-2b98-4995-9046-d83e4a48a7c1" = true
+[1faabb05-2b98-4995-9046-d83e4a48a7c1]
+description = "allergic to everything"
+include = true
 
-# no allergies
-"f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f" = true
+[f9c1b8e7-7dc5-4887-aa93-cebdcc29dd8f]
+description = "no allergies"
+include = true
 
-# just eggs
-"9e1a4364-09a6-4d94-990f-541a94a4c1e8" = true
+[9e1a4364-09a6-4d94-990f-541a94a4c1e8]
+description = "just eggs"
+include = true
 
-# just peanuts
-"8851c973-805e-4283-9e01-d0c0da0e4695" = true
+[8851c973-805e-4283-9e01-d0c0da0e4695]
+description = "just peanuts"
+include = true
 
-# just strawberries
-"2c8943cb-005e-435f-ae11-3e8fb558ea98" = true
+[2c8943cb-005e-435f-ae11-3e8fb558ea98]
+description = "just strawberries"
+include = true
 
-# eggs and peanuts
-"6fa95d26-044c-48a9-8a7b-9ee46ec32c5c" = true
+[6fa95d26-044c-48a9-8a7b-9ee46ec32c5c]
+description = "eggs and peanuts"
+include = true
 
-# more than eggs but not peanuts
-"19890e22-f63f-4c5c-a9fb-fb6eacddfe8e" = true
+[19890e22-f63f-4c5c-a9fb-fb6eacddfe8e]
+description = "more than eggs but not peanuts"
+include = true
 
-# lots of stuff
-"4b68f470-067c-44e4-889f-c9fe28917d2f" = true
+[4b68f470-067c-44e4-889f-c9fe28917d2f]
+description = "lots of stuff"
+include = true
 
-# everything
-"0881b7c5-9efa-4530-91bd-68370d054bc7" = true
+[0881b7c5-9efa-4530-91bd-68370d054bc7]
+description = "everything"
+include = true
 
-# no allergen score parts
-"12ce86de-b347-42a0-ab7c-2e0570f0c65b" = true
+[12ce86de-b347-42a0-ab7c-2e0570f0c65b]
+description = "no allergen score parts"
+include = true

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -1,43 +1,59 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no matches
-"dd40c4d2-3c8b-44e5-992a-f42b393ec373" = true
+[dd40c4d2-3c8b-44e5-992a-f42b393ec373]
+description = "no matches"
+include = true
 
-# detects two anagrams
-"b3cca662-f50a-489e-ae10-ab8290a09bdc" = true
+[b3cca662-f50a-489e-ae10-ab8290a09bdc]
+description = "detects two anagrams"
+include = true
 
-# does not detect anagram subsets
-"a27558ee-9ba0-4552-96b1-ecf665b06556" = true
+[a27558ee-9ba0-4552-96b1-ecf665b06556]
+description = "does not detect anagram subsets"
+include = true
 
-# detects anagram
-"64cd4584-fc15-4781-b633-3d814c4941a4" = true
+[64cd4584-fc15-4781-b633-3d814c4941a4]
+description = "detects anagram"
+include = true
 
-# detects three anagrams
-"99c91beb-838f-4ccd-b123-935139917283" = true
+[99c91beb-838f-4ccd-b123-935139917283]
+description = "detects three anagrams"
+include = true
 
-# detects multiple anagrams with different case
-"78487770-e258-4e1f-a646-8ece10950d90" = true
+[78487770-e258-4e1f-a646-8ece10950d90]
+description = "detects multiple anagrams with different case"
+include = true
 
-# does not detect non-anagrams with identical checksum
-"1d0ab8aa-362f-49b7-9902-3d0c668d557b" = true
+[1d0ab8aa-362f-49b7-9902-3d0c668d557b]
+description = "does not detect non-anagrams with identical checksum"
+include = true
 
-# detects anagrams case-insensitively
-"9e632c0b-c0b1-4804-8cc1-e295dea6d8a8" = true
+[9e632c0b-c0b1-4804-8cc1-e295dea6d8a8]
+description = "detects anagrams case-insensitively"
+include = true
 
-# detects anagrams using case-insensitive subject
-"b248e49f-0905-48d2-9c8d-bd02d8c3e392" = true
+[b248e49f-0905-48d2-9c8d-bd02d8c3e392]
+description = "detects anagrams using case-insensitive subject"
+include = true
 
-# detects anagrams using case-insensitive possible matches
-"f367325c-78ec-411c-be76-e79047f4bd54" = true
+[f367325c-78ec-411c-be76-e79047f4bd54]
+description = "detects anagrams using case-insensitive possible matches"
+include = true
 
-# does not detect an anagram if the original word is repeated
-"7cc195ad-e3c7-44ee-9fd2-d3c344806a2c" = true
+[7cc195ad-e3c7-44ee-9fd2-d3c344806a2c]
+description = "does not detect an anagram if the original word is repeated"
+include = true
 
-# anagrams must use all letters exactly once
-"9878a1c9-d6ea-4235-ae51-3ea2befd6842" = true
+[9878a1c9-d6ea-4235-ae51-3ea2befd6842]
+description = "anagrams must use all letters exactly once"
+include = true
 
-# words are not anagrams of themselves (case-insensitive)
-"85757361-4535-45fd-ac0e-3810d40debc1" = true
+[85757361-4535-45fd-ac0e-3810d40debc1]
+description = "words are not anagrams of themselves (case-insensitive)"
+include = true
 
-# words other than themselves can be anagrams
-"a0705568-628c-4b55-9798-82e4acde51ca" = true
+[a0705568-628c-4b55-9798-82e4acde51ca]
+description = "words other than themselves can be anagrams"
+include = true

--- a/exercises/practice/armstrong-numbers/.meta/tests.toml
+++ b/exercises/practice/armstrong-numbers/.meta/tests.toml
@@ -1,28 +1,39 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Zero is an Armstrong number
-"c1ed103c-258d-45b2-be73-d8c6d9580c7b" = true
+[c1ed103c-258d-45b2-be73-d8c6d9580c7b]
+description = "Zero is an Armstrong number"
+include = true
 
-# Single digit numbers are Armstrong numbers
-"579e8f03-9659-4b85-a1a2-d64350f6b17a" = true
+[579e8f03-9659-4b85-a1a2-d64350f6b17a]
+description = "Single digit numbers are Armstrong numbers"
+include = true
 
-# There are no 2 digit Armstrong numbers
-"2d6db9dc-5bf8-4976-a90b-b2c2b9feba60" = true
+[2d6db9dc-5bf8-4976-a90b-b2c2b9feba60]
+description = "There are no 2 digit Armstrong numbers"
+include = true
 
-# Three digit number that is an Armstrong number
-"509c087f-e327-4113-a7d2-26a4e9d18283" = true
+[509c087f-e327-4113-a7d2-26a4e9d18283]
+description = "Three digit number that is an Armstrong number"
+include = true
 
-# Three digit number that is not an Armstrong number
-"7154547d-c2ce-468d-b214-4cb953b870cf" = true
+[7154547d-c2ce-468d-b214-4cb953b870cf]
+description = "Three digit number that is not an Armstrong number"
+include = true
 
-# Four digit number that is an Armstrong number
-"6bac5b7b-42e9-4ecb-a8b0-4832229aa103" = true
+[6bac5b7b-42e9-4ecb-a8b0-4832229aa103]
+description = "Four digit number that is an Armstrong number"
+include = true
 
-# Four digit number that is not an Armstrong number
-"eed4b331-af80-45b5-a80b-19c9ea444b2e" = true
+[eed4b331-af80-45b5-a80b-19c9ea444b2e]
+description = "Four digit number that is not an Armstrong number"
+include = true
 
-# Seven digit number that is an Armstrong number
-"f971ced7-8d68-4758-aea1-d4194900b864" = true
+[f971ced7-8d68-4758-aea1-d4194900b864]
+description = "Seven digit number that is an Armstrong number"
+include = true
 
-# Seven digit number that is not an Armstrong number
-"7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18" = true
+[7ee45d52-5d35-4fbd-b6f1-5c8cd8a67f18]
+description = "Seven digit number that is not an Armstrong number"
+include = true

--- a/exercises/practice/atbash-cipher/.meta/tests.toml
+++ b/exercises/practice/atbash-cipher/.meta/tests.toml
@@ -1,43 +1,59 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# encode yes
-"2f47ebe1-eab9-4d6b-b3c6-627562a31c77" = true
+[2f47ebe1-eab9-4d6b-b3c6-627562a31c77]
+description = "encode yes"
+include = true
 
-# encode no
-"b4ffe781-ea81-4b74-b268-cc58ba21c739" = true
+[b4ffe781-ea81-4b74-b268-cc58ba21c739]
+description = "encode no"
+include = true
 
-# encode OMG
-"10e48927-24ab-4c4d-9d3f-3067724ace00" = true
+[10e48927-24ab-4c4d-9d3f-3067724ace00]
+description = "encode OMG"
+include = true
 
-# encode spaces
-"d59b8bc3-509a-4a9a-834c-6f501b98750b" = true
+[d59b8bc3-509a-4a9a-834c-6f501b98750b]
+description = "encode spaces"
+include = true
 
-# encode mindblowingly
-"31d44b11-81b7-4a94-8b43-4af6a2449429" = true
+[31d44b11-81b7-4a94-8b43-4af6a2449429]
+description = "encode mindblowingly"
+include = true
 
-# encode numbers
-"d503361a-1433-48c0-aae0-d41b5baa33ff" = true
+[d503361a-1433-48c0-aae0-d41b5baa33ff]
+description = "encode numbers"
+include = true
 
-# encode deep thought
-"79c8a2d5-0772-42d4-b41b-531d0b5da926" = true
+[79c8a2d5-0772-42d4-b41b-531d0b5da926]
+description = "encode deep thought"
+include = true
 
-# encode all the letters
-"9ca13d23-d32a-4967-a1fd-6100b8742bab" = true
+[9ca13d23-d32a-4967-a1fd-6100b8742bab]
+description = "encode all the letters"
+include = true
 
-# decode exercism
-"bb50e087-7fdf-48e7-9223-284fe7e69851" = true
+[bb50e087-7fdf-48e7-9223-284fe7e69851]
+description = "decode exercism"
+include = true
 
-# decode a sentence
-"ac021097-cd5d-4717-8907-b0814b9e292c" = true
+[ac021097-cd5d-4717-8907-b0814b9e292c]
+description = "decode a sentence"
+include = true
 
-# decode numbers
-"18729de3-de74-49b8-b68c-025eaf77f851" = true
+[18729de3-de74-49b8-b68c-025eaf77f851]
+description = "decode numbers"
+include = true
 
-# decode all the letters
-"0f30325f-f53b-415d-ad3e-a7a4f63de034" = true
+[0f30325f-f53b-415d-ad3e-a7a4f63de034]
+description = "decode all the letters"
+include = true
 
-# decode with too many spaces
-"39640287-30c6-4c8c-9bac-9d613d1a5674" = true
+[39640287-30c6-4c8c-9bac-9d613d1a5674]
+description = "decode with too many spaces"
+include = true
 
-# decode with no spaces
-"b34edf13-34c0-49b5-aa21-0768928000d5" = true
+[b34edf13-34c0-49b5-aa21-0768928000d5]
+description = "decode with no spaces"
+include = true

--- a/exercises/practice/binary-search/.meta/tests.toml
+++ b/exercises/practice/binary-search/.meta/tests.toml
@@ -1,34 +1,47 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# finds a value in an array with one element
-"b55c24a9-a98d-4379-a08c-2adcf8ebeee8" = true
+[b55c24a9-a98d-4379-a08c-2adcf8ebeee8]
+description = "finds a value in an array with one element"
+include = true
 
-# finds a value in the middle of an array
-"73469346-b0a0-4011-89bf-989e443d503d" = true
+[73469346-b0a0-4011-89bf-989e443d503d]
+description = "finds a value in the middle of an array"
+include = true
 
-# finds a value at the beginning of an array
-"327bc482-ab85-424e-a724-fb4658e66ddb" = true
+[327bc482-ab85-424e-a724-fb4658e66ddb]
+description = "finds a value at the beginning of an array"
+include = true
 
-# finds a value at the end of an array
-"f9f94b16-fe5e-472c-85ea-c513804c7d59" = true
+[f9f94b16-fe5e-472c-85ea-c513804c7d59]
+description = "finds a value at the end of an array"
+include = true
 
-# finds a value in an array of odd length
-"f0068905-26e3-4342-856d-ad153cadb338" = true
+[f0068905-26e3-4342-856d-ad153cadb338]
+description = "finds a value in an array of odd length"
+include = true
 
-# finds a value in an array of even length
-"fc316b12-c8b3-4f5e-9e89-532b3389de8c" = true
+[fc316b12-c8b3-4f5e-9e89-532b3389de8c]
+description = "finds a value in an array of even length"
+include = true
 
-# identifies that a value is not included in the array
-"da7db20a-354f-49f7-a6a1-650a54998aa6" = true
+[da7db20a-354f-49f7-a6a1-650a54998aa6]
+description = "identifies that a value is not included in the array"
+include = true
 
-# a value smaller than the array's smallest value is not found
-"95d869ff-3daf-4c79-b622-6e805c675f97" = true
+[95d869ff-3daf-4c79-b622-6e805c675f97]
+description = "a value smaller than the array's smallest value is not found"
+include = true
 
-# a value larger than the array's largest value is not found
-"8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba" = true
+[8b24ef45-6e51-4a94-9eac-c2bf38fdb0ba]
+description = "a value larger than the array's largest value is not found"
+include = true
 
-# nothing is found in an empty array
-"f439a0fa-cf42-4262-8ad1-64bf41ce566a" = true
+[f439a0fa-cf42-4262-8ad1-64bf41ce566a]
+description = "nothing is found in an empty array"
+include = true
 
-# nothing is found when the left and right bounds cross
-"2c353967-b56d-40b8-acff-ce43115eed64" = true
+[2c353967-b56d-40b8-acff-ce43115eed64]
+description = "nothing is found when the left and right bounds cross"
+include = true

--- a/exercises/practice/bob/.meta/tests.toml
+++ b/exercises/practice/bob/.meta/tests.toml
@@ -1,76 +1,103 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# stating something
-"e162fead-606f-437a-a166-d051915cea8e" = true
+[e162fead-606f-437a-a166-d051915cea8e]
+description = "stating something"
+include = true
 
-# shouting
-"73a966dc-8017-47d6-bb32-cf07d1a5fcd9" = true
+[73a966dc-8017-47d6-bb32-cf07d1a5fcd9]
+description = "shouting"
+include = true
 
-# shouting gibberish
-"d6c98afd-df35-4806-b55e-2c457c3ab748" = true
+[d6c98afd-df35-4806-b55e-2c457c3ab748]
+description = "shouting gibberish"
+include = true
 
-# asking a question
-"8a2e771d-d6f1-4e3f-b6c6-b41495556e37" = true
+[8a2e771d-d6f1-4e3f-b6c6-b41495556e37]
+description = "asking a question"
+include = true
 
-# asking a numeric question
-"81080c62-4e4d-4066-b30a-48d8d76920d9" = true
+[81080c62-4e4d-4066-b30a-48d8d76920d9]
+description = "asking a numeric question"
+include = true
 
-# asking gibberish
-"2a02716d-685b-4e2e-a804-2adaf281c01e" = true
+[2a02716d-685b-4e2e-a804-2adaf281c01e]
+description = "asking gibberish"
+include = true
 
-# talking forcefully
-"c02f9179-ab16-4aa7-a8dc-940145c385f7" = true
+[c02f9179-ab16-4aa7-a8dc-940145c385f7]
+description = "talking forcefully"
+include = true
 
-# using acronyms in regular speech
-"153c0e25-9bb5-4ec5-966e-598463658bcd" = true
+[153c0e25-9bb5-4ec5-966e-598463658bcd]
+description = "using acronyms in regular speech"
+include = true
 
-# forceful question
-"a5193c61-4a92-4f68-93e2-f554eb385ec6" = true
+[a5193c61-4a92-4f68-93e2-f554eb385ec6]
+description = "forceful question"
+include = true
 
-# shouting numbers
-"a20e0c54-2224-4dde-8b10-bd2cdd4f61bc" = true
+[a20e0c54-2224-4dde-8b10-bd2cdd4f61bc]
+description = "shouting numbers"
+include = true
 
-# no letters
-"f7bc4b92-bdff-421e-a238-ae97f230ccac" = true
+[f7bc4b92-bdff-421e-a238-ae97f230ccac]
+description = "no letters"
+include = true
 
-# question with no letters
-"bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2" = true
+[bb0011c5-cd52-4a5b-8bfb-a87b6283b0e2]
+description = "question with no letters"
+include = true
 
-# shouting with special characters
-"496143c8-1c31-4c01-8a08-88427af85c66" = true
+[496143c8-1c31-4c01-8a08-88427af85c66]
+description = "shouting with special characters"
+include = true
 
-# shouting with no exclamation mark
-"e6793c1c-43bd-4b8d-bc11-499aea73925f" = true
+[e6793c1c-43bd-4b8d-bc11-499aea73925f]
+description = "shouting with no exclamation mark"
+include = true
 
-# statement containing question mark
-"aa8097cc-c548-4951-8856-14a404dd236a" = true
+[aa8097cc-c548-4951-8856-14a404dd236a]
+description = "statement containing question mark"
+include = true
 
-# non-letters with question
-"9bfc677d-ea3a-45f2-be44-35bc8fa3753e" = true
+[9bfc677d-ea3a-45f2-be44-35bc8fa3753e]
+description = "non-letters with question"
+include = true
 
-# prattling on
-"8608c508-f7de-4b17-985b-811878b3cf45" = true
+[8608c508-f7de-4b17-985b-811878b3cf45]
+description = "prattling on"
+include = true
 
-# silence
-"bc39f7c6-f543-41be-9a43-fd1c2f753fc0" = true
+[bc39f7c6-f543-41be-9a43-fd1c2f753fc0]
+description = "silence"
+include = true
 
-# prolonged silence
-"d6c47565-372b-4b09-b1dd-c40552b8378b" = true
+[d6c47565-372b-4b09-b1dd-c40552b8378b]
+description = "prolonged silence"
+include = true
 
-# alternate silence
-"4428f28d-4100-4d85-a902-e5a78cb0ecd3" = true
+[4428f28d-4100-4d85-a902-e5a78cb0ecd3]
+description = "alternate silence"
+include = true
 
-# multiple line question
-"66953780-165b-4e7e-8ce3-4bcb80b6385a" = true
+[66953780-165b-4e7e-8ce3-4bcb80b6385a]
+description = "multiple line question"
+include = true
 
-# starting with whitespace
-"5371ef75-d9ea-4103-bcfa-2da973ddec1b" = true
+[5371ef75-d9ea-4103-bcfa-2da973ddec1b]
+description = "starting with whitespace"
+include = true
 
-# ending with whitespace
-"05b304d6-f83b-46e7-81e0-4cd3ca647900" = true
+[05b304d6-f83b-46e7-81e0-4cd3ca647900]
+description = "ending with whitespace"
+include = true
 
-# other whitespace
-"72bd5ad3-9b2f-4931-a988-dce1f5771de2" = true
+[72bd5ad3-9b2f-4931-a988-dce1f5771de2]
+description = "other whitespace"
+include = true
 
-# non-question ending with whitespace
-"12983553-8601-46a8-92fa-fcaa3bc4a2a0" = true
+[12983553-8601-46a8-92fa-fcaa3bc4a2a0]
+description = "non-question ending with whitespace"
+include = true

--- a/exercises/practice/collatz-conjecture/.meta/tests.toml
+++ b/exercises/practice/collatz-conjecture/.meta/tests.toml
@@ -1,19 +1,27 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# zero steps for one
-"540a3d51-e7a6-47a5-92a3-4ad1838f0bfd" = true
+[540a3d51-e7a6-47a5-92a3-4ad1838f0bfd]
+description = "zero steps for one"
+include = true
 
-# divide if even
-"3d76a0a6-ea84-444a-821a-f7857c2c1859" = true
+[3d76a0a6-ea84-444a-821a-f7857c2c1859]
+description = "divide if even"
+include = true
 
-# even and odd steps
-"754dea81-123c-429e-b8bc-db20b05a87b9" = true
+[754dea81-123c-429e-b8bc-db20b05a87b9]
+description = "even and odd steps"
+include = true
 
-# large number of even and odd steps
-"ecfd0210-6f85-44f6-8280-f65534892ff6" = true
+[ecfd0210-6f85-44f6-8280-f65534892ff6]
+description = "large number of even and odd steps"
+include = true
 
-# zero is an error
-"7d4750e6-def9-4b86-aec7-9f7eb44f95a3" = true
+[7d4750e6-def9-4b86-aec7-9f7eb44f95a3]
+description = "zero is an error"
+include = true
 
-# negative value is an error
-"c6c795bf-a288-45e9-86a1-841359ad426d" = true
+[c6c795bf-a288-45e9-86a1-841359ad426d]
+description = "negative value is an error"
+include = true

--- a/exercises/practice/difference-of-squares/.meta/tests.toml
+++ b/exercises/practice/difference-of-squares/.meta/tests.toml
@@ -1,28 +1,39 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# square of sum 1
-"e46c542b-31fc-4506-bcae-6b62b3268537" = true
+[e46c542b-31fc-4506-bcae-6b62b3268537]
+description = "square of sum 1"
+include = true
 
-# square of sum 5
-"9b3f96cb-638d-41ee-99b7-b4f9c0622948" = true
+[9b3f96cb-638d-41ee-99b7-b4f9c0622948]
+description = "square of sum 5"
+include = true
 
-# square of sum 100
-"54ba043f-3c35-4d43-86ff-3a41625d5e86" = true
+[54ba043f-3c35-4d43-86ff-3a41625d5e86]
+description = "square of sum 100"
+include = true
 
-# sum of squares 1
-"01d84507-b03e-4238-9395-dd61d03074b5" = true
+[01d84507-b03e-4238-9395-dd61d03074b5]
+description = "sum of squares 1"
+include = true
 
-# sum of squares 5
-"c93900cd-8cc2-4ca4-917b-dd3027023499" = true
+[c93900cd-8cc2-4ca4-917b-dd3027023499]
+description = "sum of squares 5"
+include = true
 
-# sum of squares 100
-"94807386-73e4-4d9e-8dec-69eb135b19e4" = true
+[94807386-73e4-4d9e-8dec-69eb135b19e4]
+description = "sum of squares 100"
+include = true
 
-# difference of squares 1
-"44f72ae6-31a7-437f-858d-2c0837adabb6" = true
+[44f72ae6-31a7-437f-858d-2c0837adabb6]
+description = "difference of squares 1"
+include = true
 
-# difference of squares 5
-"005cb2bf-a0c8-46f3-ae25-924029f8b00b" = true
+[005cb2bf-a0c8-46f3-ae25-924029f8b00b]
+description = "difference of squares 5"
+include = true
 
-# difference of squares 100
-"b1bf19de-9a16-41c0-a62b-1f02ecc0b036" = true
+[b1bf19de-9a16-41c0-a62b-1f02ecc0b036]
+description = "difference of squares 100"
+include = true

--- a/exercises/practice/etl/.meta/tests.toml
+++ b/exercises/practice/etl/.meta/tests.toml
@@ -1,13 +1,19 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# single letter
-"78a7a9f9-4490-4a47-8ee9-5a38bb47d28f" = true
+[78a7a9f9-4490-4a47-8ee9-5a38bb47d28f]
+description = "single letter"
+include = true
 
-# single score with multiple letters
-"60dbd000-451d-44c7-bdbb-97c73ac1f497" = true
+[60dbd000-451d-44c7-bdbb-97c73ac1f497]
+description = "single score with multiple letters"
+include = true
 
-# multiple scores with multiple letters
-"f5c5de0c-301f-4fdd-a0e5-df97d4214f54" = true
+[f5c5de0c-301f-4fdd-a0e5-df97d4214f54]
+description = "multiple scores with multiple letters"
+include = true
 
-# multiple scores with differing numbers of letters
-"5db8ea89-ecb4-4dcd-902f-2b418cc87b9d" = true
+[5db8ea89-ecb4-4dcd-902f-2b418cc87b9d]
+description = "multiple scores with differing numbers of letters"
+include = true

--- a/exercises/practice/gigasecond/.meta/tests.toml
+++ b/exercises/practice/gigasecond/.meta/tests.toml
@@ -1,16 +1,23 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# date only specification of time
-"92fbe71c-ea52-4fac-bd77-be38023cacf7" = true
+[92fbe71c-ea52-4fac-bd77-be38023cacf7]
+description = "date only specification of time"
+include = true
 
-# second test for date only specification of time
-"6d86dd16-6f7a-47be-9e58-bb9fb2ae1433" = true
+[6d86dd16-6f7a-47be-9e58-bb9fb2ae1433]
+description = "second test for date only specification of time"
+include = true
 
-# third test for date only specification of time
-"77eb8502-2bca-4d92-89d9-7b39ace28dd5" = true
+[77eb8502-2bca-4d92-89d9-7b39ace28dd5]
+description = "third test for date only specification of time"
+include = true
 
-# full time specified
-"c9d89a7d-06f8-4e28-a305-64f1b2abc693" = true
+[c9d89a7d-06f8-4e28-a305-64f1b2abc693]
+description = "full time specified"
+include = true
 
-# full time with day roll-over
-"09d4e30e-728a-4b52-9005-be44a58d9eba" = true
+[09d4e30e-728a-4b52-9005-be44a58d9eba]
+description = "full time with day roll-over"
+include = true

--- a/exercises/practice/grade-school/.meta/tests.toml
+++ b/exercises/practice/grade-school/.meta/tests.toml
@@ -1,22 +1,31 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Adding a student adds them to the sorted roster
-"6d0a30e4-1b4e-472e-8e20-c41702125667" = true
+[6d0a30e4-1b4e-472e-8e20-c41702125667]
+description = "Adding a student adds them to the sorted roster"
+include = true
 
-# Adding more student adds them to the sorted roster
-"233be705-dd58-4968-889d-fb3c7954c9cc" = true
+[233be705-dd58-4968-889d-fb3c7954c9cc]
+description = "Adding more student adds them to the sorted roster"
+include = true
 
-# Adding students to different grades adds them to the same sorted roster
-"75a51579-d1d7-407c-a2f8-2166e984e8ab" = true
+[75a51579-d1d7-407c-a2f8-2166e984e8ab]
+description = "Adding students to different grades adds them to the same sorted roster"
+include = true
 
-# Roster returns an empty list if there are no students enrolled
-"a3f0fb58-f240-4723-8ddc-e644666b85cc" = true
+[a3f0fb58-f240-4723-8ddc-e644666b85cc]
+description = "Roster returns an empty list if there are no students enrolled"
+include = true
 
-# Student names with grades are displayed in the same sorted roster
-"180a8ff9-5b94-43fc-9db1-d46b4a8c93b6" = true
+[180a8ff9-5b94-43fc-9db1-d46b4a8c93b6]
+description = "Student names with grades are displayed in the same sorted roster"
+include = true
 
-# Grade returns the students in that grade in alphabetical order
-"1bfbcef1-e4a3-49e8-8d22-f6f9f386187e" = true
+[1bfbcef1-e4a3-49e8-8d22-f6f9f386187e]
+description = "Grade returns the students in that grade in alphabetical order"
+include = true
 
-# Grade returns an empty list if there are no students in that grade
-"5e67aa3c-a3c6-4407-a183-d8fe59cd1630" = true
+[5e67aa3c-a3c6-4407-a183-d8fe59cd1630]
+description = "Grade returns an empty list if there are no students in that grade"
+include = true

--- a/exercises/practice/grains/.meta/tests.toml
+++ b/exercises/practice/grains/.meta/tests.toml
@@ -1,34 +1,47 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# 1
-"9fbde8de-36b2-49de-baf2-cd42d6f28405" = true
+[9fbde8de-36b2-49de-baf2-cd42d6f28405]
+description = "1"
+include = true
 
-# 2
-"ee1f30c2-01d8-4298-b25d-c677331b5e6d" = true
+[ee1f30c2-01d8-4298-b25d-c677331b5e6d]
+description = "2"
+include = true
 
-# 3
-"10f45584-2fc3-4875-8ec6-666065d1163b" = true
+[10f45584-2fc3-4875-8ec6-666065d1163b]
+description = "3"
+include = true
 
-# 4
-"a7cbe01b-36f4-4601-b053-c5f6ae055170" = true
+[a7cbe01b-36f4-4601-b053-c5f6ae055170]
+description = "4"
+include = true
 
-# 16
-"c50acc89-8535-44e4-918f-b848ad2817d4" = true
+[c50acc89-8535-44e4-918f-b848ad2817d4]
+description = "16"
+include = true
 
-# 32
-"acd81b46-c2ad-4951-b848-80d15ed5a04f" = true
+[acd81b46-c2ad-4951-b848-80d15ed5a04f]
+description = "32"
+include = true
 
-# 64
-"c73b470a-5efb-4d53-9ac6-c5f6487f227b" = true
+[c73b470a-5efb-4d53-9ac6-c5f6487f227b]
+description = "64"
+include = true
 
-# square 0 raises an exception
-"1d47d832-3e85-4974-9466-5bd35af484e3" = true
+[1d47d832-3e85-4974-9466-5bd35af484e3]
+description = "square 0 raises an exception"
+include = true
 
-# negative square raises an exception
-"61974483-eeb2-465e-be54-ca5dde366453" = true
+[61974483-eeb2-465e-be54-ca5dde366453]
+description = "negative square raises an exception"
+include = true
 
-# square greater than 64 raises an exception
-"a95e4374-f32c-45a7-a10d-ffec475c012f" = true
+[a95e4374-f32c-45a7-a10d-ffec475c012f]
+description = "square greater than 64 raises an exception"
+include = true
 
-# returns the total number of grains on the board
-"6eb07385-3659-4b45-a6be-9dc474222750" = true
+[6eb07385-3659-4b45-a6be-9dc474222750]
+description = "returns the total number of grains on the board"
+include = true

--- a/exercises/practice/hamming/.meta/tests.toml
+++ b/exercises/practice/hamming/.meta/tests.toml
@@ -1,28 +1,39 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty strands
-"f6dcb64f-03b0-4b60-81b1-3c9dbf47e887" = true
+[f6dcb64f-03b0-4b60-81b1-3c9dbf47e887]
+description = "empty strands"
+include = true
 
-# single letter identical strands
-"54681314-eee2-439a-9db0-b0636c656156" = true
+[54681314-eee2-439a-9db0-b0636c656156]
+description = "single letter identical strands"
+include = true
 
-# single letter different strands
-"294479a3-a4c8-478f-8d63-6209815a827b" = true
+[294479a3-a4c8-478f-8d63-6209815a827b]
+description = "single letter different strands"
+include = true
 
-# long identical strands
-"9aed5f34-5693-4344-9b31-40c692fb5592" = true
+[9aed5f34-5693-4344-9b31-40c692fb5592]
+description = "long identical strands"
+include = true
 
-# long different strands
-"cd2273a5-c576-46c8-a52b-dee251c3e6e5" = true
+[cd2273a5-c576-46c8-a52b-dee251c3e6e5]
+description = "long different strands"
+include = true
 
-# disallow first strand longer
-"919f8ef0-b767-4d1b-8516-6379d07fcb28" = true
+[919f8ef0-b767-4d1b-8516-6379d07fcb28]
+description = "disallow first strand longer"
+include = true
 
-# disallow second strand longer
-"8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e" = true
+[8a2d4ed0-ead5-4fdd-924d-27c4cf56e60e]
+description = "disallow second strand longer"
+include = true
 
-# disallow left empty strand
-"5dce058b-28d4-4ca7-aa64-adfe4e17784c" = true
+[5dce058b-28d4-4ca7-aa64-adfe4e17784c]
+description = "disallow left empty strand"
+include = true
 
-# disallow right empty strand
-"38826d4b-16fb-4639-ac3e-ba027dec8b5f" = true
+[38826d4b-16fb-4639-ac3e-ba027dec8b5f]
+description = "disallow right empty strand"
+include = true

--- a/exercises/practice/hello-world/.meta/tests.toml
+++ b/exercises/practice/hello-world/.meta/tests.toml
@@ -1,4 +1,7 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Say Hi!
-"af9ffe10-dc13-42d8-a742-e7bdafac449d" = true
+[af9ffe10-dc13-42d8-a742-e7bdafac449d]
+description = "Say Hi!"
+include = true

--- a/exercises/practice/isogram/.meta/tests.toml
+++ b/exercises/practice/isogram/.meta/tests.toml
@@ -1,40 +1,55 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty string
-"a0e97d2d-669e-47c7-8134-518a1e2c4555" = true
+[a0e97d2d-669e-47c7-8134-518a1e2c4555]
+description = "empty string"
+include = true
 
-# isogram with only lower case characters
-"9a001b50-f194-4143-bc29-2af5ec1ef652" = true
+[9a001b50-f194-4143-bc29-2af5ec1ef652]
+description = "isogram with only lower case characters"
+include = true
 
-# word with one duplicated character
-"8ddb0ca3-276e-4f8b-89da-d95d5bae78a4" = true
+[8ddb0ca3-276e-4f8b-89da-d95d5bae78a4]
+description = "word with one duplicated character"
+include = true
 
-# word with one duplicated character from the end of the alphabet
-"6450b333-cbc2-4b24-a723-0b459b34fe18" = true
+[6450b333-cbc2-4b24-a723-0b459b34fe18]
+description = "word with one duplicated character from the end of the alphabet"
+include = true
 
-# longest reported english isogram
-"a15ff557-dd04-4764-99e7-02cc1a385863" = true
+[a15ff557-dd04-4764-99e7-02cc1a385863]
+description = "longest reported english isogram"
+include = true
 
-# word with duplicated character in mixed case
-"f1a7f6c7-a42f-4915-91d7-35b2ea11c92e" = true
+[f1a7f6c7-a42f-4915-91d7-35b2ea11c92e]
+description = "word with duplicated character in mixed case"
+include = true
 
-# word with duplicated character in mixed case, lowercase first
-"14a4f3c1-3b47-4695-b645-53d328298942" = true
+[14a4f3c1-3b47-4695-b645-53d328298942]
+description = "word with duplicated character in mixed case, lowercase first"
+include = true
 
-# hypothetical isogrammic word with hyphen
-"423b850c-7090-4a8a-b057-97f1cadd7c42" = true
+[423b850c-7090-4a8a-b057-97f1cadd7c42]
+description = "hypothetical isogrammic word with hyphen"
+include = true
 
-# hypothetical word with duplicated character following hyphen
-"93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2" = true
+[93dbeaa0-3c5a-45c2-8b25-428b8eacd4f2]
+description = "hypothetical word with duplicated character following hyphen"
+include = true
 
-# isogram with duplicated hyphen
-"36b30e5c-173f-49c6-a515-93a3e825553f" = true
+[36b30e5c-173f-49c6-a515-93a3e825553f]
+description = "isogram with duplicated hyphen"
+include = true
 
-# made-up name that is an isogram
-"cdabafa0-c9f4-4c1f-b142-689c6ee17d93" = true
+[cdabafa0-c9f4-4c1f-b142-689c6ee17d93]
+description = "made-up name that is an isogram"
+include = true
 
-# duplicated character in the middle
-"5fc61048-d74e-48fd-bc34-abfc21552d4d" = true
+[5fc61048-d74e-48fd-bc34-abfc21552d4d]
+description = "duplicated character in the middle"
+include = true
 
-# same first and last characters
-"310ac53d-8932-47bc-bbb4-b2b94f25a83e" = true
+[310ac53d-8932-47bc-bbb4-b2b94f25a83e]
+description = "same first and last characters"
+include = true

--- a/exercises/practice/largest-series-product/.meta/tests.toml
+++ b/exercises/practice/largest-series-product/.meta/tests.toml
@@ -1,46 +1,63 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# finds the largest product if span equals length
-"7c82f8b7-e347-48ee-8a22-f672323324d4" = true
+[7c82f8b7-e347-48ee-8a22-f672323324d4]
+description = "finds the largest product if span equals length"
+include = true
 
-# can find the largest product of 2 with numbers in order
-"88523f65-21ba-4458-a76a-b4aaf6e4cb5e" = true
+[88523f65-21ba-4458-a76a-b4aaf6e4cb5e]
+description = "can find the largest product of 2 with numbers in order"
+include = true
 
-# can find the largest product of 2
-"f1376b48-1157-419d-92c2-1d7e36a70b8a" = true
+[f1376b48-1157-419d-92c2-1d7e36a70b8a]
+description = "can find the largest product of 2"
+include = true
 
-# can find the largest product of 3 with numbers in order
-"46356a67-7e02-489e-8fea-321c2fa7b4a4" = true
+[46356a67-7e02-489e-8fea-321c2fa7b4a4]
+description = "can find the largest product of 3 with numbers in order"
+include = true
 
-# can find the largest product of 3
-"a2dcb54b-2b8f-4993-92dd-5ce56dece64a" = true
+[a2dcb54b-2b8f-4993-92dd-5ce56dece64a]
+description = "can find the largest product of 3"
+include = true
 
-# can find the largest product of 5 with numbers in order
-"673210a3-33cd-4708-940b-c482d7a88f9d" = true
+[673210a3-33cd-4708-940b-c482d7a88f9d]
+description = "can find the largest product of 5 with numbers in order"
+include = true
 
-# can get the largest product of a big number
-"02acd5a6-3bbf-46df-8282-8b313a80a7c9" = true
+[02acd5a6-3bbf-46df-8282-8b313a80a7c9]
+description = "can get the largest product of a big number"
+include = true
 
-# reports zero if the only digits are zero
-"76dcc407-21e9-424c-a98e-609f269622b5" = true
+[76dcc407-21e9-424c-a98e-609f269622b5]
+description = "reports zero if the only digits are zero"
+include = true
 
-# reports zero if all spans include zero
-"6ef0df9f-52d4-4a5d-b210-f6fae5f20e19" = true
+[6ef0df9f-52d4-4a5d-b210-f6fae5f20e19]
+description = "reports zero if all spans include zero"
+include = true
 
-# rejects span longer than string length
-"5d81aaf7-4f67-4125-bf33-11493cc7eab7" = true
+[5d81aaf7-4f67-4125-bf33-11493cc7eab7]
+description = "rejects span longer than string length"
+include = true
 
-# reports 1 for empty string and empty product (0 span)
-"06bc8b90-0c51-4c54-ac22-3ec3893a079e" = true
+[06bc8b90-0c51-4c54-ac22-3ec3893a079e]
+description = "reports 1 for empty string and empty product (0 span)"
+include = true
 
-# reports 1 for nonempty string and empty product (0 span)
-"3ec0d92e-f2e2-4090-a380-70afee02f4c0" = true
+[3ec0d92e-f2e2-4090-a380-70afee02f4c0]
+description = "reports 1 for nonempty string and empty product (0 span)"
+include = true
 
-# rejects empty string and nonzero span
-"6d96c691-4374-4404-80ee-2ea8f3613dd4" = true
+[6d96c691-4374-4404-80ee-2ea8f3613dd4]
+description = "rejects empty string and nonzero span"
+include = true
 
-# rejects invalid character in digits
-"7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74" = true
+[7a38f2d6-3c35-45f6-8d6f-12e6e32d4d74]
+description = "rejects invalid character in digits"
+include = true
 
-# rejects negative span
-"5fe3c0e5-a945-49f2-b584-f0814b4dd1ef" = true
+[5fe3c0e5-a945-49f2-b584-f0814b4dd1ef]
+description = "rejects negative span"
+include = true

--- a/exercises/practice/leap/.meta/tests.toml
+++ b/exercises/practice/leap/.meta/tests.toml
@@ -1,28 +1,39 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# year not divisible by 4 in common year
-"6466b30d-519c-438e-935d-388224ab5223" = true
+[6466b30d-519c-438e-935d-388224ab5223]
+description = "year not divisible by 4 in common year"
+include = true
 
-# year divisible by 2, not divisible by 4 in common year
-"ac227e82-ee82-4a09-9eb6-4f84331ffdb0" = true
+[ac227e82-ee82-4a09-9eb6-4f84331ffdb0]
+description = "year divisible by 2, not divisible by 4 in common year"
+include = true
 
-# year divisible by 4, not divisible by 100 in leap year
-"4fe9b84c-8e65-489e-970b-856d60b8b78e" = true
+[4fe9b84c-8e65-489e-970b-856d60b8b78e]
+description = "year divisible by 4, not divisible by 100 in leap year"
+include = true
 
-# year divisible by 4 and 5 is still a leap year
-"7fc6aed7-e63c-48f5-ae05-5fe182f60a5d" = true
+[7fc6aed7-e63c-48f5-ae05-5fe182f60a5d]
+description = "year divisible by 4 and 5 is still a leap year"
+include = true
 
-# year divisible by 100, not divisible by 400 in common year
-"78a7848f-9667-4192-ae53-87b30c9a02dd" = true
+[78a7848f-9667-4192-ae53-87b30c9a02dd]
+description = "year divisible by 100, not divisible by 400 in common year"
+include = true
 
-# year divisible by 100 but not by 3 is still not a leap year
-"9d70f938-537c-40a6-ba19-f50739ce8bac" = true
+[9d70f938-537c-40a6-ba19-f50739ce8bac]
+description = "year divisible by 100 but not by 3 is still not a leap year"
+include = true
 
-# year divisible by 400 in leap year
-"42ee56ad-d3e6-48f1-8e3f-c84078d916fc" = true
+[42ee56ad-d3e6-48f1-8e3f-c84078d916fc]
+description = "year divisible by 400 in leap year"
+include = true
 
-# year divisible by 400 but not by 125 is still a leap year
-"57902c77-6fe9-40de-8302-587b5c27121e" = true
+[57902c77-6fe9-40de-8302-587b5c27121e]
+description = "year divisible by 400 but not by 125 is still a leap year"
+include = true
 
-# year divisible by 200, not divisible by 400 in common year
-"c30331f6-f9f6-4881-ad38-8ca8c12520c1" = true
+[c30331f6-f9f6-4881-ad38-8ca8c12520c1]
+description = "year divisible by 200, not divisible by 400 in common year"
+include = true

--- a/exercises/practice/list-ops/.meta/tests.toml
+++ b/exercises/practice/list-ops/.meta/tests.toml
@@ -1,64 +1,87 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty lists
-"485b9452-bf94-40f7-a3db-c3cf4850066a" = true
+[485b9452-bf94-40f7-a3db-c3cf4850066a]
+description = "empty lists"
+include = true
 
-# list to empty list
-"2c894696-b609-4569-b149-8672134d340a" = true
+[2c894696-b609-4569-b149-8672134d340a]
+description = "list to empty list"
+include = true
 
-# non-empty lists
-"71dcf5eb-73ae-4a0e-b744-a52ee387922f" = true
+[71dcf5eb-73ae-4a0e-b744-a52ee387922f]
+description = "non-empty lists"
+include = true
 
-# empty list
-"28444355-201b-4af2-a2f6-5550227bde21" = true
+[28444355-201b-4af2-a2f6-5550227bde21]
+description = "empty list"
+include = true
 
-# list of lists
-"331451c1-9573-42a1-9869-2d06e3b389a9" = true
+[331451c1-9573-42a1-9869-2d06e3b389a9]
+description = "list of lists"
+include = true
 
-# list of nested lists
-"d6ecd72c-197f-40c3-89a4-aa1f45827e09" = true
+[d6ecd72c-197f-40c3-89a4-aa1f45827e09]
+description = "list of nested lists"
+include = true
 
-# empty list
-"0524fba8-3e0f-4531-ad2b-f7a43da86a16" = true
+[0524fba8-3e0f-4531-ad2b-f7a43da86a16]
+description = "empty list"
+include = true
 
-# non-empty list
-"88494bd5-f520-4edb-8631-88e415b62d24" = true
+[88494bd5-f520-4edb-8631-88e415b62d24]
+description = "non-empty list"
+include = true
 
-# empty list
-"1cf0b92d-8d96-41d5-9c21-7b3c37cb6aad" = true
+[1cf0b92d-8d96-41d5-9c21-7b3c37cb6aad]
+description = "empty list"
+include = true
 
-# non-empty list
-"d7b8d2d9-2d16-44c4-9a19-6e5f237cb71e" = true
+[d7b8d2d9-2d16-44c4-9a19-6e5f237cb71e]
+description = "non-empty list"
+include = true
 
-# empty list
-"c0bc8962-30e2-4bec-9ae4-668b8ecd75aa" = true
+[c0bc8962-30e2-4bec-9ae4-668b8ecd75aa]
+description = "empty list"
+include = true
 
-# non-empty list
-"11e71a95-e78b-4909-b8e4-60cdcaec0e91" = true
+[11e71a95-e78b-4909-b8e4-60cdcaec0e91]
+description = "non-empty list"
+include = true
 
-# empty list
-"613b20b7-1873-4070-a3a6-70ae5f50d7cc" = true
+[613b20b7-1873-4070-a3a6-70ae5f50d7cc]
+description = "empty list"
+include = true
 
-# direction independent function applied to non-empty list
-"e56df3eb-9405-416a-b13a-aabb4c3b5194" = true
+[e56df3eb-9405-416a-b13a-aabb4c3b5194]
+description = "direction independent function applied to non-empty list"
+include = true
 
-# direction dependent function applied to non-empty list
-"d2cf5644-aee1-4dfc-9b88-06896676fe27" = true
+[d2cf5644-aee1-4dfc-9b88-06896676fe27]
+description = "direction dependent function applied to non-empty list"
+include = true
 
-# empty list
-"aeb576b9-118e-4a57-a451-db49fac20fdc" = true
+[aeb576b9-118e-4a57-a451-db49fac20fdc]
+description = "empty list"
+include = true
 
-# direction independent function applied to non-empty list
-"c4b64e58-313e-4c47-9c68-7764964efb8e" = true
+[c4b64e58-313e-4c47-9c68-7764964efb8e]
+description = "direction independent function applied to non-empty list"
+include = true
 
-# direction dependent function applied to non-empty list
-"be396a53-c074-4db3-8dd6-f7ed003cce7c" = true
+[be396a53-c074-4db3-8dd6-f7ed003cce7c]
+description = "direction dependent function applied to non-empty list"
+include = true
 
-# empty list
-"94231515-050e-4841-943d-d4488ab4ee30" = true
+[94231515-050e-4841-943d-d4488ab4ee30]
+description = "empty list"
+include = true
 
-# non-empty list
-"fcc03d1e-42e0-4712-b689-d54ad761f360" = true
+[fcc03d1e-42e0-4712-b689-d54ad761f360]
+description = "non-empty list"
+include = true
 
-# list of lists is not flattened
-"40872990-b5b8-4cb8-9085-d91fc0d05d26" = true
+[40872990-b5b8-4cb8-9085-d91fc0d05d26]
+description = "list of lists is not flattened"
+include = true

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -1,55 +1,75 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# single digit strings can not be valid
-"792a7082-feb7-48c7-b88b-bbfec160865e" = true
+[792a7082-feb7-48c7-b88b-bbfec160865e]
+description = "single digit strings can not be valid"
+include = true
 
-# a single zero is invalid
-"698a7924-64d4-4d89-8daa-32e1aadc271e" = true
+[698a7924-64d4-4d89-8daa-32e1aadc271e]
+description = "a single zero is invalid"
+include = true
 
-# a simple valid SIN that remains valid if reversed
-"73c2f62b-9b10-4c9f-9a04-83cee7367965" = true
+[73c2f62b-9b10-4c9f-9a04-83cee7367965]
+description = "a simple valid SIN that remains valid if reversed"
+include = true
 
-# a simple valid SIN that becomes invalid if reversed
-"9369092e-b095-439f-948d-498bd076be11" = true
+[9369092e-b095-439f-948d-498bd076be11]
+description = "a simple valid SIN that becomes invalid if reversed"
+include = true
 
-# a valid Canadian SIN
-"8f9f2350-1faf-4008-ba84-85cbb93ffeca" = true
+[8f9f2350-1faf-4008-ba84-85cbb93ffeca]
+description = "a valid Canadian SIN"
+include = true
 
-# invalid Canadian SIN
-"1cdcf269-6560-44fc-91f6-5819a7548737" = true
+[1cdcf269-6560-44fc-91f6-5819a7548737]
+description = "invalid Canadian SIN"
+include = true
 
-# invalid credit card
-"656c48c1-34e8-4e60-9a5a-aad8a367810a" = true
+[656c48c1-34e8-4e60-9a5a-aad8a367810a]
+description = "invalid credit card"
+include = true
 
-# invalid long number with an even remainder
-"20e67fad-2121-43ed-99a8-14b5b856adb9" = true
+[20e67fad-2121-43ed-99a8-14b5b856adb9]
+description = "invalid long number with an even remainder"
+include = true
 
-# valid number with an even number of digits
-"ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa" = true
+[ad2a0c5f-84ed-4e5b-95da-6011d6f4f0aa]
+description = "valid number with an even number of digits"
+include = true
 
-# valid number with an odd number of spaces
-"ef081c06-a41f-4761-8492-385e13c8202d" = true
+[ef081c06-a41f-4761-8492-385e13c8202d]
+description = "valid number with an odd number of spaces"
+include = true
 
-# valid strings with a non-digit added at the end become invalid
-"bef66f64-6100-4cbb-8f94-4c9713c5e5b2" = true
+[bef66f64-6100-4cbb-8f94-4c9713c5e5b2]
+description = "valid strings with a non-digit added at the end become invalid"
+include = true
 
-# valid strings with punctuation included become invalid
-"2177e225-9ce7-40f6-b55d-fa420e62938e" = true
+[2177e225-9ce7-40f6-b55d-fa420e62938e]
+description = "valid strings with punctuation included become invalid"
+include = true
 
-# valid strings with symbols included become invalid
-"ebf04f27-9698-45e1-9afe-7e0851d0fe8d" = true
+[ebf04f27-9698-45e1-9afe-7e0851d0fe8d]
+description = "valid strings with symbols included become invalid"
+include = true
 
-# single zero with space is invalid
-"08195c5e-ce7f-422c-a5eb-3e45fece68ba" = true
+[08195c5e-ce7f-422c-a5eb-3e45fece68ba]
+description = "single zero with space is invalid"
+include = true
 
-# more than a single zero is valid
-"12e63a3c-f866-4a79-8c14-b359fc386091" = true
+[12e63a3c-f866-4a79-8c14-b359fc386091]
+description = "more than a single zero is valid"
+include = true
 
-# input digit 9 is correctly converted to output digit 9
-"ab56fa80-5de8-4735-8a4a-14dae588663e" = true
+[ab56fa80-5de8-4735-8a4a-14dae588663e]
+description = "input digit 9 is correctly converted to output digit 9"
+include = true
 
-# using ascii value for non-doubled non-digit isn't allowed
-"39a06a5a-5bad-4e0f-b215-b042d46209b1" = true
+[39a06a5a-5bad-4e0f-b215-b042d46209b1]
+description = "using ascii value for non-doubled non-digit isn't allowed"
+include = true
 
-# using ascii value for doubled non-digit isn't allowed
-"f94cf191-a62f-4868-bc72-7253114aa157" = true
+[f94cf191-a62f-4868-bc72-7253114aa157]
+description = "using ascii value for doubled non-digit isn't allowed"
+include = true

--- a/exercises/practice/matching-brackets/.meta/tests.toml
+++ b/exercises/practice/matching-brackets/.meta/tests.toml
@@ -1,52 +1,71 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# paired square brackets
-"81ec11da-38dd-442a-bcf9-3de7754609a5" = true
+[81ec11da-38dd-442a-bcf9-3de7754609a5]
+description = "paired square brackets"
+include = true
 
-# empty string
-"287f0167-ac60-4b64-8452-a0aa8f4e5238" = true
+[287f0167-ac60-4b64-8452-a0aa8f4e5238]
+description = "empty string"
+include = true
 
-# unpaired brackets
-"6c3615a3-df01-4130-a731-8ef5f5d78dac" = true
+[6c3615a3-df01-4130-a731-8ef5f5d78dac]
+description = "unpaired brackets"
+include = true
 
-# wrong ordered brackets
-"9d414171-9b98-4cac-a4e5-941039a97a77" = true
+[9d414171-9b98-4cac-a4e5-941039a97a77]
+description = "wrong ordered brackets"
+include = true
 
-# wrong closing bracket
-"f0f97c94-a149-4736-bc61-f2c5148ffb85" = true
+[f0f97c94-a149-4736-bc61-f2c5148ffb85]
+description = "wrong closing bracket"
+include = true
 
-# paired with whitespace
-"754468e0-4696-4582-a30e-534d47d69756" = true
+[754468e0-4696-4582-a30e-534d47d69756]
+description = "paired with whitespace"
+include = true
 
-# partially paired brackets
-"ba84f6ee-8164-434a-9c3e-b02c7f8e8545" = true
+[ba84f6ee-8164-434a-9c3e-b02c7f8e8545]
+description = "partially paired brackets"
+include = true
 
-# simple nested brackets
-"3c86c897-5ff3-4a2b-ad9b-47ac3a30651d" = true
+[3c86c897-5ff3-4a2b-ad9b-47ac3a30651d]
+description = "simple nested brackets"
+include = true
 
-# several paired brackets
-"2d137f2c-a19e-4993-9830-83967a2d4726" = true
+[2d137f2c-a19e-4993-9830-83967a2d4726]
+description = "several paired brackets"
+include = true
 
-# paired and nested brackets
-"2e1f7b56-c137-4c92-9781-958638885a44" = true
+[2e1f7b56-c137-4c92-9781-958638885a44]
+description = "paired and nested brackets"
+include = true
 
-# unopened closing brackets
-"84f6233b-e0f7-4077-8966-8085d295c19b" = true
+[84f6233b-e0f7-4077-8966-8085d295c19b]
+description = "unopened closing brackets"
+include = true
 
-# unpaired and nested brackets
-"9b18c67d-7595-4982-b2c5-4cb949745d49" = true
+[9b18c67d-7595-4982-b2c5-4cb949745d49]
+description = "unpaired and nested brackets"
+include = true
 
-# paired and wrong nested brackets
-"a0205e34-c2ac-49e6-a88a-899508d7d68e" = true
+[a0205e34-c2ac-49e6-a88a-899508d7d68e]
+description = "paired and wrong nested brackets"
+include = true
 
-# paired and incomplete brackets
-"ef47c21b-bcfd-4998-844c-7ad5daad90a8" = true
+[ef47c21b-bcfd-4998-844c-7ad5daad90a8]
+description = "paired and incomplete brackets"
+include = true
 
-# too many closing brackets
-"a4675a40-a8be-4fc2-bc47-2a282ce6edbe" = true
+[a4675a40-a8be-4fc2-bc47-2a282ce6edbe]
+description = "too many closing brackets"
+include = true
 
-# math expression
-"99255f93-261b-4435-a352-02bdecc9bdf2" = true
+[99255f93-261b-4435-a352-02bdecc9bdf2]
+description = "math expression"
+include = true
 
-# complex latex expression
-"8e357d79-f302-469a-8515-2561877256a1" = true
+[8e357d79-f302-469a-8515-2561877256a1]
+description = "complex latex expression"
+include = true

--- a/exercises/practice/nucleotide-count/.meta/tests.toml
+++ b/exercises/practice/nucleotide-count/.meta/tests.toml
@@ -1,16 +1,23 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty strand
-"3e5c30a8-87e2-4845-a815-a49671ade970" = true
+[3e5c30a8-87e2-4845-a815-a49671ade970]
+description = "empty strand"
+include = true
 
-# can count one nucleotide in single-character input
-"a0ea42a6-06d9-4ac6-828c-7ccaccf98fec" = true
+[a0ea42a6-06d9-4ac6-828c-7ccaccf98fec]
+description = "can count one nucleotide in single-character input"
+include = true
 
-# strand with repeated nucleotide
-"eca0d565-ed8c-43e7-9033-6cefbf5115b5" = true
+[eca0d565-ed8c-43e7-9033-6cefbf5115b5]
+description = "strand with repeated nucleotide"
+include = true
 
-# strand with multiple nucleotides
-"40a45eac-c83f-4740-901a-20b22d15a39f" = true
+[40a45eac-c83f-4740-901a-20b22d15a39f]
+description = "strand with multiple nucleotides"
+include = true
 
-# strand with invalid nucleotides
-"b4c47851-ee9e-4b0a-be70-a86e343bd851" = true
+[b4c47851-ee9e-4b0a-be70-a86e343bd851]
+description = "strand with invalid nucleotides"
+include = true

--- a/exercises/practice/pangram/.meta/tests.toml
+++ b/exercises/practice/pangram/.meta/tests.toml
@@ -1,31 +1,43 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty sentence
-"64f61791-508e-4f5c-83ab-05de042b0149" = true
+[64f61791-508e-4f5c-83ab-05de042b0149]
+description = "empty sentence"
+include = true
 
-# perfect lower case
-"74858f80-4a4d-478b-8a5e-c6477e4e4e84" = true
+[74858f80-4a4d-478b-8a5e-c6477e4e4e84]
+description = "perfect lower case"
+include = true
 
-# only lower case
-"61288860-35ca-4abe-ba08-f5df76ecbdcd" = true
+[61288860-35ca-4abe-ba08-f5df76ecbdcd]
+description = "only lower case"
+include = true
 
-# missing the letter 'x'
-"6564267d-8ac5-4d29-baf2-e7d2e304a743" = true
+[6564267d-8ac5-4d29-baf2-e7d2e304a743]
+description = "missing the letter 'x'"
+include = true
 
-# missing the letter 'h'
-"c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0" = true
+[c79af1be-d715-4cdb-a5f2-b2fa3e7e0de0]
+description = "missing the letter 'h'"
+include = true
 
-# with underscores
-"d835ec38-bc8f-48e4-9e36-eb232427b1df" = true
+[d835ec38-bc8f-48e4-9e36-eb232427b1df]
+description = "with underscores"
+include = true
 
-# with numbers
-"8cc1e080-a178-4494-b4b3-06982c9be2a8" = true
+[8cc1e080-a178-4494-b4b3-06982c9be2a8]
+description = "with numbers"
+include = true
 
-# missing letters replaced by numbers
-"bed96b1c-ff95-45b8-9731-fdbdcb6ede9a" = true
+[bed96b1c-ff95-45b8-9731-fdbdcb6ede9a]
+description = "missing letters replaced by numbers"
+include = true
 
-# mixed case and punctuation
-"938bd5d8-ade5-40e2-a2d9-55a338a01030" = true
+[938bd5d8-ade5-40e2-a2d9-55a338a01030]
+description = "mixed case and punctuation"
+include = true
 
-# case insensitive
-"2577bf54-83c8-402d-a64b-a2c0f7bb213a" = true
+[2577bf54-83c8-402d-a64b-a2c0f7bb213a]
+description = "case insensitive"
+include = true

--- a/exercises/practice/pascals-triangle/.meta/tests.toml
+++ b/exercises/practice/pascals-triangle/.meta/tests.toml
@@ -1,25 +1,35 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# zero rows
-"9920ce55-9629-46d5-85d6-4201f4a4234d" = true
+[9920ce55-9629-46d5-85d6-4201f4a4234d]
+description = "zero rows"
+include = true
 
-# single row
-"70d643ce-a46d-4e93-af58-12d88dd01f21" = true
+[70d643ce-a46d-4e93-af58-12d88dd01f21]
+description = "single row"
+include = true
 
-# two rows
-"a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd" = true
+[a6e5a2a2-fc9a-4b47-9f4f-ed9ad9fbe4bd]
+description = "two rows"
+include = true
 
-# three rows
-"97206a99-79ba-4b04-b1c5-3c0fa1e16925" = true
+[97206a99-79ba-4b04-b1c5-3c0fa1e16925]
+description = "three rows"
+include = true
 
-# four rows
-"565a0431-c797-417c-a2c8-2935e01ce306" = true
+[565a0431-c797-417c-a2c8-2935e01ce306]
+description = "four rows"
+include = true
 
-# five rows
-"06f9ea50-9f51-4eb2-b9a9-c00975686c27" = true
+[06f9ea50-9f51-4eb2-b9a9-c00975686c27]
+description = "five rows"
+include = true
 
-# six rows
-"c3912965-ddb4-46a9-848e-3363e6b00b13" = true
+[c3912965-ddb4-46a9-848e-3363e6b00b13]
+description = "six rows"
+include = true
 
-# ten rows
-"6cb26c66-7b57-4161-962c-81ec8c99f16b" = true
+[6cb26c66-7b57-4161-962c-81ec8c99f16b]
+description = "ten rows"
+include = true

--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -1,55 +1,75 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# cleans the number
-"79666dce-e0f1-46de-95a1-563802913c35" = true
+[79666dce-e0f1-46de-95a1-563802913c35]
+description = "cleans the number"
+include = true
 
-# cleans numbers with dots
-"c360451f-549f-43e4-8aba-fdf6cb0bf83f" = true
+[c360451f-549f-43e4-8aba-fdf6cb0bf83f]
+description = "cleans numbers with dots"
+include = true
 
-# cleans numbers with multiple spaces
-"08f94c34-9a37-46a2-a123-2a8e9727395d" = true
+[08f94c34-9a37-46a2-a123-2a8e9727395d]
+description = "cleans numbers with multiple spaces"
+include = true
 
-# invalid when 9 digits
-"598d8432-0659-4019-a78b-1c6a73691d21" = true
+[598d8432-0659-4019-a78b-1c6a73691d21]
+description = "invalid when 9 digits"
+include = true
 
-# invalid when 11 digits does not start with a 1
-"57061c72-07b5-431f-9766-d97da7c4399d" = true
+[57061c72-07b5-431f-9766-d97da7c4399d]
+description = "invalid when 11 digits does not start with a 1"
+include = true
 
-# valid when 11 digits and starting with 1
-"9962cbf3-97bb-4118-ba9b-38ff49c64430" = true
+[9962cbf3-97bb-4118-ba9b-38ff49c64430]
+description = "valid when 11 digits and starting with 1"
+include = true
 
-# valid when 11 digits and starting with 1 even with punctuation
-"fa724fbf-054c-4d91-95da-f65ab5b6dbca" = true
+[fa724fbf-054c-4d91-95da-f65ab5b6dbca]
+description = "valid when 11 digits and starting with 1 even with punctuation"
+include = true
 
-# invalid when more than 11 digits
-"c6a5f007-895a-4fc5-90bc-a7e70f9b5cad" = true
+[c6a5f007-895a-4fc5-90bc-a7e70f9b5cad]
+description = "invalid when more than 11 digits"
+include = true
 
-# invalid with letters
-"63f38f37-53f6-4a5f-bd86-e9b404f10a60" = true
+[63f38f37-53f6-4a5f-bd86-e9b404f10a60]
+description = "invalid with letters"
+include = true
 
-# invalid with punctuations
-"4bd97d90-52fd-45d3-b0db-06ab95b1244e" = true
+[4bd97d90-52fd-45d3-b0db-06ab95b1244e]
+description = "invalid with punctuations"
+include = true
 
-# invalid if area code starts with 0
-"d77d07f8-873c-4b17-8978-5f66139bf7d7" = true
+[d77d07f8-873c-4b17-8978-5f66139bf7d7]
+description = "invalid if area code starts with 0"
+include = true
 
-# invalid if area code starts with 1
-"c7485cfb-1e7b-4081-8e96-8cdb3b77f15e" = true
+[c7485cfb-1e7b-4081-8e96-8cdb3b77f15e]
+description = "invalid if area code starts with 1"
+include = true
 
-# invalid if exchange code starts with 0
-"4d622293-6976-413d-b8bf-dd8a94d4e2ac" = true
+[4d622293-6976-413d-b8bf-dd8a94d4e2ac]
+description = "invalid if exchange code starts with 0"
+include = true
 
-# invalid if exchange code starts with 1
-"4cef57b4-7d8e-43aa-8328-1e1b89001262" = true
+[4cef57b4-7d8e-43aa-8328-1e1b89001262]
+description = "invalid if exchange code starts with 1"
+include = true
 
-# invalid if area code starts with 0 on valid 11-digit number
-"9925b09c-1a0d-4960-a197-5d163cbe308c" = true
+[9925b09c-1a0d-4960-a197-5d163cbe308c]
+description = "invalid if area code starts with 0 on valid 11-digit number"
+include = true
 
-# invalid if area code starts with 1 on valid 11-digit number
-"3f809d37-40f3-44b5-ad90-535838b1a816" = true
+[3f809d37-40f3-44b5-ad90-535838b1a816]
+description = "invalid if area code starts with 1 on valid 11-digit number"
+include = true
 
-# invalid if exchange code starts with 0 on valid 11-digit number
-"e08e5532-d621-40d4-b0cc-96c159276b65" = true
+[e08e5532-d621-40d4-b0cc-96c159276b65]
+description = "invalid if exchange code starts with 0 on valid 11-digit number"
+include = true
 
-# invalid if exchange code starts with 1 on valid 11-digit number
-"57b32f3d-696a-455c-8bf1-137b6d171cdf" = true
+[57b32f3d-696a-455c-8bf1-137b6d171cdf]
+description = "invalid if exchange code starts with 1 on valid 11-digit number"
+include = true

--- a/exercises/practice/pythagorean-triplet/.meta/tests.toml
+++ b/exercises/practice/pythagorean-triplet/.meta/tests.toml
@@ -1,22 +1,31 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# triplets whose sum is 12
-"a19de65d-35b8-4480-b1af-371d9541e706" = true
+[a19de65d-35b8-4480-b1af-371d9541e706]
+description = "triplets whose sum is 12"
+include = true
 
-# triplets whose sum is 108
-"48b21332-0a3d-43b2-9a52-90b2a6e5c9f5" = true
+[48b21332-0a3d-43b2-9a52-90b2a6e5c9f5]
+description = "triplets whose sum is 108"
+include = true
 
-# triplets whose sum is 1000
-"dffc1266-418e-4daa-81af-54c3e95c3bb5" = true
+[dffc1266-418e-4daa-81af-54c3e95c3bb5]
+description = "triplets whose sum is 1000"
+include = true
 
-# no matching triplets for 1001
-"5f86a2d4-6383-4cce-93a5-e4489e79b186" = true
+[5f86a2d4-6383-4cce-93a5-e4489e79b186]
+description = "no matching triplets for 1001"
+include = true
 
-# returns all matching triplets
-"bf17ba80-1596-409a-bb13-343bdb3b2904" = true
+[bf17ba80-1596-409a-bb13-343bdb3b2904]
+description = "returns all matching triplets"
+include = true
 
-# several matching triplets
-"9d8fb5d5-6c6f-42df-9f95-d3165963ac57" = true
+[9d8fb5d5-6c6f-42df-9f95-d3165963ac57]
+description = "several matching triplets"
+include = true
 
-# triplets for large number
-"f5be5734-8aa0-4bd1-99a2-02adcc4402b4" = true
+[f5be5734-8aa0-4bd1-99a2-02adcc4402b4]
+description = "triplets for large number"
+include = true

--- a/exercises/practice/raindrops/.meta/tests.toml
+++ b/exercises/practice/raindrops/.meta/tests.toml
@@ -1,55 +1,75 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# the sound for 1 is 1
-"1575d549-e502-46d4-a8e1-6b7bec6123d8" = true
+[1575d549-e502-46d4-a8e1-6b7bec6123d8]
+description = "the sound for 1 is 1"
+include = true
 
-# the sound for 3 is Pling
-"1f51a9f9-4895-4539-b182-d7b0a5ab2913" = true
+[1f51a9f9-4895-4539-b182-d7b0a5ab2913]
+description = "the sound for 3 is Pling"
+include = true
 
-# the sound for 5 is Plang
-"2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0" = true
+[2d9bfae5-2b21-4bcd-9629-c8c0e388f3e0]
+description = "the sound for 5 is Plang"
+include = true
 
-# the sound for 7 is Plong
-"d7e60daa-32ef-4c23-b688-2abff46c4806" = true
+[d7e60daa-32ef-4c23-b688-2abff46c4806]
+description = "the sound for 7 is Plong"
+include = true
 
-# the sound for 6 is Pling as it has a factor 3
-"6bb4947b-a724-430c-923f-f0dc3d62e56a" = true
+[6bb4947b-a724-430c-923f-f0dc3d62e56a]
+description = "the sound for 6 is Pling as it has a factor 3"
+include = true
 
-# 2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base
-"ce51e0e8-d9d4-446d-9949-96eac4458c2d" = true
+[ce51e0e8-d9d4-446d-9949-96eac4458c2d]
+description = "2 to the power 3 does not make a raindrop sound as 3 is the exponent not the base"
+include = true
 
-# the sound for 9 is Pling as it has a factor 3
-"0dd66175-e3e2-47fc-8750-d01739856671" = true
+[0dd66175-e3e2-47fc-8750-d01739856671]
+description = "the sound for 9 is Pling as it has a factor 3"
+include = true
 
-# the sound for 10 is Plang as it has a factor 5
-"022c44d3-2182-4471-95d7-c575af225c96" = true
+[022c44d3-2182-4471-95d7-c575af225c96]
+description = "the sound for 10 is Plang as it has a factor 5"
+include = true
 
-# the sound for 14 is Plong as it has a factor of 7
-"37ab74db-fed3-40ff-b7b9-04acdfea8edf" = true
+[37ab74db-fed3-40ff-b7b9-04acdfea8edf]
+description = "the sound for 14 is Plong as it has a factor of 7"
+include = true
 
-# the sound for 15 is PlingPlang as it has factors 3 and 5
-"31f92999-6afb-40ee-9aa4-6d15e3334d0f" = true
+[31f92999-6afb-40ee-9aa4-6d15e3334d0f]
+description = "the sound for 15 is PlingPlang as it has factors 3 and 5"
+include = true
 
-# the sound for 21 is PlingPlong as it has factors 3 and 7
-"ff9bb95d-6361-4602-be2c-653fe5239b54" = true
+[ff9bb95d-6361-4602-be2c-653fe5239b54]
+description = "the sound for 21 is PlingPlong as it has factors 3 and 7"
+include = true
 
-# the sound for 25 is Plang as it has a factor 5
-"d2e75317-b72e-40ab-8a64-6734a21dece1" = true
+[d2e75317-b72e-40ab-8a64-6734a21dece1]
+description = "the sound for 25 is Plang as it has a factor 5"
+include = true
 
-# the sound for 27 is Pling as it has a factor 3
-"a09c4c58-c662-4e32-97fe-f1501ef7125c" = true
+[a09c4c58-c662-4e32-97fe-f1501ef7125c]
+description = "the sound for 27 is Pling as it has a factor 3"
+include = true
 
-# the sound for 35 is PlangPlong as it has factors 5 and 7
-"bdf061de-8564-4899-a843-14b48b722789" = true
+[bdf061de-8564-4899-a843-14b48b722789]
+description = "the sound for 35 is PlangPlong as it has factors 5 and 7"
+include = true
 
-# the sound for 49 is Plong as it has a factor 7
-"c4680bee-69ba-439d-99b5-70c5fd1a7a83" = true
+[c4680bee-69ba-439d-99b5-70c5fd1a7a83]
+description = "the sound for 49 is Plong as it has a factor 7"
+include = true
 
-# the sound for 52 is 52
-"17f2bc9a-b65a-4d23-8ccd-266e8c271444" = true
+[17f2bc9a-b65a-4d23-8ccd-266e8c271444]
+description = "the sound for 52 is 52"
+include = true
 
-# the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7
-"e46677ed-ff1a-419f-a740-5c713d2830e4" = true
+[e46677ed-ff1a-419f-a740-5c713d2830e4]
+description = "the sound for 105 is PlingPlangPlong as it has factors 3, 5 and 7"
+include = true
 
-# the sound for 3125 is Plang as it has a factor 5
-"13c6837a-0fcd-4b86-a0eb-20572f7deb0b" = true
+[13c6837a-0fcd-4b86-a0eb-20572f7deb0b]
+description = "the sound for 3125 is Plang as it has a factor 5"
+include = true

--- a/exercises/practice/rna-transcription/.meta/tests.toml
+++ b/exercises/practice/rna-transcription/.meta/tests.toml
@@ -1,19 +1,27 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# Empty RNA sequence
-"b4631f82-c98c-4a2f-90b3-c5c2b6c6f661" = true
+[b4631f82-c98c-4a2f-90b3-c5c2b6c6f661]
+description = "Empty RNA sequence"
+include = true
 
-# RNA complement of cytosine is guanine
-"a9558a3c-318c-4240-9256-5d5ed47005a6" = true
+[a9558a3c-318c-4240-9256-5d5ed47005a6]
+description = "RNA complement of cytosine is guanine"
+include = true
 
-# RNA complement of guanine is cytosine
-"6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7" = true
+[6eedbb5c-12cb-4c8b-9f51-f8320b4dc2e7]
+description = "RNA complement of guanine is cytosine"
+include = true
 
-# RNA complement of thymine is adenine
-"870bd3ec-8487-471d-8d9a-a25046488d3e" = true
+[870bd3ec-8487-471d-8d9a-a25046488d3e]
+description = "RNA complement of thymine is adenine"
+include = true
 
-# RNA complement of adenine is uracil
-"aade8964-02e1-4073-872f-42d3ffd74c5f" = true
+[aade8964-02e1-4073-872f-42d3ffd74c5f]
+description = "RNA complement of adenine is uracil"
+include = true
 
-# RNA complement
-"79ed2757-f018-4f47-a1d7-34a559392dbf" = true
+[79ed2757-f018-4f47-a1d7-34a559392dbf]
+description = "RNA complement"
+include = true

--- a/exercises/practice/robot-simulator/.meta/tests.toml
+++ b/exercises/practice/robot-simulator/.meta/tests.toml
@@ -1,55 +1,75 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# at origin facing north
-"c557c16d-26c1-4e06-827c-f6602cd0785c" = true
+[c557c16d-26c1-4e06-827c-f6602cd0785c]
+description = "at origin facing north"
+include = true
 
-# at negative position facing south
-"bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d" = true
+[bf0dffce-f11c-4cdb-8a5e-2c89d8a5a67d]
+description = "at negative position facing south"
+include = true
 
-# changes north to east
-"8cbd0086-6392-4680-b9b9-73cf491e67e5" = true
+[8cbd0086-6392-4680-b9b9-73cf491e67e5]
+description = "changes north to east"
+include = true
 
-# changes east to south
-"8abc87fc-eab2-4276-93b7-9c009e866ba1" = true
+[8abc87fc-eab2-4276-93b7-9c009e866ba1]
+description = "changes east to south"
+include = true
 
-# changes south to west
-"3cfe1b85-bbf2-4bae-b54d-d73e7e93617a" = true
+[3cfe1b85-bbf2-4bae-b54d-d73e7e93617a]
+description = "changes south to west"
+include = true
 
-# changes west to north
-"5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716" = true
+[5ea9fb99-3f2c-47bd-86f7-46b7d8c3c716]
+description = "changes west to north"
+include = true
 
-# changes north to west
-"fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63" = true
+[fa0c40f5-6ba3-443d-a4b3-58cbd6cb8d63]
+description = "changes north to west"
+include = true
 
-# changes west to south
-"da33d734-831f-445c-9907-d66d7d2a92e2" = true
+[da33d734-831f-445c-9907-d66d7d2a92e2]
+description = "changes west to south"
+include = true
 
-# changes south to east
-"bd1ca4b9-4548-45f4-b32e-900fc7c19389" = true
+[bd1ca4b9-4548-45f4-b32e-900fc7c19389]
+description = "changes south to east"
+include = true
 
-# changes east to north
-"2de27b67-a25c-4b59-9883-bc03b1b55bba" = true
+[2de27b67-a25c-4b59-9883-bc03b1b55bba]
+description = "changes east to north"
+include = true
 
-# facing north increments Y
-"f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8" = true
+[f0dc2388-cddc-4f83-9bed-bcf46b8fc7b8]
+description = "facing north increments Y"
+include = true
 
-# facing south decrements Y
-"2786cf80-5bbf-44b0-9503-a89a9c5789da" = true
+[2786cf80-5bbf-44b0-9503-a89a9c5789da]
+description = "facing south decrements Y"
+include = true
 
-# facing east increments X
-"84bf3c8c-241f-434d-883d-69817dbd6a48" = true
+[84bf3c8c-241f-434d-883d-69817dbd6a48]
+description = "facing east increments X"
+include = true
 
-# facing west decrements X
-"bb69c4a7-3bbf-4f64-b415-666fa72d7b04" = true
+[bb69c4a7-3bbf-4f64-b415-666fa72d7b04]
+description = "facing west decrements X"
+include = true
 
-# moving east and north from README
-"e34ac672-4ed4-4be3-a0b8-d9af259cbaa1" = true
+[e34ac672-4ed4-4be3-a0b8-d9af259cbaa1]
+description = "moving east and north from README"
+include = true
 
-# moving west and north
-"f30e4955-4b47-4aa3-8b39-ae98cfbd515b" = true
+[f30e4955-4b47-4aa3-8b39-ae98cfbd515b]
+description = "moving west and north"
+include = true
 
-# moving west and south
-"3e466bf6-20ab-4d79-8b51-264165182fca" = true
+[3e466bf6-20ab-4d79-8b51-264165182fca]
+description = "moving west and south"
+include = true
 
-# moving east and north
-"41f0bb96-c617-4e6b-acff-a4b279d44514" = true
+[41f0bb96-c617-4e6b-acff-a4b279d44514]
+description = "moving east and north"
+include = true

--- a/exercises/practice/roman-numerals/.meta/tests.toml
+++ b/exercises/practice/roman-numerals/.meta/tests.toml
@@ -1,58 +1,79 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# 1 is a single I
-"19828a3a-fbf7-4661-8ddd-cbaeee0e2178" = true
+[19828a3a-fbf7-4661-8ddd-cbaeee0e2178]
+description = "1 is a single I"
+include = true
 
-# 2 is two I's
-"f088f064-2d35-4476-9a41-f576da3f7b03" = true
+[f088f064-2d35-4476-9a41-f576da3f7b03]
+description = "2 is two I's"
+include = true
 
-# 3 is three I's
-"b374a79c-3bea-43e6-8db8-1286f79c7106" = true
+[b374a79c-3bea-43e6-8db8-1286f79c7106]
+description = "3 is three I's"
+include = true
 
-# 4, being 5 - 1, is IV
-"05a0a1d4-a140-4db1-82e8-fcc21fdb49bb" = true
+[05a0a1d4-a140-4db1-82e8-fcc21fdb49bb]
+description = "4, being 5 - 1, is IV"
+include = true
 
-# 5 is a single V
-"57c0f9ad-5024-46ab-975d-de18c430b290" = true
+[57c0f9ad-5024-46ab-975d-de18c430b290]
+description = "5 is a single V"
+include = true
 
-# 6, being 5 + 1, is VI
-"20a2b47f-e57f-4797-a541-0b3825d7f249" = true
+[20a2b47f-e57f-4797-a541-0b3825d7f249]
+description = "6, being 5 + 1, is VI"
+include = true
 
-# 9, being 10 - 1, is IX
-"ff3fb08c-4917-4aab-9f4e-d663491d083d" = true
+[ff3fb08c-4917-4aab-9f4e-d663491d083d]
+description = "9, being 10 - 1, is IX"
+include = true
 
-# 20 is two X's
-"2bda64ca-7d28-4c56-b08d-16ce65716cf6" = true
+[2bda64ca-7d28-4c56-b08d-16ce65716cf6]
+description = "20 is two X's"
+include = true
 
-# 48 is not 50 - 2 but rather 40 + 8
-"a1f812ef-84da-4e02-b4f0-89c907d0962c" = true
+[a1f812ef-84da-4e02-b4f0-89c907d0962c]
+description = "48 is not 50 - 2 but rather 40 + 8"
+include = true
 
-# 49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1
-"607ead62-23d6-4c11-a396-ef821e2e5f75" = true
+[607ead62-23d6-4c11-a396-ef821e2e5f75]
+description = "49 is not 40 + 5 + 4 but rather 50 - 10 + 10 - 1"
+include = true
 
-# 50 is a single L
-"d5b283d4-455d-4e68-aacf-add6c4b51915" = true
+[d5b283d4-455d-4e68-aacf-add6c4b51915]
+description = "50 is a single L"
+include = true
 
-# 90, being 100 - 10, is XC
-"46b46e5b-24da-4180-bfe2-2ef30b39d0d0" = true
+[46b46e5b-24da-4180-bfe2-2ef30b39d0d0]
+description = "90, being 100 - 10, is XC"
+include = true
 
-# 100 is a single C
-"30494be1-9afb-4f84-9d71-db9df18b55e3" = true
+[30494be1-9afb-4f84-9d71-db9df18b55e3]
+description = "100 is a single C"
+include = true
 
-# 60, being 50 + 10, is LX
-"267f0207-3c55-459a-b81d-67cec7a46ed9" = true
+[267f0207-3c55-459a-b81d-67cec7a46ed9]
+description = "60, being 50 + 10, is LX"
+include = true
 
-# 400, being 500 - 100, is CD
-"cdb06885-4485-4d71-8bfb-c9d0f496b404" = true
+[cdb06885-4485-4d71-8bfb-c9d0f496b404]
+description = "400, being 500 - 100, is CD"
+include = true
 
-# 500 is a single D
-"6b71841d-13b2-46b4-ba97-dec28133ea80" = true
+[6b71841d-13b2-46b4-ba97-dec28133ea80]
+description = "500 is a single D"
+include = true
 
-# 900, being 1000 - 100, is CM
-"432de891-7fd6-4748-a7f6-156082eeca2f" = true
+[432de891-7fd6-4748-a7f6-156082eeca2f]
+description = "900, being 1000 - 100, is CM"
+include = true
 
-# 1000 is a single M
-"e6de6d24-f668-41c0-88d7-889c0254d173" = true
+[e6de6d24-f668-41c0-88d7-889c0254d173]
+description = "1000 is a single M"
+include = true
 
-# 3000 is three M's
-"bb550038-d4eb-4be2-a9ce-f21961ac3bc6" = true
+[bb550038-d4eb-4be2-a9ce-f21961ac3bc6]
+description = "3000 is three M's"
+include = true

--- a/exercises/practice/run-length-encoding/.meta/tests.toml
+++ b/exercises/practice/run-length-encoding/.meta/tests.toml
@@ -1,40 +1,55 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty string
-"ad53b61b-6ffc-422f-81a6-61f7df92a231" = true
+[ad53b61b-6ffc-422f-81a6-61f7df92a231]
+description = "empty string"
+include = true
 
-# single characters only are encoded without count
-"52012823-b7e6-4277-893c-5b96d42f82de" = true
+[52012823-b7e6-4277-893c-5b96d42f82de]
+description = "single characters only are encoded without count"
+include = true
 
-# string with no single characters
-"b7868492-7e3a-415f-8da3-d88f51f80409" = true
+[b7868492-7e3a-415f-8da3-d88f51f80409]
+description = "string with no single characters"
+include = true
 
-# single characters mixed with repeated characters
-"859b822b-6e9f-44d6-9c46-6091ee6ae358" = true
+[859b822b-6e9f-44d6-9c46-6091ee6ae358]
+description = "single characters mixed with repeated characters"
+include = true
 
-# multiple whitespace mixed in string
-"1b34de62-e152-47be-bc88-469746df63b3" = true
+[1b34de62-e152-47be-bc88-469746df63b3]
+description = "multiple whitespace mixed in string"
+include = true
 
-# lowercase characters
-"abf176e2-3fbd-40ad-bb2f-2dd6d4df721a" = true
+[abf176e2-3fbd-40ad-bb2f-2dd6d4df721a]
+description = "lowercase characters"
+include = true
 
-# empty string
-"7ec5c390-f03c-4acf-ac29-5f65861cdeb5" = true
+[7ec5c390-f03c-4acf-ac29-5f65861cdeb5]
+description = "empty string"
+include = true
 
-# single characters only
-"ad23f455-1ac2-4b0e-87d0-b85b10696098" = true
+[ad23f455-1ac2-4b0e-87d0-b85b10696098]
+description = "single characters only"
+include = true
 
-# string with no single characters
-"21e37583-5a20-4a0e-826c-3dee2c375f54" = true
+[21e37583-5a20-4a0e-826c-3dee2c375f54]
+description = "string with no single characters"
+include = true
 
-# single characters with repeated characters
-"1389ad09-c3a8-4813-9324-99363fba429c" = true
+[1389ad09-c3a8-4813-9324-99363fba429c]
+description = "single characters with repeated characters"
+include = true
 
-# multiple whitespace mixed in string
-"3f8e3c51-6aca-4670-b86c-a213bf4706b0" = true
+[3f8e3c51-6aca-4670-b86c-a213bf4706b0]
+description = "multiple whitespace mixed in string"
+include = true
 
-# lower case string
-"29f721de-9aad-435f-ba37-7662df4fb551" = true
+[29f721de-9aad-435f-ba37-7662df4fb551]
+description = "lower case string"
+include = true
 
-# encode followed by decode gives original string
-"2a762efd-8695-4e04-b0d6-9736899fbc16" = true
+[2a762efd-8695-4e04-b0d6-9736899fbc16]
+description = "encode followed by decode gives original string"
+include = true

--- a/exercises/practice/say/.meta/tests.toml
+++ b/exercises/practice/say/.meta/tests.toml
@@ -1,46 +1,63 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# zero
-"5d22a120-ba0c-428c-bd25-8682235d83e8" = true
+[5d22a120-ba0c-428c-bd25-8682235d83e8]
+description = "zero"
+include = true
 
-# one
-"9b5eed77-dbf6-439d-b920-3f7eb58928f6" = true
+[9b5eed77-dbf6-439d-b920-3f7eb58928f6]
+description = "one"
+include = true
 
-# fourteen
-"7c499be1-612e-4096-a5e1-43b2f719406d" = true
+[7c499be1-612e-4096-a5e1-43b2f719406d]
+description = "fourteen"
+include = true
 
-# twenty
-"f541dd8e-f070-4329-92b4-b7ce2fcf06b4" = true
+[f541dd8e-f070-4329-92b4-b7ce2fcf06b4]
+description = "twenty"
+include = true
 
-# twenty-two
-"d78601eb-4a84-4bfa-bf0e-665aeb8abe94" = true
+[d78601eb-4a84-4bfa-bf0e-665aeb8abe94]
+description = "twenty-two"
+include = true
 
-# one hundred
-"e417d452-129e-4056-bd5b-6eb1df334dce" = true
+[e417d452-129e-4056-bd5b-6eb1df334dce]
+description = "one hundred"
+include = true
 
-# one hundred twenty-three
-"d6924f30-80ba-4597-acf6-ea3f16269da8" = true
+[d6924f30-80ba-4597-acf6-ea3f16269da8]
+description = "one hundred twenty-three"
+include = true
 
-# one thousand
-"3d83da89-a372-46d3-b10d-de0c792432b3" = true
+[3d83da89-a372-46d3-b10d-de0c792432b3]
+description = "one thousand"
+include = true
 
-# one thousand two hundred thirty-four
-"865af898-1d5b-495f-8ff0-2f06d3c73709" = true
+[865af898-1d5b-495f-8ff0-2f06d3c73709]
+description = "one thousand two hundred thirty-four"
+include = true
 
-# one million
-"b6a3f442-266e-47a3-835d-7f8a35f6cf7f" = true
+[b6a3f442-266e-47a3-835d-7f8a35f6cf7f]
+description = "one million"
+include = true
 
-# one million two thousand three hundred forty-five
-"2cea9303-e77e-4212-b8ff-c39f1978fc70" = true
+[2cea9303-e77e-4212-b8ff-c39f1978fc70]
+description = "one million two thousand three hundred forty-five"
+include = true
 
-# one billion
-"3e240eeb-f564-4b80-9421-db123f66a38f" = true
+[3e240eeb-f564-4b80-9421-db123f66a38f]
+description = "one billion"
+include = true
 
-# a big number
-"9a43fed1-c875-4710-8286-5065d73b8a9e" = true
+[9a43fed1-c875-4710-8286-5065d73b8a9e]
+description = "a big number"
+include = true
 
-# numbers below zero are out of range
-"49a6a17b-084e-423e-994d-a87c0ecc05ef" = true
+[49a6a17b-084e-423e-994d-a87c0ecc05ef]
+description = "numbers below zero are out of range"
+include = true
 
-# numbers above 999,999,999,999 are out of range
-"4d6492eb-5853-4d16-9d34-b0f61b261fd9" = true
+[4d6492eb-5853-4d16-9d34-b0f61b261fd9]
+description = "numbers above 999,999,999,999 are out of range"
+include = true

--- a/exercises/practice/scrabble-score/.meta/tests.toml
+++ b/exercises/practice/scrabble-score/.meta/tests.toml
@@ -1,34 +1,47 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# lowercase letter
-"f46cda29-1ca5-4ef2-bd45-388a767e3db2" = true
+[f46cda29-1ca5-4ef2-bd45-388a767e3db2]
+description = "lowercase letter"
+include = true
 
-# uppercase letter
-"f7794b49-f13e-45d1-a933-4e48459b2201" = true
+[f7794b49-f13e-45d1-a933-4e48459b2201]
+description = "uppercase letter"
+include = true
 
-# valuable letter
-"eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa" = true
+[eaba9c76-f9fa-49c9-a1b0-d1ba3a5b31fa]
+description = "valuable letter"
+include = true
 
-# short word
-"f3c8c94e-bb48-4da2-b09f-e832e103151e" = true
+[f3c8c94e-bb48-4da2-b09f-e832e103151e]
+description = "short word"
+include = true
 
-# short, valuable word
-"71e3d8fa-900d-4548-930e-68e7067c4615" = true
+[71e3d8fa-900d-4548-930e-68e7067c4615]
+description = "short, valuable word"
+include = true
 
-# medium word
-"d3088ad9-570c-4b51-8764-c75d5a430e99" = true
+[d3088ad9-570c-4b51-8764-c75d5a430e99]
+description = "medium word"
+include = true
 
-# medium, valuable word
-"fa20c572-ad86-400a-8511-64512daac352" = true
+[fa20c572-ad86-400a-8511-64512daac352]
+description = "medium, valuable word"
+include = true
 
-# long, mixed-case word
-"9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967" = true
+[9336f0ba-9c2b-4fa0-bd1c-2e2d328cf967]
+description = "long, mixed-case word"
+include = true
 
-# english-like word
-"1e34e2c3-e444-4ea7-b598-3c2b46fd2c10" = true
+[1e34e2c3-e444-4ea7-b598-3c2b46fd2c10]
+description = "english-like word"
+include = true
 
-# empty input
-"4efe3169-b3b6-4334-8bae-ff4ef24a7e4f" = true
+[4efe3169-b3b6-4334-8bae-ff4ef24a7e4f]
+description = "empty input"
+include = true
 
-# entire alphabet available
-"3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7" = true
+[3b305c1c-f260-4e15-a5b5-cb7d3ea7c3d7]
+description = "entire alphabet available"
+include = true

--- a/exercises/practice/series/.meta/tests.toml
+++ b/exercises/practice/series/.meta/tests.toml
@@ -1,31 +1,43 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# slices of one from one
-"7ae7a46a-d992-4c2a-9c15-a112d125ebad" = true
+[7ae7a46a-d992-4c2a-9c15-a112d125ebad]
+description = "slices of one from one"
+include = true
 
-# slices of one from two
-"3143b71d-f6a5-4221-aeae-619f906244d2" = true
+[3143b71d-f6a5-4221-aeae-619f906244d2]
+description = "slices of one from two"
+include = true
 
-# slices of two
-"dbb68ff5-76c5-4ccd-895a-93dbec6d5805" = true
+[dbb68ff5-76c5-4ccd-895a-93dbec6d5805]
+description = "slices of two"
+include = true
 
-# slices of two overlap
-"19bbea47-c987-4e11-a7d1-e103442adf86" = true
+[19bbea47-c987-4e11-a7d1-e103442adf86]
+description = "slices of two overlap"
+include = true
 
-# slices can include duplicates
-"8e17148d-ba0a-4007-a07f-d7f87015d84c" = true
+[8e17148d-ba0a-4007-a07f-d7f87015d84c]
+description = "slices can include duplicates"
+include = true
 
-# slices of a long series
-"bd5b085e-f612-4f81-97a8-6314258278b0" = true
+[bd5b085e-f612-4f81-97a8-6314258278b0]
+description = "slices of a long series"
+include = true
 
-# slice length is too large
-"6d235d85-46cf-4fae-9955-14b6efef27cd" = true
+[6d235d85-46cf-4fae-9955-14b6efef27cd]
+description = "slice length is too large"
+include = true
 
-# slice length cannot be zero
-"d34004ad-8765-4c09-8ba1-ada8ce776806" = true
+[d34004ad-8765-4c09-8ba1-ada8ce776806]
+description = "slice length cannot be zero"
+include = true
 
-# slice length cannot be negative
-"10ab822d-8410-470a-a85d-23fbeb549e54" = true
+[10ab822d-8410-470a-a85d-23fbeb549e54]
+description = "slice length cannot be negative"
+include = true
 
-# empty series is invalid
-"c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2" = true
+[c7ed0812-0e4b-4bf3-99c4-28cbbfc246a2]
+description = "empty series is invalid"
+include = true

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -1,25 +1,35 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# age on Earth
-"84f609af-5a91-4d68-90a3-9e32d8a5cd34" = true
+[84f609af-5a91-4d68-90a3-9e32d8a5cd34]
+description = "age on Earth"
+include = true
 
-# age on Mercury
-"ca20c4e9-6054-458c-9312-79679ffab40b" = true
+[ca20c4e9-6054-458c-9312-79679ffab40b]
+description = "age on Mercury"
+include = true
 
-# age on Venus
-"502c6529-fd1b-41d3-8fab-65e03082b024" = true
+[502c6529-fd1b-41d3-8fab-65e03082b024]
+description = "age on Venus"
+include = true
 
-# age on Mars
-"9ceadf5e-a0d5-4388-9d40-2c459227ceb8" = true
+[9ceadf5e-a0d5-4388-9d40-2c459227ceb8]
+description = "age on Mars"
+include = true
 
-# age on Jupiter
-"42927dc3-fe5e-4f76-a5b5-f737fc19bcde" = true
+[42927dc3-fe5e-4f76-a5b5-f737fc19bcde]
+description = "age on Jupiter"
+include = true
 
-# age on Saturn
-"8469b332-7837-4ada-b27c-00ee043ebcad" = true
+[8469b332-7837-4ada-b27c-00ee043ebcad]
+description = "age on Saturn"
+include = true
 
-# age on Uranus
-"999354c1-76f8-4bb5-a672-f317b6436743" = true
+[999354c1-76f8-4bb5-a672-f317b6436743]
+description = "age on Uranus"
+include = true
 
-# age on Neptune
-"80096d30-a0d4-4449-903e-a381178355d8" = true
+[80096d30-a0d4-4449-903e-a381178355d8]
+description = "age on Neptune"
+include = true

--- a/exercises/practice/sublist/.meta/tests.toml
+++ b/exercises/practice/sublist/.meta/tests.toml
@@ -1,52 +1,71 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty lists
-"97319c93-ebc5-47ab-a022-02a1980e1d29" = true
+[97319c93-ebc5-47ab-a022-02a1980e1d29]
+description = "empty lists"
+include = true
 
-# empty list within non empty list
-"de27dbd4-df52-46fe-a336-30be58457382" = true
+[de27dbd4-df52-46fe-a336-30be58457382]
+description = "empty list within non empty list"
+include = true
 
-# non empty list contains empty list
-"5487cfd1-bc7d-429f-ac6f-1177b857d4fb" = true
+[5487cfd1-bc7d-429f-ac6f-1177b857d4fb]
+description = "non empty list contains empty list"
+include = true
 
-# list equals itself
-"1f390b47-f6b2-4a93-bc23-858ba5dda9a6" = true
+[1f390b47-f6b2-4a93-bc23-858ba5dda9a6]
+description = "list equals itself"
+include = true
 
-# different lists
-"7ed2bfb2-922b-4363-ae75-f3a05e8274f5" = true
+[7ed2bfb2-922b-4363-ae75-f3a05e8274f5]
+description = "different lists"
+include = true
 
-# false start
-"3b8a2568-6144-4f06-b0a1-9d266b365341" = true
+[3b8a2568-6144-4f06-b0a1-9d266b365341]
+description = "false start"
+include = true
 
-# consecutive
-"dc39ed58-6311-4814-be30-05a64bc8d9b1" = true
+[dc39ed58-6311-4814-be30-05a64bc8d9b1]
+description = "consecutive"
+include = true
 
-# sublist at start
-"d1270dab-a1ce-41aa-b29d-b3257241ac26" = true
+[d1270dab-a1ce-41aa-b29d-b3257241ac26]
+description = "sublist at start"
+include = true
 
-# sublist in middle
-"81f3d3f7-4f25-4ada-bcdc-897c403de1b6" = true
+[81f3d3f7-4f25-4ada-bcdc-897c403de1b6]
+description = "sublist in middle"
+include = true
 
-# sublist at end
-"43bcae1e-a9cf-470e-923e-0946e04d8fdd" = true
+[43bcae1e-a9cf-470e-923e-0946e04d8fdd]
+description = "sublist at end"
+include = true
 
-# at start of superlist
-"76cf99ed-0ff0-4b00-94af-4dfb43fe5caa" = true
+[76cf99ed-0ff0-4b00-94af-4dfb43fe5caa]
+description = "at start of superlist"
+include = true
 
-# in middle of superlist
-"b83989ec-8bdf-4655-95aa-9f38f3e357fd" = true
+[b83989ec-8bdf-4655-95aa-9f38f3e357fd]
+description = "in middle of superlist"
+include = true
 
-# at end of superlist
-"26f9f7c3-6cf6-4610-984a-662f71f8689b" = true
+[26f9f7c3-6cf6-4610-984a-662f71f8689b]
+description = "at end of superlist"
+include = true
 
-# first list missing element from second list
-"0a6db763-3588-416a-8f47-76b1cedde31e" = true
+[0a6db763-3588-416a-8f47-76b1cedde31e]
+description = "first list missing element from second list"
+include = true
 
-# second list missing element from first list
-"83ffe6d8-a445-4a3c-8795-1e51a95e65c3" = true
+[83ffe6d8-a445-4a3c-8795-1e51a95e65c3]
+description = "second list missing element from first list"
+include = true
 
-# order matters to a list
-"0d7ee7c1-0347-45c8-9ef5-b88db152b30b" = true
+[0d7ee7c1-0347-45c8-9ef5-b88db152b30b]
+description = "order matters to a list"
+include = true
 
-# same digits but different numbers
-"5f47ce86-944e-40f9-9f31-6368aad70aa6" = true
+[5f47ce86-944e-40f9-9f31-6368aad70aa6]
+description = "same digits but different numbers"
+include = true

--- a/exercises/practice/sum-of-multiples/.meta/tests.toml
+++ b/exercises/practice/sum-of-multiples/.meta/tests.toml
@@ -1,49 +1,67 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no multiples within limit
-"54aaab5a-ce86-4edc-8b40-d3ab2400a279" = true
+[54aaab5a-ce86-4edc-8b40-d3ab2400a279]
+description = "no multiples within limit"
+include = true
 
-# one factor has multiples within limit
-"361e4e50-c89b-4f60-95ef-5bc5c595490a" = true
+[361e4e50-c89b-4f60-95ef-5bc5c595490a]
+description = "one factor has multiples within limit"
+include = true
 
-# more than one multiple within limit
-"e644e070-040e-4ae0-9910-93c69fc3f7ce" = true
+[e644e070-040e-4ae0-9910-93c69fc3f7ce]
+description = "more than one multiple within limit"
+include = true
 
-# more than one factor with multiples within limit
-"607d6eb9-535c-41ce-91b5-3a61da3fa57f" = true
+[607d6eb9-535c-41ce-91b5-3a61da3fa57f]
+description = "more than one factor with multiples within limit"
+include = true
 
-# each multiple is only counted once
-"f47e8209-c0c5-4786-b07b-dc273bf86b9b" = true
+[f47e8209-c0c5-4786-b07b-dc273bf86b9b]
+description = "each multiple is only counted once"
+include = true
 
-# a much larger limit
-"28c4b267-c980-4054-93e9-07723db615ac" = true
+[28c4b267-c980-4054-93e9-07723db615ac]
+description = "a much larger limit"
+include = true
 
-# three factors
-"09c4494d-ff2d-4e0f-8421-f5532821ee12" = true
+[09c4494d-ff2d-4e0f-8421-f5532821ee12]
+description = "three factors"
+include = true
 
-# factors not relatively prime
-"2d0d5faa-f177-4ad6-bde9-ebb865083751" = true
+[2d0d5faa-f177-4ad6-bde9-ebb865083751]
+description = "factors not relatively prime"
+include = true
 
-# some pairs of factors relatively prime and some not
-"ece8f2e8-96aa-4166-bbb7-6ce71261e354" = true
+[ece8f2e8-96aa-4166-bbb7-6ce71261e354]
+description = "some pairs of factors relatively prime and some not"
+include = true
 
-# one factor is a multiple of another
-"624fdade-6ffb-400e-8472-456a38c171c0" = true
+[624fdade-6ffb-400e-8472-456a38c171c0]
+description = "one factor is a multiple of another"
+include = true
 
-# much larger factors
-"949ee7eb-db51-479c-b5cb-4a22b40ac057" = true
+[949ee7eb-db51-479c-b5cb-4a22b40ac057]
+description = "much larger factors"
+include = true
 
-# all numbers are multiples of 1
-"41093673-acbd-482c-ab80-d00a0cbedecd" = true
+[41093673-acbd-482c-ab80-d00a0cbedecd]
+description = "all numbers are multiples of 1"
+include = true
 
-# no factors means an empty sum
-"1730453b-baaa-438e-a9c2-d754497b2a76" = true
+[1730453b-baaa-438e-a9c2-d754497b2a76]
+description = "no factors means an empty sum"
+include = true
 
-# the only multiple of 0 is 0
-"214a01e9-f4bf-45bb-80f1-1dce9fbb0310" = true
+[214a01e9-f4bf-45bb-80f1-1dce9fbb0310]
+description = "the only multiple of 0 is 0"
+include = true
 
-# the factor 0 does not affect the sum of multiples of other factors
-"c423ae21-a0cb-4ec7-aeb1-32971af5b510" = true
+[c423ae21-a0cb-4ec7-aeb1-32971af5b510]
+description = "the factor 0 does not affect the sum of multiples of other factors"
+include = true
 
-# solutions using include-exclude must extend to cardinality greater than 3
-"17053ba9-112f-4ac0-aadb-0519dd836342" = true
+[17053ba9-112f-4ac0-aadb-0519dd836342]
+description = "solutions using include-exclude must extend to cardinality greater than 3"
+include = true

--- a/exercises/practice/transpose/.meta/tests.toml
+++ b/exercises/practice/transpose/.meta/tests.toml
@@ -1,34 +1,47 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# empty string
-"404b7262-c050-4df0-a2a2-0cb06cd6a821" = true
+[404b7262-c050-4df0-a2a2-0cb06cd6a821]
+description = "empty string"
+include = true
 
-# two characters in a row
-"a89ce8a3-c940-4703-a688-3ea39412fbcb" = true
+[a89ce8a3-c940-4703-a688-3ea39412fbcb]
+description = "two characters in a row"
+include = true
 
-# two characters in a column
-"855bb6ae-4180-457c-abd0-ce489803ce98" = true
+[855bb6ae-4180-457c-abd0-ce489803ce98]
+description = "two characters in a column"
+include = true
 
-# simple
-"5ceda1c0-f940-441c-a244-0ced197769c8" = true
+[5ceda1c0-f940-441c-a244-0ced197769c8]
+description = "simple"
+include = true
 
-# single line
-"a54675dd-ae7d-4a58-a9c4-0c20e99a7c1f" = true
+[a54675dd-ae7d-4a58-a9c4-0c20e99a7c1f]
+description = "single line"
+include = true
 
-# first line longer than second line
-"0dc2ec0b-549d-4047-aeeb-8029fec8d5c5" = true
+[0dc2ec0b-549d-4047-aeeb-8029fec8d5c5]
+description = "first line longer than second line"
+include = true
 
-# second line longer than first line
-"984e2ec3-b3d3-4b53-8bd6-96f5ef404102" = true
+[984e2ec3-b3d3-4b53-8bd6-96f5ef404102]
+description = "second line longer than first line"
+include = true
 
-# mixed line length
-"eccd3784-45f0-4a3f-865a-360cb323d314" = true
+[eccd3784-45f0-4a3f-865a-360cb323d314]
+description = "mixed line length"
+include = true
 
-# square
-"85b96b3f-d00c-4f80-8ca2-c8a5c9216c2d" = true
+[85b96b3f-d00c-4f80-8ca2-c8a5c9216c2d]
+description = "square"
+include = true
 
-# rectangle
-"b9257625-7a53-4748-8863-e08e9d27071d" = true
+[b9257625-7a53-4748-8863-e08e9d27071d]
+description = "rectangle"
+include = true
 
-# triangle
-"b80badc9-057e-4543-bd07-ce1296a1ea2c" = true
+[b80badc9-057e-4543-bd07-ce1296a1ea2c]
+description = "triangle"
+include = true

--- a/exercises/practice/triangle/.meta/tests.toml
+++ b/exercises/practice/triangle/.meta/tests.toml
@@ -1,58 +1,79 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# all sides are equal
-"8b2c43ac-7257-43f9-b552-7631a91988af" = true
+[8b2c43ac-7257-43f9-b552-7631a91988af]
+description = "all sides are equal"
+include = true
 
-# any side is unequal
-"33eb6f87-0498-4ccf-9573-7f8c3ce92b7b" = true
+[33eb6f87-0498-4ccf-9573-7f8c3ce92b7b]
+description = "any side is unequal"
+include = true
 
-# no sides are equal
-"c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87" = true
+[c6585b7d-a8c0-4ad8-8a34-e21d36f7ad87]
+description = "no sides are equal"
+include = true
 
-# all zero sides is not a triangle
-"16e8ceb0-eadb-46d1-b892-c50327479251" = true
+[16e8ceb0-eadb-46d1-b892-c50327479251]
+description = "all zero sides is not a triangle"
+include = true
 
-# sides may be floats
-"3022f537-b8e5-4cc1-8f12-fd775827a00c" = true
+[3022f537-b8e5-4cc1-8f12-fd775827a00c]
+description = "sides may be floats"
+include = true
 
-# last two sides are equal
-"cbc612dc-d75a-4c1c-87fc-e2d5edd70b71" = true
+[cbc612dc-d75a-4c1c-87fc-e2d5edd70b71]
+description = "last two sides are equal"
+include = true
 
-# first two sides are equal
-"e388ce93-f25e-4daf-b977-4b7ede992217" = true
+[e388ce93-f25e-4daf-b977-4b7ede992217]
+description = "first two sides are equal"
+include = true
 
-# first and last sides are equal
-"d2080b79-4523-4c3f-9d42-2da6e81ab30f" = true
+[d2080b79-4523-4c3f-9d42-2da6e81ab30f]
+description = "first and last sides are equal"
+include = true
 
-# equilateral triangles are also isosceles
-"8d71e185-2bd7-4841-b7e1-71689a5491d8" = true
+[8d71e185-2bd7-4841-b7e1-71689a5491d8]
+description = "equilateral triangles are also isosceles"
+include = true
 
-# no sides are equal
-"840ed5f8-366f-43c5-ac69-8f05e6f10bbb" = true
+[840ed5f8-366f-43c5-ac69-8f05e6f10bbb]
+description = "no sides are equal"
+include = true
 
-# first triangle inequality violation
-"2eba0cfb-6c65-4c40-8146-30b608905eae" = true
+[2eba0cfb-6c65-4c40-8146-30b608905eae]
+description = "first triangle inequality violation"
+include = true
 
-# second triangle inequality violation
-"278469cb-ac6b-41f0-81d4-66d9b828f8ac" = true
+[278469cb-ac6b-41f0-81d4-66d9b828f8ac]
+description = "second triangle inequality violation"
+include = true
 
-# third triangle inequality violation
-"90efb0c7-72bb-4514-b320-3a3892e278ff" = true
+[90efb0c7-72bb-4514-b320-3a3892e278ff]
+description = "third triangle inequality violation"
+include = true
 
-# sides may be floats
-"adb4ee20-532f-43dc-8d31-e9271b7ef2bc" = true
+[adb4ee20-532f-43dc-8d31-e9271b7ef2bc]
+description = "sides may be floats"
+include = true
 
-# no sides are equal
-"e8b5f09c-ec2e-47c1-abec-f35095733afb" = true
+[e8b5f09c-ec2e-47c1-abec-f35095733afb]
+description = "no sides are equal"
+include = true
 
-# all sides are equal
-"2510001f-b44d-4d18-9872-2303e7977dc1" = true
+[2510001f-b44d-4d18-9872-2303e7977dc1]
+description = "all sides are equal"
+include = true
 
-# two sides are equal
-"c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e" = true
+[c6e15a92-90d9-4fb3-90a2-eef64f8d3e1e]
+description = "two sides are equal"
+include = true
 
-# may not violate triangle inequality
-"70ad5154-0033-48b7-af2c-b8d739cd9fdc" = true
+[70ad5154-0033-48b7-af2c-b8d739cd9fdc]
+description = "may not violate triangle inequality"
+include = true
 
-# sides may be floats
-"26d9d59d-f8f1-40d3-ad58-ae4d54123d7d" = true
+[26d9d59d-f8f1-40d3-ad58-ae4d54123d7d]
+description = "sides may be floats"
+include = true

--- a/exercises/practice/twelve-days/.meta/tests.toml
+++ b/exercises/practice/twelve-days/.meta/tests.toml
@@ -1,46 +1,63 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# first day a partridge in a pear tree
-"c0b5a5e6-c89d-49b1-a6b2-9f523bff33f7" = true
+[c0b5a5e6-c89d-49b1-a6b2-9f523bff33f7]
+description = "first day a partridge in a pear tree"
+include = true
 
-# second day two turtle doves
-"1c64508a-df3d-420a-b8e1-fe408847854a" = true
+[1c64508a-df3d-420a-b8e1-fe408847854a]
+description = "second day two turtle doves"
+include = true
 
-# third day three french hens
-"a919e09c-75b2-4e64-bb23-de4a692060a8" = true
+[a919e09c-75b2-4e64-bb23-de4a692060a8]
+description = "third day three french hens"
+include = true
 
-# fourth day four calling birds
-"9bed8631-ec60-4894-a3bb-4f0ec9fbe68d" = true
+[9bed8631-ec60-4894-a3bb-4f0ec9fbe68d]
+description = "fourth day four calling birds"
+include = true
 
-# fifth day five gold rings
-"cf1024f0-73b6-4545-be57-e9cea565289a" = true
+[cf1024f0-73b6-4545-be57-e9cea565289a]
+description = "fifth day five gold rings"
+include = true
 
-# sixth day six geese-a-laying
-"50bd3393-868a-4f24-a618-68df3d02ff04" = true
+[50bd3393-868a-4f24-a618-68df3d02ff04]
+description = "sixth day six geese-a-laying"
+include = true
 
-# seventh day seven swans-a-swimming
-"8f29638c-9bf1-4680-94be-e8b84e4ade83" = true
+[8f29638c-9bf1-4680-94be-e8b84e4ade83]
+description = "seventh day seven swans-a-swimming"
+include = true
 
-# eighth day eight maids-a-milking
-"7038d6e1-e377-47ad-8c37-10670a05bc05" = true
+[7038d6e1-e377-47ad-8c37-10670a05bc05]
+description = "eighth day eight maids-a-milking"
+include = true
 
-# ninth day nine ladies dancing
-"37a800a6-7a56-4352-8d72-0f51eb37cfe8" = true
+[37a800a6-7a56-4352-8d72-0f51eb37cfe8]
+description = "ninth day nine ladies dancing"
+include = true
 
-# tenth day ten lords-a-leaping
-"10b158aa-49ff-4b2d-afc3-13af9133510d" = true
+[10b158aa-49ff-4b2d-afc3-13af9133510d]
+description = "tenth day ten lords-a-leaping"
+include = true
 
-# eleventh day eleven pipers piping
-"08d7d453-f2ba-478d-8df0-d39ea6a4f457" = true
+[08d7d453-f2ba-478d-8df0-d39ea6a4f457]
+description = "eleventh day eleven pipers piping"
+include = true
 
-# twelfth day twelve drummers drumming
-"0620fea7-1704-4e48-b557-c05bf43967f0" = true
+[0620fea7-1704-4e48-b557-c05bf43967f0]
+description = "twelfth day twelve drummers drumming"
+include = true
 
-# recites first three verses of the song
-"da8b9013-b1e8-49df-b6ef-ddec0219e398" = true
+[da8b9013-b1e8-49df-b6ef-ddec0219e398]
+description = "recites first three verses of the song"
+include = true
 
-# recites three verses from the middle of the song
-"c095af0d-3137-4653-ad32-bfb899eda24c" = true
+[c095af0d-3137-4653-ad32-bfb899eda24c]
+description = "recites three verses from the middle of the song"
+include = true
 
-# recites the whole song
-"20921bc9-cc52-4627-80b3-198cbbfcf9b7" = true
+[20921bc9-cc52-4627-80b3-198cbbfcf9b7]
+description = "recites the whole song"
+include = true

--- a/exercises/practice/two-fer/.meta/tests.toml
+++ b/exercises/practice/two-fer/.meta/tests.toml
@@ -1,10 +1,15 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# no name given
-"1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce" = true
+[1cf3e15a-a3d7-4a87-aeb3-ba1b43bc8dce]
+description = "no name given"
+include = true
 
-# a name given
-"b4c6dbb8-b4fb-42c2-bafd-10785abe7709" = true
+[b4c6dbb8-b4fb-42c2-bafd-10785abe7709]
+description = "a name given"
+include = true
 
-# another name given
-"3549048d-1a6e-4653-9a79-b0bda163e8d5" = true
+[3549048d-1a6e-4653-9a79-b0bda163e8d5]
+description = "another name given"
+include = true

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -1,40 +1,55 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# count one word
-"61559d5f-2cad-48fb-af53-d3973a9ee9ef" = true
+[61559d5f-2cad-48fb-af53-d3973a9ee9ef]
+description = "count one word"
+include = true
 
-# count one of each word
-"5abd53a3-1aed-43a4-a15a-29f88c09cbbd" = true
+[5abd53a3-1aed-43a4-a15a-29f88c09cbbd]
+description = "count one of each word"
+include = true
 
-# multiple occurrences of a word
-"2a3091e5-952e-4099-9fac-8f85d9655c0e" = true
+[2a3091e5-952e-4099-9fac-8f85d9655c0e]
+description = "multiple occurrences of a word"
+include = true
 
-# handles cramped lists
-"e81877ae-d4da-4af4-931c-d923cd621ca6" = true
+[e81877ae-d4da-4af4-931c-d923cd621ca6]
+description = "handles cramped lists"
+include = true
 
-# handles expanded lists
-"7349f682-9707-47c0-a9af-be56e1e7ff30" = true
+[7349f682-9707-47c0-a9af-be56e1e7ff30]
+description = "handles expanded lists"
+include = true
 
-# ignore punctuation
-"a514a0f2-8589-4279-8892-887f76a14c82" = true
+[a514a0f2-8589-4279-8892-887f76a14c82]
+description = "ignore punctuation"
+include = true
 
-# include numbers
-"d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e" = true
+[d2e5cee6-d2ec-497b-bdc9-3ebe092ce55e]
+description = "include numbers"
+include = true
 
-# normalize case
-"dac6bc6a-21ae-4954-945d-d7f716392dbf" = true
+[dac6bc6a-21ae-4954-945d-d7f716392dbf]
+description = "normalize case"
+include = true
 
-# with apostrophes
-"4185a902-bdb0-4074-864c-f416e42a0f19" = true
+[4185a902-bdb0-4074-864c-f416e42a0f19]
+description = "with apostrophes"
+include = true
 
-# with quotations
-"be72af2b-8afe-4337-b151-b297202e4a7b" = true
+[be72af2b-8afe-4337-b151-b297202e4a7b]
+description = "with quotations"
+include = true
 
-# substrings from the beginning
-"8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6" = true
+[8d6815fe-8a51-4a65-96f9-2fb3f6dc6ed6]
+description = "substrings from the beginning"
+include = true
 
-# multiple spaces not detected as a word
-"c5f4ef26-f3f7-4725-b314-855c04fb4c13" = true
+[c5f4ef26-f3f7-4725-b314-855c04fb4c13]
+description = "multiple spaces not detected as a word"
+include = true
 
-# alternating word separators not detected as a word
-"50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360" = true
+[50176e8a-fe8e-4f4c-b6b6-aa9cf8f20360]
+description = "alternating word separators not detected as a word"
+include = true

--- a/exercises/practice/wordy/.meta/tests.toml
+++ b/exercises/practice/wordy/.meta/tests.toml
@@ -1,70 +1,95 @@
-[canonical-tests]
+# This is an auto-generated file. Regular comments will be removed when this
+# file is regenerated. Regenerating will not touch any manually added keys,
+# so comments can be added in a "comment" key.
 
-# just a number
-"88bf4b28-0de3-4883-93c7-db1b14aa806e" = true
+[88bf4b28-0de3-4883-93c7-db1b14aa806e]
+description = "just a number"
+include = true
 
-# addition
-"bb8c655c-cf42-4dfc-90e0-152fcfd8d4e0" = true
+[bb8c655c-cf42-4dfc-90e0-152fcfd8d4e0]
+description = "addition"
+include = true
 
-# more addition
-"79e49e06-c5ae-40aa-a352-7a3a01f70015" = true
+[79e49e06-c5ae-40aa-a352-7a3a01f70015]
+description = "more addition"
+include = true
 
-# addition with negative numbers
-"b345dbe0-f733-44e1-863c-5ae3568f3803" = true
+[b345dbe0-f733-44e1-863c-5ae3568f3803]
+description = "addition with negative numbers"
+include = true
 
-# large addition
-"cd070f39-c4cc-45c4-97fb-1be5e5846f87" = true
+[cd070f39-c4cc-45c4-97fb-1be5e5846f87]
+description = "large addition"
+include = true
 
-# subtraction
-"0d86474a-cd93-4649-a4fa-f6109a011191" = true
+[0d86474a-cd93-4649-a4fa-f6109a011191]
+description = "subtraction"
+include = true
 
-# multiplication
-"30bc8395-5500-4712-a0cf-1d788a529be5" = true
+[30bc8395-5500-4712-a0cf-1d788a529be5]
+description = "multiplication"
+include = true
 
-# division
-"34c36b08-8605-4217-bb57-9a01472c427f" = true
+[34c36b08-8605-4217-bb57-9a01472c427f]
+description = "division"
+include = true
 
-# multiple additions
-"da6d2ce4-fb94-4d26-8f5f-b078adad0596" = true
+[da6d2ce4-fb94-4d26-8f5f-b078adad0596]
+description = "multiple additions"
+include = true
 
-# addition and subtraction
-"7fd74c50-9911-4597-be09-8de7f2fea2bb" = true
+[7fd74c50-9911-4597-be09-8de7f2fea2bb]
+description = "addition and subtraction"
+include = true
 
-# multiple subtraction
-"b120ffd5-bad6-4e22-81c8-5512e8faf905" = true
+[b120ffd5-bad6-4e22-81c8-5512e8faf905]
+description = "multiple subtraction"
+include = true
 
-# subtraction then addition
-"4f4a5749-ef0c-4f60-841f-abcfaf05d2ae" = true
+[4f4a5749-ef0c-4f60-841f-abcfaf05d2ae]
+description = "subtraction then addition"
+include = true
 
-# multiple multiplication
-"312d908c-f68f-42c9-aa75-961623cc033f" = true
+[312d908c-f68f-42c9-aa75-961623cc033f]
+description = "multiple multiplication"
+include = true
 
-# addition and multiplication
-"38e33587-8940-4cc1-bc28-bfd7e3966276" = true
+[38e33587-8940-4cc1-bc28-bfd7e3966276]
+description = "addition and multiplication"
+include = true
 
-# multiple division
-"3c854f97-9311-46e8-b574-92b60d17d394" = true
+[3c854f97-9311-46e8-b574-92b60d17d394]
+description = "multiple division"
+include = true
 
-# unknown operation
-"3ad3e433-8af7-41ec-aa9b-97b42ab49357" = true
+[3ad3e433-8af7-41ec-aa9b-97b42ab49357]
+description = "unknown operation"
+include = true
 
-# Non math question
-"8a7e85a8-9e7b-4d46-868f-6d759f4648f8" = true
+[8a7e85a8-9e7b-4d46-868f-6d759f4648f8]
+description = "Non math question"
+include = true
 
-# reject problem missing an operand
-"42d78b5f-dbd7-4cdb-8b30-00f794bb24cf" = true
+[42d78b5f-dbd7-4cdb-8b30-00f794bb24cf]
+description = "reject problem missing an operand"
+include = true
 
-# reject problem with no operands or operators
-"c2c3cbfc-1a72-42f2-b597-246e617e66f5" = true
+[c2c3cbfc-1a72-42f2-b597-246e617e66f5]
+description = "reject problem with no operands or operators"
+include = true
 
-# reject two operations in a row
-"4b3df66d-6ed5-4c95-a0a1-d38891fbdab6" = true
+[4b3df66d-6ed5-4c95-a0a1-d38891fbdab6]
+description = "reject two operations in a row"
+include = true
 
-# reject two numbers in a row
-"6abd7a50-75b4-4665-aa33-2030fd08bab1" = true
+[6abd7a50-75b4-4665-aa33-2030fd08bab1]
+description = "reject two numbers in a row"
+include = true
 
-# reject postfix notation
-"10a56c22-e0aa-405f-b1d2-c642d9c4c9de" = true
+[10a56c22-e0aa-405f-b1d2-c642d9c4c9de]
+description = "reject postfix notation"
+include = true
 
-# reject prefix notation
-"0035bc63-ac43-4bb5-ad6d-e8651b7d954e" = true
+[0035bc63-ac43-4bb5-ad6d-e8651b7d954e]
+description = "reject prefix notation"
+include = true


### PR DESCRIPTION
Track maintainers found that they wanted to add comments to the tests.toml file to e.g. indicate _why_ a test was not included.
Unfortunately, running configlet sync would re-generate the entire file so any manually added comments were lost.

In this PR we're updating the format of tests.toml files to support adding comments.
We do this by creating a separate table for each test case which has `description` and `include` fields.
Tracks are then free to add additional fields, like a `comment` field, but also any other fields they feel might be useful to them.

configlet has _not_ yet been updated to support this new format, but we hope to do this soon. Sorry for the inconvenience.

For more information, see this discussion: https://github.com/exercism/configlet/issues/186

## Implementation

The PR expects the tests.toml files to be in their original format:

```toml
# <description>
"<uuid>" = <include>
```

This is transformed to:

```toml
[<uuid>]
description = "<description>"
include = <include>
```

## Example

```toml
# one factor has multiples within limit
"361e4e50-c89b-4f60-95ef-5bc5c595490a" = true
```

becomes

```toml
[361e4e50-c89b-4f60-95ef-5bc5c595490a]
description = "one factor has multiples within limit"
include = true
```

## Existing comments

As some tracks have manually added comments to tests, we try to detect them by assuming they are either:

- Added as a line comment _before_ the description (we'll ignore empty lines)
- Added as an inline comment _after_ boolean include value

For any such manually detected comments, we'll add a `comment` field.

## Tracking

https://github.com/exercism/v3-launch/issues/22
