### PR TITLE
Update test instructions

### DIFF
--- a/exercises/shared/.docs/tests.md
+++ b/exercises/shared/.docs/tests.md
@@ -1,5 +1,5 @@
 # Tests
 
-If you are running the code locally (and not through the web interface) run the command `elm-test` from within the exercise directory to run the tests.
+Run the command `elm-test` from within the exercise directory to run the tests.
 
 This assumes that you have already followed the installation instructions for the Elm track.


### PR DESCRIPTION
This PR removes the reference to the online editor from the test instructions in the `exercises/shared/.docs/tests.md` file, as that file is never shown on the website and only included in the generated `HELP.md` file when using the CLI.