### PR TITLE
🤖 Add authors and contributors to Practice Exercises

### DIFF
--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -9,7 +9,6 @@
     "iamvery",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "andys8",
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "andys8",
-    "bobwhitelock",
     "nathanielknight",
     "parkerl",
     "tuxagon"

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -7,7 +7,6 @@
     "andys8",
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/accumulate/.meta/config.json
+++ b/exercises/practice/accumulate/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "andys8",
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "parkerl",
     "tuxagon"

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Convert a long phrase to its acronym",
-  "authors": [],
+  "authors": [
+    "tuxagon"
+  ],
+  "contributors": [
+    "mpizenberg",
+    "nathanielknight"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/acronym/.meta/config.json
+++ b/exercises/practice/acronym/.meta/config.json
@@ -4,7 +4,6 @@
     "tuxagon"
   ],
   "contributors": [
-    "mpizenberg",
     "nathanielknight"
   ],
   "files": {

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "nathanielknight",
-    "Phippsaurus",
     "tgecho",
     "tuxagon"
   ],

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,6 +1,14 @@
 {
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
   "authors": [],
+  "contributors": [
+    "bobwhitelock",
+    "mpizenberg",
+    "nathanielknight",
+    "Phippsaurus",
+    "tgecho",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -3,7 +3,6 @@
   "authors": [],
   "contributors": [
     "bobwhitelock",
-    "mpizenberg",
     "nathanielknight",
     "Phippsaurus",
     "tgecho",

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -4,6 +4,7 @@
     "mcmillhj"
   ],
   "contributors": [
+    "bobwhitelock",
     "nathanielknight",
     "tgecho",
     "tuxagon"

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -1,6 +1,8 @@
 {
   "blurb": "Convert a number, represented as a sequence of digits in one base, to any other base.",
-  "authors": [],
+  "authors": [
+    "mcmillhj"
+  ],
   "contributors": [
     "bobwhitelock",
     "nathanielknight",

--- a/exercises/practice/all-your-base/.meta/config.json
+++ b/exercises/practice/all-your-base/.meta/config.json
@@ -4,7 +4,6 @@
     "mcmillhj"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "tgecho",
     "tuxagon"

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "edgerunner",
     "nathanielknight",
     "parkerl",

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -9,7 +9,6 @@
     "iamvery",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -7,7 +7,6 @@
     "bobwhitelock",
     "edgerunner",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "edgerunner",
-    "iamvery",
     "nathanielknight",
     "parkerl",
     "tuxagon"

--- a/exercises/practice/allergies/.meta/config.json
+++ b/exercises/practice/allergies/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Given a person's allergy score, determine whether or not they're allergic to a given item, and their full list of allergies.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "edgerunner",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "parkerl",
     "thomchop",

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "parkerl",
     "thomchop",

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Given a word and a list of possible anagrams, select the correct sublist.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "thomchop",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/anagram/.meta/config.json
+++ b/exercises/practice/anagram/.meta/config.json
@@ -8,7 +8,6 @@
     "iamvery",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "thomchop",
     "tuxagon"
   ],

--- a/exercises/practice/armstrong-numbers/.meta/config.json
+++ b/exercises/practice/armstrong-numbers/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Determine if a number is an Armstrong number",
-  "authors": [],
+  "authors": [
+    "CharlonTank"
+  ],
+  "contributors": [
+    "mpizenberg"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -7,7 +7,6 @@
     "bobwhitelock",
     "iamvery",
     "nathanielknight",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Create an implementation of the atbash cipher, an ancient encryption system created in the Middle East.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "tuxagon"
   ],

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "tuxagon"
   ],

--- a/exercises/practice/atbash-cipher/.meta/config.json
+++ b/exercises/practice/atbash-cipher/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "Phippsaurus",
     "tuxagon"

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -1,6 +1,14 @@
 {
   "blurb": "Implement a binary search algorithm.",
-  "authors": [],
+  "authors": [
+    "churchie317"
+  ],
+  "contributors": [
+    "michaelglass",
+    "mpizenberg",
+    "nathanielknight",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/binary-search/.meta/config.json
+++ b/exercises/practice/binary-search/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "michaelglass",
-    "mpizenberg",
     "nathanielknight",
     "tuxagon"
   ],

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -4,7 +4,6 @@
     "parkerl"
   ],
   "contributors": [
-    "bobwhitelock",
     "churchie317",
     "gilesbowkett",
     "kytrinyx",

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -7,7 +7,6 @@
     "bobwhitelock",
     "churchie317",
     "gilesbowkett",
-    "iamvery",
     "kytrinyx",
     "leojpod",
     "nathanielknight",

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -11,7 +11,6 @@
     "kytrinyx",
     "leojpod",
     "nathanielknight",
-    "Phippsaurus",
     "tgecho",
     "thomchop",
     "tuxagon"

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -8,7 +8,6 @@
     "churchie317",
     "gilesbowkett",
     "iamvery",
-    "Janiczek",
     "kytrinyx",
     "leojpod",
     "mpizenberg",

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -1,6 +1,23 @@
 {
   "blurb": "Bob is a lackadaisical teenager. In conversation, his responses are very limited.",
-  "authors": [],
+  "authors": [
+    "parkerl"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "churchie317",
+    "gilesbowkett",
+    "iamvery",
+    "Janiczek",
+    "kytrinyx",
+    "leojpod",
+    "mpizenberg",
+    "nathanielknight",
+    "Phippsaurus",
+    "tgecho",
+    "thomchop",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/bob/.meta/config.json
+++ b/exercises/practice/bob/.meta/config.json
@@ -10,7 +10,6 @@
     "iamvery",
     "kytrinyx",
     "leojpod",
-    "mpizenberg",
     "nathanielknight",
     "Phippsaurus",
     "tgecho",

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "kytrinyx",
     "nathanielknight",
-    "Phippsaurus",
     "tgecho",
     "tuxagon"
   ],

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -3,7 +3,6 @@
   "authors": [],
   "contributors": [
     "kytrinyx",
-    "mpizenberg",
     "nathanielknight",
     "Phippsaurus",
     "tgecho",

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,6 +1,14 @@
 {
   "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
   "authors": [],
+  "contributors": [
+    "kytrinyx",
+    "mpizenberg",
+    "nathanielknight",
+    "Phippsaurus",
+    "tgecho",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/collatz-conjecture/.meta/config.json
+++ b/exercises/practice/collatz-conjecture/.meta/config.json
@@ -1,6 +1,8 @@
 {
   "blurb": "Calculate the number of steps to reach 1 using the Collatz conjecture",
-  "authors": [],
+  "authors": [
+    "mortenaa"
+  ],
   "contributors": [
     "kytrinyx",
     "nathanielknight",

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Find the difference between the square of the sum and the sum of the squares of the first N natural numbers.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -8,7 +8,6 @@
     "iamvery",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "parkerl",
     "tuxagon"

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/difference-of-squares/.meta/config.json
+++ b/exercises/practice/difference-of-squares/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "parkerl",
     "tuxagon"

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -1,6 +1,13 @@
 {
   "blurb": "We are going to do the `Transform` step of an Extract-Transform-Load.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "mpizenberg",
+    "nathanielknight",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/etl/.meta/config.json
+++ b/exercises/practice/etl/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "mpizenberg",
     "nathanielknight",
     "tuxagon"
   ],

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -4,7 +4,6 @@
     "jehoshua02"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "tgecho",
     "tuxagon"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "Phippsaurus",
     "tgecho",

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "tgecho",
     "tuxagon"

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -7,7 +7,6 @@
     "bobwhitelock",
     "iamvery",
     "nathanielknight",
-    "Phippsaurus",
     "tgecho",
     "tuxagon"
   ],

--- a/exercises/practice/gigasecond/.meta/config.json
+++ b/exercises/practice/gigasecond/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Given a moment, determine the moment that would be after a gigasecond has passed.",
-  "authors": [],
+  "authors": [
+    "jehoshua02"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "Phippsaurus",
+    "tgecho",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "leojpod",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "SiriusStarr",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "leojpod",
     "nathanielknight",
     "parkerl",

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "leojpod",
     "nathanielknight",
     "parkerl",

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -7,7 +7,6 @@
     "bobwhitelock",
     "iamvery",
     "leojpod",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -9,7 +9,6 @@
     "leojpod",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "SiriusStarr",
     "tuxagon"
   ],

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -4,7 +4,6 @@
     "ErikSchierboom"
   ],
   "contributors": [
-    "iamvery",
     "nathanielknight",
     "tgecho",
     "tuxagon"

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Calculate the number of grains of wheat on a chessboard given that the number on each square doubles.",
-  "authors": [],
+  "authors": [
+    "ErikSchierboom"
+  ],
+  "contributors": [
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "tgecho",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/grains/.meta/config.json
+++ b/exercises/practice/grains/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "tgecho",
     "tuxagon"

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "parkerl",
     "petemcfarlane",

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -9,7 +9,6 @@
     "nathanielknight",
     "parkerl",
     "petemcfarlane",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "parkerl",
     "petemcfarlane",

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "petemcfarlane",

--- a/exercises/practice/hamming/.meta/config.json
+++ b/exercises/practice/hamming/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Calculate the Hamming difference between two DNA strands.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "petemcfarlane",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "benreyn",
-    "bobwhitelock",
     "nathanielknight",
     "parkerl",
     "tgecho",

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -7,7 +7,6 @@
     "benreyn",
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -1,6 +1,20 @@
 {
   "blurb": "The classical introductory exercise. Just say \"Hello, World!\"",
-  "authors": [],
+  "authors": [
+    "kytrinyx"
+  ],
+  "contributors": [
+    "benreyn",
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tgecho",
+    "TrevorBramble",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -9,7 +9,6 @@
     "iamvery",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tgecho",
     "TrevorBramble",
     "tuxagon"

--- a/exercises/practice/hello-world/.meta/config.json
+++ b/exercises/practice/hello-world/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "benreyn",
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "parkerl",
     "tgecho",

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -4,7 +4,6 @@
     "anuragsoni"
   ],
   "contributors": [
-    "mpizenberg",
     "nathanielknight",
     "Phippsaurus",
     "tgecho",

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Determine if a word or phrase is an isogram.",
-  "authors": [],
+  "authors": [
+    "anuragsoni"
+  ],
+  "contributors": [
+    "mpizenberg",
+    "nathanielknight",
+    "Phippsaurus",
+    "tgecho",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/isogram/.meta/config.json
+++ b/exercises/practice/isogram/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "nathanielknight",
-    "Phippsaurus",
     "tgecho",
     "tuxagon"
   ],

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -7,7 +7,6 @@
     "bobwhitelock",
     "iamvery",
     "nathanielknight",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Given a string of digits, calculate the largest product for a contiguous substring of digits of length n.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "tuxagon"
   ],

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "tuxagon"
   ],

--- a/exercises/practice/largest-series-product/.meta/config.json
+++ b/exercises/practice/largest-series-product/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "Phippsaurus",
     "tuxagon"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -8,7 +8,6 @@
     "iamvery",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "parkerl",
     "tuxagon"

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Given a year, report if it is a leap year.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/leap/.meta/config.json
+++ b/exercises/practice/leap/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "parkerl",
     "tuxagon"

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "Phippsaurus",
     "tgecho",

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "tgecho",
     "tuxagon"

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -7,7 +7,6 @@
     "bobwhitelock",
     "iamvery",
     "nathanielknight",
-    "Phippsaurus",
     "tgecho",
     "tuxagon"
   ],

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Implement basic list operations",
-  "authors": [],
+  "authors": [
+    "jcshih"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "Phippsaurus",
+    "tgecho",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/list-ops/.meta/config.json
+++ b/exercises/practice/list-ops/.meta/config.json
@@ -4,7 +4,6 @@
     "jcshih"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "tgecho",
     "tuxagon"

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Given a number determine whether or not it is valid per the Luhn formula.",
-  "authors": [],
+  "authors": [
+    "tuxagon"
+  ],
+  "contributors": [
+    "mpizenberg",
+    "nathanielknight"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/luhn/.meta/config.json
+++ b/exercises/practice/luhn/.meta/config.json
@@ -4,7 +4,6 @@
     "tuxagon"
   ],
   "contributors": [
-    "mpizenberg",
     "nathanielknight"
   ],
   "files": {

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Make sure the brackets and braces all match.",
-  "authors": [],
+  "authors": [
+    "tuxagon"
+  ],
+  "contributors": [
+    "edgerunner",
+    "mpizenberg"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/matching-brackets/.meta/config.json
+++ b/exercises/practice/matching-brackets/.meta/config.json
@@ -4,8 +4,7 @@
     "tuxagon"
   ],
   "contributors": [
-    "edgerunner",
-    "mpizenberg"
+    "edgerunner"
   ],
   "files": {
     "solution": [],

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "albronca",
-    "bobwhitelock",
     "nathanielknight",
     "parkerl",
     "tuxagon",

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -9,7 +9,6 @@
     "iamvery",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tuxagon",
     "ulve"
   ],

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "albronca",
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "parkerl",
     "tuxagon",

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Given a DNA string, compute how many times each nucleotide occurs in the string.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "albronca",
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon",
+    "ulve"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/nucleotide-count/.meta/config.json
+++ b/exercises/practice/nucleotide-count/.meta/config.json
@@ -7,7 +7,6 @@
     "albronca",
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -7,7 +7,6 @@
     "bdukes",
     "bobwhitelock",
     "duckmole",
-    "iamvery",
     "liammccartney",
     "nathanielknight",
     "parkerl",

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -9,7 +9,6 @@
     "duckmole",
     "iamvery",
     "liammccartney",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bdukes",
-    "bobwhitelock",
     "duckmole",
     "liammccartney",
     "nathanielknight",

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -11,7 +11,6 @@
     "liammccartney",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -1,6 +1,21 @@
 {
   "blurb": "Determine if a sentence is a pangram.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bdukes",
+    "bobwhitelock",
+    "duckmole",
+    "iamvery",
+    "Janiczek",
+    "liammccartney",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/pangram/.meta/config.json
+++ b/exercises/practice/pangram/.meta/config.json
@@ -8,7 +8,6 @@
     "bobwhitelock",
     "duckmole",
     "iamvery",
-    "Janiczek",
     "liammccartney",
     "mpizenberg",
     "nathanielknight",

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -1,6 +1,15 @@
 {
   "blurb": "Compute Pascal's triangle up to a given number of rows.",
-  "authors": [],
+  "authors": [
+    "anuragsoni"
+  ],
+  "contributors": [
+    "mpizenberg",
+    "nathanielknight",
+    "Phippsaurus",
+    "tgecho",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -4,7 +4,6 @@
     "anuragsoni"
   ],
   "contributors": [
-    "mpizenberg",
     "nathanielknight",
     "Phippsaurus",
     "tgecho",

--- a/exercises/practice/pascals-triangle/.meta/config.json
+++ b/exercises/practice/pascals-triangle/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "nathanielknight",
-    "Phippsaurus",
     "tgecho",
     "tuxagon"
   ],

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -8,6 +8,7 @@
     "mrattner",
     "nathanielknight",
     "parkerl",
+    "Phippsaurus",
     "SiriusStarr",
     "tuxagon"
   ],

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -10,7 +10,6 @@
     "mrattner",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "SiriusStarr",
     "tuxagon"
   ],

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Clean up user-entered phone numbers so that they can be sent SMS messages.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "mrattner",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "SiriusStarr",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "mpizenberg",
     "mrattner",
     "nathanielknight",

--- a/exercises/practice/phone-number/.meta/config.json
+++ b/exercises/practice/phone-number/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "mpizenberg",
     "mrattner",
     "nathanielknight",

--- a/exercises/practice/pythagorean-triplet/.meta/config.json
+++ b/exercises/practice/pythagorean-triplet/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "There exists exactly one Pythagorean triplet for which a + b + c = 1000. Find the product a * b * c.",
-  "authors": [],
+  "authors": [
+    "leojpod"
+  ],
+  "contributors": [
+    "mpizenberg"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -8,7 +8,6 @@
     "iamvery",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "parkerl",
     "tuxagon"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "parkerl",
     "tuxagon"

--- a/exercises/practice/raindrops/.meta/config.json
+++ b/exercises/practice/raindrops/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Convert a number to a string, the content of which depends on the number's factors.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Given a DNA strand, return its RNA Complement Transcription.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "nhawkes",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "nhawkes",
     "parkerl",

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "nhawkes",
     "parkerl",

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "nhawkes",
     "parkerl",

--- a/exercises/practice/rna-transcription/.meta/config.json
+++ b/exercises/practice/rna-transcription/.meta/config.json
@@ -9,7 +9,6 @@
     "nathanielknight",
     "nhawkes",
     "parkerl",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -8,7 +8,6 @@
     "iamvery",
     "michaelkpfeifer",
     "nathanielknight",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Write a robot simulator.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "michaelkpfeifer",
+    "mpizenberg",
+    "nathanielknight",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "michaelkpfeifer",
     "nathanielknight",
     "tuxagon"

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -7,7 +7,6 @@
     "bobwhitelock",
     "iamvery",
     "michaelkpfeifer",
-    "mpizenberg",
     "nathanielknight",
     "Phippsaurus",
     "tuxagon"

--- a/exercises/practice/robot-simulator/.meta/config.json
+++ b/exercises/practice/robot-simulator/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "michaelkpfeifer",
     "nathanielknight",
     "tuxagon"

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "Phippsaurus",
     "tgecho",

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "tgecho",
     "tuxagon"

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -7,7 +7,6 @@
     "bobwhitelock",
     "iamvery",
     "nathanielknight",
-    "Phippsaurus",
     "tgecho",
     "tuxagon"
   ],

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Write a function to convert from normal numbers to Roman Numerals.",
-  "authors": [],
+  "authors": [
+    "rebelwarrior"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "Phippsaurus",
+    "tgecho",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/roman-numerals/.meta/config.json
+++ b/exercises/practice/roman-numerals/.meta/config.json
@@ -4,7 +4,6 @@
     "rebelwarrior"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "tgecho",
     "tuxagon"

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -9,7 +9,6 @@
     "mrattner",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tuxagon",
     "ulve"
   ],

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "mrattner",
     "nathanielknight",
     "parkerl",

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "mrattner",
     "nathanielknight",
     "parkerl",

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -1,6 +1,19 @@
 {
   "blurb": "Implement run-length encoding and decoding.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "mrattner",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon",
+    "ulve"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/run-length-encoding/.meta/config.json
+++ b/exercises/practice/run-length-encoding/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "mrattner",
     "nathanielknight",
     "parkerl",

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Given a number from 0 to 999,999,999,999, spell out that number in English.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -7,7 +7,6 @@
     "bobwhitelock",
     "iamvery",
     "nathanielknight",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "tuxagon"
   ],

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "tuxagon"
   ],

--- a/exercises/practice/say/.meta/config.json
+++ b/exercises/practice/say/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "Phippsaurus",
     "tuxagon"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "A5308Y",
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "tgecho",
     "tuxagon"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "A5308Y",
-    "bobwhitelock",
     "nathanielknight",
     "tgecho",
     "tuxagon"

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,6 +1,16 @@
 {
   "blurb": "Given a word, compute the Scrabble score for that word.",
   "authors": [],
+  "contributors": [
+    "A5308Y",
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "Phippsaurus",
+    "tgecho",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -8,7 +8,6 @@
     "bobwhitelock",
     "iamvery",
     "nathanielknight",
-    "Phippsaurus",
     "tgecho",
     "tuxagon"
   ],

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -1,6 +1,8 @@
 {
   "blurb": "Given a word, compute the Scrabble score for that word.",
-  "authors": [],
+  "authors": [
+    "woylie"
+  ],
   "contributors": [
     "A5308Y",
     "bobwhitelock",

--- a/exercises/practice/scrabble-score/.meta/config.json
+++ b/exercises/practice/scrabble-score/.meta/config.json
@@ -5,7 +5,6 @@
     "A5308Y",
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "Phippsaurus",
     "tgecho",

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -8,7 +8,6 @@
     "iamvery",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "parkerl",
     "tuxagon"

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Given a string of digits, output all the contiguous substrings of length `n` in that string.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/series/.meta/config.json
+++ b/exercises/practice/series/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "parkerl",
     "tuxagon"

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "michaelglass",
     "nathanielknight",
     "nmbrgts",

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -1,6 +1,20 @@
 {
   "blurb": "Given an age in seconds, calculate how old someone is in terms of a given planet's solar years.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "michaelglass",
+    "mpizenberg",
+    "nathanielknight",
+    "nmbrgts",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon",
+    "yurrriq"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -10,7 +10,6 @@
     "nathanielknight",
     "nmbrgts",
     "parkerl",
-    "Phippsaurus",
     "tuxagon",
     "yurrriq"
   ],

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -7,7 +7,6 @@
     "bobwhitelock",
     "iamvery",
     "michaelglass",
-    "mpizenberg",
     "nathanielknight",
     "nmbrgts",
     "parkerl",

--- a/exercises/practice/space-age/.meta/config.json
+++ b/exercises/practice/space-age/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "michaelglass",
     "nathanielknight",
     "nmbrgts",

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -8,7 +8,6 @@
     "iamvery",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "parkerl",
     "tuxagon"

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "parkerl",
     "tuxagon"

--- a/exercises/practice/strain/.meta/config.json
+++ b/exercises/practice/strain/.meta/config.json
@@ -1,6 +1,17 @@
 {
   "blurb": "Implement the `keep` and `discard` operation on collections. Given a collection and a predicate on the collection's elements, `keep` returns a new collection containing those elements where the predicate is true, while `discard` returns a new collection containing those elements where the predicate is false.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "nathanielknight",
     "parkerl",
     "tuxagon",

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "iamvery",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -8,7 +8,6 @@
     "iamvery",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tuxagon",
     "ulve"
   ],

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Write a function to determine if a list is a sublist of another list.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon",
+    "ulve"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/sublist/.meta/config.json
+++ b/exercises/practice/sublist/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "nathanielknight",
     "parkerl",
     "tuxagon",

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -9,7 +9,6 @@
     "michaelkpfeifer",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -1,6 +1,18 @@
 {
   "blurb": "Given a number, find the sum of all the multiples of particular numbers up to but not including that number.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "michaelkpfeifer",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "michaelkpfeifer",
     "nathanielknight",
     "parkerl",

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "michaelkpfeifer",
     "nathanielknight",
     "parkerl",

--- a/exercises/practice/sum-of-multiples/.meta/config.json
+++ b/exercises/practice/sum-of-multiples/.meta/config.json
@@ -7,7 +7,6 @@
     "bobwhitelock",
     "iamvery",
     "michaelkpfeifer",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -4,7 +4,6 @@
     "tuxagon"
   ],
   "contributors": [
-    "mpizenberg",
     "nathanielknight"
   ],
   "files": {

--- a/exercises/practice/transpose/.meta/config.json
+++ b/exercises/practice/transpose/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Take input text and output it transposed.",
-  "authors": [],
+  "authors": [
+    "tuxagon"
+  ],
+  "contributors": [
+    "mpizenberg",
+    "nathanielknight"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -6,7 +6,6 @@
   "contributors": [
     "bobwhitelock",
     "Emiluren",
-    "iamvery",
     "lpil",
     "nathanielknight",
     "parkerl",

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "Emiluren",
     "lpil",
     "nathanielknight",

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -10,7 +10,6 @@
     "lpil",
     "nathanielknight",
     "parkerl",
-    "Phippsaurus",
     "tuxagon",
     "ulve"
   ],

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -1,6 +1,20 @@
 {
   "blurb": "Determine if a triangle is equilateral, isosceles, or scalene.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "Emiluren",
+    "iamvery",
+    "lpil",
+    "mpizenberg",
+    "nathanielknight",
+    "parkerl",
+    "Phippsaurus",
+    "tuxagon",
+    "ulve"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/triangle/.meta/config.json
+++ b/exercises/practice/triangle/.meta/config.json
@@ -8,7 +8,6 @@
     "Emiluren",
     "iamvery",
     "lpil",
-    "mpizenberg",
     "nathanielknight",
     "parkerl",
     "Phippsaurus",

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -4,7 +4,6 @@
     "tuxagon"
   ],
   "contributors": [
-    "mpizenberg",
     "nathanielknight",
     "rebelwarrior"
   ],

--- a/exercises/practice/twelve-days/.meta/config.json
+++ b/exercises/practice/twelve-days/.meta/config.json
@@ -1,6 +1,13 @@
 {
   "blurb": "Output the lyrics to 'The Twelve Days of Christmas'",
-  "authors": [],
+  "authors": [
+    "tuxagon"
+  ],
+  "contributors": [
+    "mpizenberg",
+    "nathanielknight",
+    "rebelwarrior"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -1,6 +1,12 @@
 {
   "blurb": "Create a sentence of the form \"One for X, one for me.\"",
-  "authors": [],
+  "authors": [
+    "benreyn"
+  ],
+  "contributors": [
+    "mpizenberg",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/two-fer/.meta/config.json
+++ b/exercises/practice/two-fer/.meta/config.json
@@ -4,7 +4,6 @@
     "benreyn"
   ],
   "contributors": [
-    "mpizenberg",
     "tuxagon"
   ],
   "files": {

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -1,6 +1,20 @@
 {
   "blurb": "Given a phrase, count the occurrences of each word in that phrase.",
-  "authors": [],
+  "authors": [
+    "tgecho"
+  ],
+  "contributors": [
+    "bobwhitelock",
+    "iamvery",
+    "michaelkpfeifer",
+    "mpizenberg",
+    "nathanielknight",
+    "NobbZ",
+    "parkerl",
+    "Phippsaurus",
+    "rebelwarrior",
+    "tuxagon"
+  ],
   "files": {
     "solution": [],
     "test": [],

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -4,7 +4,6 @@
     "tgecho"
   ],
   "contributors": [
-    "bobwhitelock",
     "michaelkpfeifer",
     "mpizenberg",
     "nathanielknight",

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -11,7 +11,6 @@
     "nathanielknight",
     "NobbZ",
     "parkerl",
-    "Phippsaurus",
     "rebelwarrior",
     "tuxagon"
   ],

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -5,7 +5,6 @@
   ],
   "contributors": [
     "bobwhitelock",
-    "iamvery",
     "michaelkpfeifer",
     "mpizenberg",
     "nathanielknight",

--- a/exercises/practice/wordy/.meta/config.json
+++ b/exercises/practice/wordy/.meta/config.json
@@ -1,6 +1,11 @@
 {
   "blurb": "Parse and evaluate simple math word problems returning the answer as an integer.",
-  "authors": [],
+  "authors": [
+    "SiriusStarr"
+  ],
+  "contributors": [
+    "mpizenberg"
+  ],
   "files": {
     "solution": [],
     "test": [],


### PR DESCRIPTION
_If you got tagged in this PR, it is because you are being credited for work you've done in the past on Exercism here, and we want to ensure you don't miss out on the recognition you deserve 🙂_

---

With v3, we've introduced the idea of exercise authors and contributors. This information is stored in the exercises' `.meta/config.json` files (see [the docs](https://github.com/exercism/docs/blob/main/building/tracks/practice-exercises.md#file-metaconfigjson)).

Concept Exercises, which are all new, already contain authors and contributors. Practice Exercises though are missing this information. In this PR, we attempt to populate the authors and contributors of Practice Exercises based on their commit history.

## Maintainer TODO list

These are the things you, the maintainers, should do:

- [ ] Check the authors and contributors, adding/removing users where the data is missing or incorrect
- [ ] Double-check any renamed Practice Exercises
- [ ] Check for Practice Exercises with missing authors, which are most likely due to the author not being on GitHub anymore 
- [ ] Add additional authors if you know that a Practice Exercise has actually been created by more than one author 

**For clarity, authors should be the people who originally created the exercise on this track. Contributors should be people who have substantially contributed to that exercise. PRs for typos or multiple-exercise PRs do not automatically mean someone should be considered a contributor to that exercise. Those non-exercise-specific contributions will get recognition through Exercism's reputation system in v3.**

If you find something needs updating, just push a new commit to this PR.

## Automatic Merging

We will automatically merge this PR before we launch v3, but will give the maximum time we can to maintainers to review it first.

---

_The rest of this issue explains how this PR has been generated. You do not **need** to read it._

## Algorithm

We start out by looking at the current Practice Exercises. For each Practice Exercise, we'll look at the commit history of its files to see which commits touched that Practice Exercise. How renames are handled is discussed in the "Renames" section later in this document. 

Any commit that we can associate with a Practice Exercise is used to determine authorship/contributorship. Here is how we assign authorship/contributorship:

### Authors

1. Find the Git commit author of the oldest commit linked to that Practice Exercise.
2. Find the GitHub username for the Git commit author of that commit
3. Add the GitHub username of the Git commit author to the `authors` key in the `.meta/config.json` file

### Contributors

1. Find the Git commit authors and any co-authors of all but the oldest commit linked to that Practice Exercise. If there is only one commit, there won't be any contributors.
1. Exclude the Git commit author and any co-authors of the oldest commit from the list of Git commit authors (an author is _not_ also a contributor) 
2. Find the GitHub usernames for the Git commit authors and any co-authors of those commits
3. Add the GitHub usernames of the Git commit authors and any co-authors to the `contributor` key in the `.meta/config.json` file

We're using the GitHub GraphQL API to find the username of a commit author and any co-authors. In some cases though, a username cannot be found for a commit (e.g. due to the user account no longer existing), in which case we'll skip the commit. 

## Renames

There are a small number of Practice Exercises that might have been renamed at some point. You can ask Git to "follow" a file over its renames using `git log --follow <file>`, which will also return commits made before renames. Unfortunately, Git does not store renames, it just stores the contents of the renamed files and tries to guess if a file was renamed by looking at its contents. This _can_ (and will) lead to false positives, where Git will think a file has been renamed whereas it hasn't. As we don't want to have incorrect authors/contributors for exercises, we're ignoring renames. The only exception to this are known exercise renames:

- `bracket-push` was renamed to `matching-brackets`
- `retree` was renamed to `satellite`
- `resistor-colors` was renamed to `resistor-color-duo`
- `kindergarden-garden` was renamed to `kindergarten-garden`

If you know of a rename of a Practice Exercise, please check to see if its authors and contributors are correctly set.

## Exclusions

There are some commits that we skip over, which thus don't influence the authors/contributors list:

- Commits authored by `dependabot[bot]`, `dependabot-preview[bot]` or `github-actions[bot]`
- Bulk update PRs made by `ErikSchierboom` or `kytrinx` to update the track

## Tracking

https://github.com/exercism/v3-launch/issues/24

---

cc @A5308Y, @albronca, @andys8, @anuragsoni, @bdukes, @benreyn, @bobwhitelock, @CharlonTank, @churchie317, @duckmole, @edgerunner, @Emiluren, @ErikSchierboom, @gilesbowkett, @iamvery, @Janiczek, @jcshih, @jehoshua02, @kytrinyx, @leojpod, @liammccartney, @lpil, @michaelglass, @michaelkpfeifer, @mpizenberg, @mrattner, @nathanielknight, @nhawkes, @nmbrgts, @NobbZ, @parkerl, @petemcfarlane, @Phippsaurus, @rebelwarrior, @SiriusStarr, @tgecho, @thomchop, @TrevorBramble, @tuxagon, @ulve, @yurrriq as you are referenced in this PR
