### PR TITLE
🤖 Flatten authors and contributors in .meta/config.json files

### DIFF
--- a/exercises/concept/lucians-luscious-lasagna/.meta/config.json
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/config.json
@@ -1,14 +1,8 @@
 {
   "blurb": "TODO: add blurb for lucians-luscious-lasagna exercise",
   "authors": [
-    {
-      "github_username": "mpizenberg",
-      "exercism_username": "mpizenberg"
-    },
-    {
-      "github_username": "ceddlyburge",
-      "exercism_username": "ceddlyburge"
-    }
+    "mpizenberg",
+    "ceddlyburge"
   ],
   "forked_from": [
     "fsharp/lucians-luscious-lasagna"


### PR DESCRIPTION
The authors and contributors of exercises are stored in an array of objects in the exercises' `.meta/config.json` files.
Each author/contributor used to have two properties: their GitHub username _and_ their Exercism username.
As we're only using the GitHub username, we're flattening the `authors` and `contributors` array to an array of strings representing the GitHub usernames.

We will update `configlet` to validate the new structure, so you might be seeing build failures once we've implemented this change. 

See https://github.com/exercism/docs/pull/90/files

## Automatic Merging

We will automatically merge this PR immediately to be able to submit a different PR in which we'll add the authors/contributors for practice exercises.

## Tracking

https://github.com/exercism/v3-launch/issues/26
