### PR TITLE
Enable concept exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,7 +13,7 @@
     "average_run_time": 2.0
   },
   "status": {
-    "concept_exercises": false,
+    "concept_exercises": true,
     "test_runner": true,
     "representer": true,
     "analyzer": false


### PR DESCRIPTION
This PR enables the Concept Exercises for this track. Without setting this to `true`, they won't be available on the website.

Note that the Concept Exercises themselves also have to change their status from `beta` to `active` (or even better: just omit the `status` key) to enable them on the production website.
