### PR TITLE
Remove type annotation on hello world

### DIFF
--- a/exercises/practice/hello-world/src/HelloWorld.elm
+++ b/exercises/practice/hello-world/src/HelloWorld.elm
@@ -9,10 +9,7 @@
 
 module HelloWorld exposing (helloWorld)
 
--- It's good style to include any types at the top level of your modules.
 
-
-helloWorld : String
 helloWorld =
     "Please implement this function"
 


### PR DESCRIPTION
The hello world practice exercise is now the first thing that have to be done to unlock a track. So I just removed the type annotation on the string constant. It's not needed for hello world and introduced in basics-2.