### PR TITLE
🤖 Fix invalid UUIDs

### DIFF
--- a/config.json
+++ b/config.json
@@ -284,7 +284,7 @@
       {
         "slug": "isogram",
         "name": "Isogram",
-        "uuid": "5f540090-061e-2f80-40a8-d9782700ed2efdf8965",
+        "uuid": "61ef49ef-1086-445b-aa0a-b99de263b728",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
@@ -457,7 +457,7 @@
       {
         "slug": "binary-search",
         "name": "Binary Search",
-        "uuid": "1F9FE5BC-8213-44FD-B7D1-5D4CC7F3A475",
+        "uuid": "5c859d35-f2fe-455c-a7d7-df9398355403",
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,


### PR DESCRIPTION
This PR regenerates each UUID on the track that was invalid.

To be valid, each value of a `uuid` key must:
- Be a well-formed version 4 UUID (compliant with RFC 4122) in the
  canonical textual representation [1]
- Not exist elsewhere on the track
- Not exist elsewhere on Exercism

A track can generate a suitable UUID by running `configlet uuid`.

In the future, `configlet lint` will produce an error for an invalid
UUID.

[1] That is, it must match this regular expression:
```
^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$
```

## Tracking

https://github.com/exercism/v3-launch/issues/29
