### PR TITLE
🤖 Add docs configuration

### DIFF
--- a/docs/config.json
+++ b/docs/config.json
@@ -1,0 +1,32 @@
+{
+  "docs": [
+    {
+      "uuid": "d8f71ffb-44a8-43d6-adea-2a0b61c3185a",
+      "slug": "installation",
+      "path": "docs/INSTALLATION.md",
+      "title": "Installing Elm locally",
+      "blurb": "Learn how to install Elm locally to solve Exercism's exercises on your own machine"
+    },
+    {
+      "uuid": "045e839e-5a3a-4378-98de-1b5fd5389233",
+      "slug": "learning",
+      "path": "docs/LEARNING.md",
+      "title": "How to learn Elm",
+      "blurb": "An overview of how to get started from scratch with Elm"
+    },
+    {
+      "uuid": "71b76107-6019-4612-9c3a-2ca88478aae2",
+      "slug": "tests",
+      "path": "docs/TESTS.md",
+      "title": "Testing on the Elm track",
+      "blurb": "Learn how to test your Elm exercises on Exercism"
+    },
+    {
+      "uuid": "1fbf2ccf-3230-4a64-957c-8dbf5a8801fd",
+      "slug": "resources",
+      "path": "docs/RESOURCES.md",
+      "title": "Useful Elm resources",
+      "blurb": "A collection of useful resources to help you master Elm"
+    }
+  ]
+}


### PR DESCRIPTION
To allow the v3 website to display the track's documentation, we're introducing a `docs/config.json` file, which contains information needed for rendering.

This commit adds the `docs/config.json` file. We will merge this PR shortly. For now, **please don't edit its contents**. We will follow up with a PR for CI, and with an issue linking you to the spec for this file once it's written up. Once that's all done, you will then be free to edit this config as normal 🙂

## Tracking

https://github.com/exercism/v3-launch/issues/25
