### PR TITLE
Fix some issues with basics 1

### DIFF
--- a/exercises/concept/lucians-luscious-lasagna/.docs/instructions.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/instructions.md
@@ -10,7 +10,7 @@ Define the `expectedMinutesInOven` constant to check how many minutes the lasagn
 
 ```elm
 expectedMinutesInOven
-// => 40
+    --> 40
 ```
 
 ## 2. Calculate the preparation time in minutes
@@ -19,7 +19,7 @@ Define the `preparationTimeInMinutes` function that takes the number of layers y
 
 ```elm
 preparationTimeInMinutes 3
-// => 6
+    --> 6
 ```
 
 ## 3. Calculate the elapsed time in minutes
@@ -28,5 +28,5 @@ Define the `elapsedTimeInMinutes` function that takes two parameters: the first 
 
 ```elm
 elapsedTimeInMinutes 3 20
-// => 26
+    --> 26
 ```

--- a/exercises/concept/lucians-luscious-lasagna/tests/Tests.elm
+++ b/exercises/concept/lucians-luscious-lasagna/tests/Tests.elm
@@ -1,7 +1,6 @@
 module Tests exposing (tests)
 
 import Expect
-import Fuzz
 import LuciansLusciousLasagna exposing (elapsedTimeInMinutes, expectedMinutesInOven, preparationTimeInMinutes)
 import Test exposing (..)
 
@@ -9,20 +8,24 @@ import Test exposing (..)
 tests : Test
 tests =
     describe "LuciansLusciousLasagna"
-        [ test "expectedMinutesInOven" <|
+        [ test "The expected amount of time in the oven is 40 minutes" <|
             \_ ->
                 expectedMinutesInOven
                     |> Expect.equal 40
-        , fuzz positiveInt "preparationTimeInMinutes" <|
-            \layers ->
-                preparationTimeInMinutes layers
-                    |> Expect.equal (2 * layers)
-        , fuzz (Fuzz.tuple ( positiveInt, positiveInt )) "elapsedTimeInMinutes" <|
-            \( layers, passedAlready ) ->
-                elapsedTimeInMinutes layers passedAlready
-                    |> Expect.equal (2 * layers + passedAlready)
+        , test "For 2 layers, the preparation time is 4 minutes" <|
+            \_ ->
+                preparationTimeInMinutes 2
+                    |> Expect.equal 4
+        , test "For 5 layers, the preparation time is 10 minutes" <|
+            \_ ->
+                preparationTimeInMinutes 5
+                    |> Expect.equal 10
+        , test "For a 3-layers lasagna already in the oven for 10 minutes, you've spent 16 minutes cooking" <|
+            \_ ->
+                elapsedTimeInMinutes 3 10
+                    |> Expect.equal 16
+        , test "For a 6-layers lasagna already in the oven for 30 minutes, you've spent 42 minutes cooking" <|
+            \_ ->
+                elapsedTimeInMinutes 6 30
+                    |> Expect.equal 42
         ]
-
-
-positiveInt =
-    Fuzz.intRange 0 1000000


### PR DESCRIPTION
- Remove usage of `Fuzz` in the tests
- Use actual sentences in tests descriptions
- Use `-->` instead of `// =>` in the code examples in the instructions