### PR TITLE
Remove 'skip' on concept exercise tests

### DIFF
--- a/exercises/concept/annalyns-infiltration/tests/Tests.elm
+++ b/exercises/concept/annalyns-infiltration/tests/Tests.elm
@@ -17,487 +17,456 @@ tests =
                 in
                 canFastAttack knightIsAwake
                     |> Expect.equal False
-        , skip <|
-            test "Can execute fast attack if knight is sleeping" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            False
-                    in
-                    canFastAttack knightIsAwake
-                        |> Expect.equal True
-        , skip <|
-            test "Cannot spy if everyone is sleeping" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            False
-
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            False
-                    in
-                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                        |> Expect.equal False
-        , skip <|
-            test "Can spy if everyone but knight is sleeping" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            True
-
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            False
-                    in
-                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                        |> Expect.equal True
-        , skip <|
-            test "Can spy if everyone but archer is sleeping" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            False
-
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            False
-                    in
-                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                        |> Expect.equal True
-        , skip <|
-            test "Can spy if everyone but prisoner is sleeping" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            False
-
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            True
-                    in
-                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                        |> Expect.equal True
-        , skip <|
-            test "Can spy if only knight is sleeping" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            False
-
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            True
-                    in
-                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                        |> Expect.equal True
-        , skip <|
-            test "Can spy if only archer is sleeping" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            True
-
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            True
-                    in
-                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                        |> Expect.equal True
-        , skip <|
-            test "Can spy if only prisoner is sleeping" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            True
-
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            False
-                    in
-                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                        |> Expect.equal True
-        , skip <|
-            test "Can spy if everyone is awake" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            True
-
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            True
-                    in
-                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                        |> Expect.equal True
-        , skip <|
-            test "Can signal prisoner if archer is sleeping and prisoner is awake" <|
-                \_ ->
-                    let
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            True
-                    in
-                    canSignalPrisoner archerIsAwake prisonerIsAwake
-                        |> Expect.equal True
-        , skip <|
-            test "Cannot signal prisoner if archer is awake and prisoner is sleeping" <|
-                \_ ->
-                    let
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            False
-                    in
-                    canSignalPrisoner archerIsAwake prisonerIsAwake
-                        |> Expect.equal False
-        , skip <|
-            test "Cannot signal prisoner if archer and prisoner are both sleeping" <|
-                \_ ->
-                    let
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            False
-                    in
-                    canSignalPrisoner archerIsAwake prisonerIsAwake
-                        |> Expect.equal False
-        , skip <|
-            test "Cannot signal prisoner if archer and prisoner are both awake" <|
-                \_ ->
-                    let
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            True
-                    in
-                    canSignalPrisoner archerIsAwake prisonerIsAwake
-                        |> Expect.equal False
-        , skip <|
-            test "Cannot release prisoner if everyone is awake and pet dog is present" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            True
-
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            True
-
-                        petDogIsPresent =
-                            True
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal False
-        , skip <|
-            test "Cannot release prisoner if everyone is awake and pet dog is absent" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            True
-
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            True
-
-                        petDogIsPresent =
-                            False
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal False
-        , skip <|
-            test "Can release prisoner if everyone is asleep and pet dog is present" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            False
-
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            False
-
-                        petDogIsPresent =
-                            True
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal True
-        , skip <|
-            test "Cannot release prisoner if everyone is asleep and pet dog is absent" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            False
-
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            False
-
-                        petDogIsPresent =
-                            False
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal False
-        , skip <|
-            test "Can release prisoner if only prisoner is awake and pet dog is present" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            False
-
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            True
-
-                        petDogIsPresent =
-                            True
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal True
-        , skip <|
-            test "Can release prisoner if only prisoner is awake and pet dog is absent" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            False
-
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            True
-
-                        petDogIsPresent =
-                            False
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal True
-        , skip <|
-            test "Cannot release prisoner if only archer is awake and pet dog is present" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            False
-
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            False
-
-                        petDogIsPresent =
-                            True
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal False
-        , skip <|
-            test "Cannot release prisoner if only archer is awake and pet dog is absent" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            False
-
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            False
-
-                        petDogIsPresent =
-                            False
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal False
-        , skip <|
-            test "Can release prisoner if only knight is awake and pet dog is present" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            True
-
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            False
-
-                        petDogIsPresent =
-                            True
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal True
-        , skip <|
-            test "Cannot release prisoner if only knight is awake and pet dog is absent" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            True
-
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            False
-
-                        petDogIsPresent =
-                            False
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal False
-        , skip <|
-            test "Cannot release prisoner if only knight is asleep and pet dog is present" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            False
-
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            True
-
-                        petDogIsPresent =
-                            True
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal False
-        , skip <|
-            test "Cannot release prisoner if only knight is asleep and pet dog is absent" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            False
-
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            True
-
-                        petDogIsPresent =
-                            False
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal False
-        , skip <|
-            test "Can release prisoner if only archer is asleep and pet dog is present" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            True
-
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            True
-
-                        petDogIsPresent =
-                            True
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal True
-        , skip <|
-            test "Cannot release prisoner if only archer is asleep and pet dog is absent" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            True
-
-                        archerIsAwake =
-                            False
-
-                        prisonerIsAwake =
-                            True
-
-                        petDogIsPresent =
-                            False
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal False
-        , skip <|
-            test "Cannot release prisoner if only prisoner is asleep and pet dog is present" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            True
-
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            False
-
-                        petDogIsPresent =
-                            True
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal False
-        , skip <|
-            test "Cannot release prisoner if only prisoner is asleep and pet dog is absent" <|
-                \_ ->
-                    let
-                        knightIsAwake =
-                            True
-
-                        archerIsAwake =
-                            True
-
-                        prisonerIsAwake =
-                            False
-
-                        petDogIsPresent =
-                            False
-                    in
-                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                        |> Expect.equal False
-        , skip <|
-            test "Annalyn does 12 damage if undetected" <|
-                \_ ->
-                    let
-                        annalynIsDetected =
-                            False
-                    in
-                    stealthAttackDamage annalynIsDetected
-                        |> Expect.equal 12
-        , skip <|
-            test "Annalyn does 7 damage if detected" <|
-                \_ ->
-                    let
-                        annalynIsDetected =
-                            True
-                    in
-                    stealthAttackDamage annalynIsDetected
-                        |> Expect.equal 7
+        , test "Can execute fast attack if knight is sleeping" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        False
+                in
+                canFastAttack knightIsAwake
+                    |> Expect.equal True
+        , test "Cannot spy if everyone is sleeping" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        False
+
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        False
+                in
+                canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                    |> Expect.equal False
+        , test "Can spy if everyone but knight is sleeping" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        True
+
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        False
+                in
+                canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                    |> Expect.equal True
+        , test "Can spy if everyone but archer is sleeping" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        False
+
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        False
+                in
+                canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                    |> Expect.equal True
+        , test "Can spy if everyone but prisoner is sleeping" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        False
+
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        True
+                in
+                canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                    |> Expect.equal True
+        , test "Can spy if only knight is sleeping" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        False
+
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        True
+                in
+                canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                    |> Expect.equal True
+        , test "Can spy if only archer is sleeping" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        True
+
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        True
+                in
+                canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                    |> Expect.equal True
+        , test "Can spy if only prisoner is sleeping" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        True
+
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        False
+                in
+                canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                    |> Expect.equal True
+        , test "Can spy if everyone is awake" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        True
+
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        True
+                in
+                canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                    |> Expect.equal True
+        , test "Can signal prisoner if archer is sleeping and prisoner is awake" <|
+            \_ ->
+                let
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        True
+                in
+                canSignalPrisoner archerIsAwake prisonerIsAwake
+                    |> Expect.equal True
+        , test "Cannot signal prisoner if archer is awake and prisoner is sleeping" <|
+            \_ ->
+                let
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        False
+                in
+                canSignalPrisoner archerIsAwake prisonerIsAwake
+                    |> Expect.equal False
+        , test "Cannot signal prisoner if archer and prisoner are both sleeping" <|
+            \_ ->
+                let
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        False
+                in
+                canSignalPrisoner archerIsAwake prisonerIsAwake
+                    |> Expect.equal False
+        , test "Cannot signal prisoner if archer and prisoner are both awake" <|
+            \_ ->
+                let
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        True
+                in
+                canSignalPrisoner archerIsAwake prisonerIsAwake
+                    |> Expect.equal False
+        , test "Cannot release prisoner if everyone is awake and pet dog is present" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        True
+
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        True
+
+                    petDogIsPresent =
+                        True
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal False
+        , test "Cannot release prisoner if everyone is awake and pet dog is absent" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        True
+
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        True
+
+                    petDogIsPresent =
+                        False
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal False
+        , test "Can release prisoner if everyone is asleep and pet dog is present" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        False
+
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        False
+
+                    petDogIsPresent =
+                        True
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal True
+        , test "Cannot release prisoner if everyone is asleep and pet dog is absent" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        False
+
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        False
+
+                    petDogIsPresent =
+                        False
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal False
+        , test "Can release prisoner if only prisoner is awake and pet dog is present" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        False
+
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        True
+
+                    petDogIsPresent =
+                        True
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal True
+        , test "Can release prisoner if only prisoner is awake and pet dog is absent" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        False
+
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        True
+
+                    petDogIsPresent =
+                        False
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal True
+        , test "Cannot release prisoner if only archer is awake and pet dog is present" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        False
+
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        False
+
+                    petDogIsPresent =
+                        True
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal False
+        , test "Cannot release prisoner if only archer is awake and pet dog is absent" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        False
+
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        False
+
+                    petDogIsPresent =
+                        False
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal False
+        , test "Can release prisoner if only knight is awake and pet dog is present" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        True
+
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        False
+
+                    petDogIsPresent =
+                        True
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal True
+        , test "Cannot release prisoner if only knight is awake and pet dog is absent" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        True
+
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        False
+
+                    petDogIsPresent =
+                        False
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal False
+        , test "Cannot release prisoner if only knight is asleep and pet dog is present" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        False
+
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        True
+
+                    petDogIsPresent =
+                        True
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal False
+        , test "Cannot release prisoner if only knight is asleep and pet dog is absent" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        False
+
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        True
+
+                    petDogIsPresent =
+                        False
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal False
+        , test "Can release prisoner if only archer is asleep and pet dog is present" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        True
+
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        True
+
+                    petDogIsPresent =
+                        True
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal True
+        , test "Cannot release prisoner if only archer is asleep and pet dog is absent" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        True
+
+                    archerIsAwake =
+                        False
+
+                    prisonerIsAwake =
+                        True
+
+                    petDogIsPresent =
+                        False
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal False
+        , test "Cannot release prisoner if only prisoner is asleep and pet dog is present" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        True
+
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        False
+
+                    petDogIsPresent =
+                        True
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal False
+        , test "Cannot release prisoner if only prisoner is asleep and pet dog is absent" <|
+            \_ ->
+                let
+                    knightIsAwake =
+                        True
+
+                    archerIsAwake =
+                        True
+
+                    prisonerIsAwake =
+                        False
+
+                    petDogIsPresent =
+                        False
+                in
+                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                    |> Expect.equal False
+        , test "Annalyn does 12 damage if undetected" <|
+            \_ ->
+                let
+                    annalynIsDetected =
+                        False
+                in
+                stealthAttackDamage annalynIsDetected
+                    |> Expect.equal 12
+        , test "Annalyn does 7 damage if detected" <|
+            \_ ->
+                let
+                    annalynIsDetected =
+                        True
+                in
+                stealthAttackDamage annalynIsDetected
+                    |> Expect.equal 7
         ]

--- a/exercises/concept/bettys-bike-shop/tests/Tests.elm
+++ b/exercises/concept/bettys-bike-shop/tests/Tests.elm
@@ -12,19 +12,16 @@ tests =
             \_ ->
                 penceToPounds 599
                     |> Expect.within (Absolute 0.001) 5.99
-        , skip <|
-            test "33 pence should be 0.33 pounds" <|
-                \_ ->
-                    penceToPounds 33
-                        |> Expect.within (Absolute 0.001) 0.33
-        , skip <|
-            test "5.99 pounds should be formatted as £5.99" <|
-                \_ ->
-                    poundsToString 5.99
-                        |> Expect.equal "£5.99"
-        , skip <|
-            test "0.33 pounds should be formatted as £0.33" <|
-                \_ ->
-                    poundsToString 0.33
-                        |> Expect.equal "£0.33"
+        , test "33 pence should be 0.33 pounds" <|
+            \_ ->
+                penceToPounds 33
+                    |> Expect.within (Absolute 0.001) 0.33
+        , test "5.99 pounds should be formatted as £5.99" <|
+            \_ ->
+                poundsToString 5.99
+                    |> Expect.equal "£5.99"
+        , test "0.33 pounds should be formatted as £0.33" <|
+            \_ ->
+                poundsToString 0.33
+                    |> Expect.equal "£0.33"
         ]

--- a/exercises/concept/lucians-luscious-lasagna/tests/Tests.elm
+++ b/exercises/concept/lucians-luscious-lasagna/tests/Tests.elm
@@ -13,16 +13,14 @@ tests =
             \_ ->
                 expectedMinutesInOven
                     |> Expect.equal 40
-        , skip <|
-            fuzz positiveInt "preparationTimeInMinutes" <|
-                \layers ->
-                    preparationTimeInMinutes layers
-                        |> Expect.equal (2 * layers)
-        , skip <|
-            fuzz (Fuzz.tuple ( positiveInt, positiveInt )) "elapsedTimeInMinutes" <|
-                \( layers, passedAlready ) ->
-                    elapsedTimeInMinutes layers passedAlready
-                        |> Expect.equal (2 * layers + passedAlready)
+        , fuzz positiveInt "preparationTimeInMinutes" <|
+            \layers ->
+                preparationTimeInMinutes layers
+                    |> Expect.equal (2 * layers)
+        , fuzz (Fuzz.tuple ( positiveInt, positiveInt )) "elapsedTimeInMinutes" <|
+            \( layers, passedAlready ) ->
+                elapsedTimeInMinutes layers passedAlready
+                    |> Expect.equal (2 * layers + passedAlready)
         ]
 
 


### PR DESCRIPTION
While all except the first test of practice exercise must be skipped in the tests file, the situation is different for concept exercises. It appears we didn't notice that change few months back so I'm making the change now. The rationale is that beginner students might not be skilled enough yet to "unskip" manually the tests. So tests in concept exercises are not skipped.

This change only affects CLI users since the online test runner "unskip" everything anyway.