### PR TITLE
🤖 Add average test runner run time to `config.json`

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,6 +10,9 @@
     "ace_editor_language": "elm",
     "highlightjs_language": "elm"
   },
+  "test_runner": {
+    "average_run_time": 2.0
+  },
   "status": {
     "concept_exercises": false,
     "test_runner": true,


### PR DESCRIPTION
**We will auto-merge this PR shortly. No action is required**

---

This PR adds a new `test_runner.average_run_time` key to the `config.json` file. The purpose of this field is allow the website to show a progress bar while the test runner runs. The average run time is defined in seconds with one digit of precision.

For more information, see https://github.com/exercism/docs/pull/130

We've pre-populated the average run time value by timing the execution time of the test runner in Docker on the example solution of the `leap` exercise, repeating that 4 more times, and then averaging the execution times. Clearly, the actual average execution time will differ between exercises and solutions, so this should be seen as very general indicator.

*This is mostly a stop-gap solution for now. We'll revisit this in 6 months time or so.* 

## Tracking

https://github.com/exercism/v3-launch/issues/35
