### PR TITLE
Remove text in concept exercise requirements

### DIFF
--- a/exercises/concept/annalyns-infiltration/.meta/design.md
+++ b/exercises/concept/annalyns-infiltration/.meta/design.md
@@ -18,10 +18,8 @@ The goal of this exercise is to teach the students what are Booleans and what yo
 
 ## Concepts
 
-The concepts this exercise unlock are:
-
-- `booleans`: Know of the existence of the `Bool` type and its two values; know about boolean operators and how to build logical expressions with them; know of the boolean operator precedence rules; know how to use conditional branching (if-then-else).
+- `booleans`
 
 ## Prerequisites
 
-- `basics-2`: Know the basic syntax of an Elm file.
+- `basics-2`

--- a/exercises/concept/bandwagoner/.meta/design.md
+++ b/exercises/concept/bandwagoner/.meta/design.md
@@ -19,8 +19,8 @@
 
 ## Concepts
 
-- `records`: Learn how to use records in an Elm program
+- `records`
 
 ## Prerequisites
 
-- `basics-2`: Know the basics of Elm programming.
+- `basics-2`

--- a/exercises/concept/bettys-bike-shop/.meta/design.md
+++ b/exercises/concept/bettys-bike-shop/.meta/design.md
@@ -14,11 +14,11 @@
 
 ## Concepts
 
-- `basics-2`: Know the basics of Elm programming.
+- `basics-2`
 
 ## Prequisites
 
-- `basics-1`: Know the basic syntax of an Elm file.
+- `basics-1`
 
 ## Analyzer
 

--- a/exercises/concept/lucians-luscious-lasagna/.meta/design.md
+++ b/exercises/concept/lucians-luscious-lasagna/.meta/design.md
@@ -16,7 +16,7 @@
 
 ## Concepts
 
-- `basics-1`: Know the basic syntax of an Elm file.
+- `basics-1`
 
 ## Prequisites
 

--- a/exercises/concept/role-playing-game/.meta/design.md
+++ b/exercises/concept/role-playing-game/.meta/design.md
@@ -21,11 +21,9 @@ The goal of this exercise is to teach students about optional values enabled by 
 
 ## Concepts
 
-The concepts this exercise unlock are:
-
-- `maybe`: know of the existence of the `Maybe` type; understand the type variable `a` of the `Maybe a` type; know how to create a `Maybe` value; know how to pattern match on its two values; know how it relates to optional values and simple error handling; know how to return a default value.
+- `maybe`
 
 ## Prerequisites
 
-- `basics-2`: Know the basic syntax of an Elm file.
-- `records`: Learn how to use records in an Elm program.
+- `basics-2`
+- `records`

--- a/exercises/concept/tisbury-treasure-hunt/.meta/design.md
+++ b/exercises/concept/tisbury-treasure-hunt/.meta/design.md
@@ -12,9 +12,9 @@ Introduce the student to tuples and how to work with them.
 
 ## Concepts
 
-- `tuples`: Understand tuples in Elm.
+- `tuples`
 
 ## Prerequisites
 
-- `basics-2`: Know the basic syntax of an Elm file.
-- `lists`: understand `List` type.
+- `basics-2`
+- `lists`

--- a/exercises/concept/tracks-on-tracks-on-tracks/.meta/design.md
+++ b/exercises/concept/tracks-on-tracks-on-tracks/.meta/design.md
@@ -20,8 +20,8 @@
 
 ## Concepts
 
-- `lists`: know of the existence of the `List` type; know how to define an empty and non-empty list; know how to add an element to a list; know some common list functions; know how to pattern match on lists.
+- `lists`
 
 ## Prerequisites
 
-- `basics-2`: Know the basic syntax of an Elm file.
+- `basics-2`

--- a/exercises/concept/valentines-day/.meta/design.md
+++ b/exercises/concept/valentines-day/.meta/design.md
@@ -13,8 +13,8 @@
 
 ## Concepts
 
-- `custom-types`: know what custom types are; know how to define a custom type, with and without data; know how to pattern match on custom types.
+- `custom-types`
 
 ## Prerequisites
 
-- `basics-2`: Know the basic syntax of an Elm file.
+- `basics-2`


### PR DESCRIPTION
We have been writing the "Concept" and "Requirements" parts of the `design.md` doc differently for the concept exercises. This change consists in simplifying and standardizing that section of this document.

Basically it now simply contains the list of the hashes of concepts required. There is no need to repeat what is already said just above or to detail requirements that are pretty obvious from the concept name. Elixir is doing the same.