### PR TITLE
Sync exercises elm.json with template/elm.json

### DIFF
--- a/exercises/concept/bettys-bike-shop/elm.json
+++ b/exercises/concept/bettys-bike-shop/elm.json
@@ -1,27 +1,28 @@
 {
-  "type": "application",
-  "source-directories": ["src"],
-  "elm-version": "0.19.1",
-  "dependencies": {
-    "direct": {
-      "elm/browser": "1.0.0",
-      "elm/core": "1.0.0",
-      "elm/html": "1.0.0",
-      "elm/regex": "1.0.0"
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
+        },
+        "indirect": {}
     },
-    "indirect": {
-      "elm/json": "1.0.0",
-      "elm/time": "1.0.0",
-      "elm/url": "1.0.0",
-      "elm/virtual-dom": "1.0.0"
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+        },
+        "indirect": {
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
+        }
     }
-  },
-  "test-dependencies": {
-    "direct": {
-      "elm-explorations/test": "1.0.0"
-    },
-    "indirect": {
-      "elm/random": "1.0.0"
-    }
-  }
 }

--- a/exercises/concept/lucians-luscious-lasagna/elm.json
+++ b/exercises/concept/lucians-luscious-lasagna/elm.json
@@ -1,27 +1,28 @@
 {
-  "type": "application",
-  "source-directories": ["src"],
-  "elm-version": "0.19.1",
-  "dependencies": {
-    "direct": {
-      "elm/browser": "1.0.0",
-      "elm/core": "1.0.0",
-      "elm/html": "1.0.0",
-      "elm/regex": "1.0.0"
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
+        },
+        "indirect": {}
     },
-    "indirect": {
-      "elm/json": "1.0.0",
-      "elm/time": "1.0.0",
-      "elm/url": "1.0.0",
-      "elm/virtual-dom": "1.0.0"
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+        },
+        "indirect": {
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
+        }
     }
-  },
-  "test-dependencies": {
-    "direct": {
-      "elm-explorations/test": "1.0.0"
-    },
-    "indirect": {
-      "elm/random": "1.0.0"
-    }
-  }
 }

--- a/exercises/concept/tracks-on-tracks-on-tracks/elm.json
+++ b/exercises/concept/tracks-on-tracks-on-tracks/elm.json
@@ -1,27 +1,28 @@
 {
-  "type": "application",
-  "source-directories": ["src"],
-  "elm-version": "0.19.1",
-  "dependencies": {
-    "direct": {
-      "elm/browser": "1.0.0",
-      "elm/core": "1.0.0",
-      "elm/html": "1.0.0",
-      "elm/regex": "1.0.0"
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
+        },
+        "indirect": {}
     },
-    "indirect": {
-      "elm/json": "1.0.0",
-      "elm/time": "1.0.0",
-      "elm/url": "1.0.0",
-      "elm/virtual-dom": "1.0.0"
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+        },
+        "indirect": {
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
+        }
     }
-  },
-  "test-dependencies": {
-    "direct": {
-      "elm-explorations/test": "1.0.0"
-    },
-    "indirect": {
-      "elm/random": "1.0.0"
-    }
-  }
 }

--- a/exercises/practice/accumulate/elm.json
+++ b/exercises/practice/accumulate/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/acronym/elm.json
+++ b/exercises/practice/acronym/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/all-your-base/elm.json
+++ b/exercises/practice/all-your-base/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/allergies/elm.json
+++ b/exercises/practice/allergies/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/anagram/elm.json
+++ b/exercises/practice/anagram/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/armstrong-numbers/elm.json
+++ b/exercises/practice/armstrong-numbers/elm.json
@@ -6,7 +6,10 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/core": "1.0.0",
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0"
         },
@@ -14,13 +17,12 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0",
-            "elm/parser": "1.1.0",
+            "elm-explorations/test": "1.2.2",
             "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0",
-            "elm/json": "1.1.3"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/atbash-cipher/elm.json
+++ b/exercises/practice/atbash-cipher/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/binary-search/elm.json
+++ b/exercises/practice/binary-search/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/bob/elm.json
+++ b/exercises/practice/bob/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/collatz-conjecture/elm.json
+++ b/exercises/practice/collatz-conjecture/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/difference-of-squares/elm.json
+++ b/exercises/practice/difference-of-squares/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/etl/elm.json
+++ b/exercises/practice/etl/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/gigasecond/elm.json
+++ b/exercises/practice/gigasecond/elm.json
@@ -6,26 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
             "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.2"
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/grade-school/elm.json
+++ b/exercises/practice/grade-school/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/grains/elm.json
+++ b/exercises/practice/grains/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/hamming/elm.json
+++ b/exercises/practice/hamming/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/hello-world/elm.json
+++ b/exercises/practice/hello-world/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/isogram/elm.json
+++ b/exercises/practice/isogram/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/largest-series-product/elm.json
+++ b/exercises/practice/largest-series-product/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/leap/elm.json
+++ b/exercises/practice/leap/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/list-ops/elm.json
+++ b/exercises/practice/list-ops/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/luhn/elm.json
+++ b/exercises/practice/luhn/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/matching-brackets/elm.json
+++ b/exercises/practice/matching-brackets/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/nucleotide-count/elm.json
+++ b/exercises/practice/nucleotide-count/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/pangram/elm.json
+++ b/exercises/practice/pangram/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/pascals-triangle/elm.json
+++ b/exercises/practice/pascals-triangle/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/phone-number/elm.json
+++ b/exercises/practice/phone-number/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/pythagorean-triplet/elm.json
+++ b/exercises/practice/pythagorean-triplet/elm.json
@@ -6,7 +6,10 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/core": "1.0.0",
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
             "elm/time": "1.0.0"
         },
@@ -14,13 +17,12 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0",
-            "elm/parser": "1.1.0",
+            "elm-explorations/test": "1.2.2",
             "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0",
-            "elm/json": "1.1.3"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/raindrops/elm.json
+++ b/exercises/practice/raindrops/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/rna-transcription/elm.json
+++ b/exercises/practice/rna-transcription/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/robot-simulator/elm.json
+++ b/exercises/practice/robot-simulator/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/roman-numerals/elm.json
+++ b/exercises/practice/roman-numerals/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/run-length-encoding/elm.json
+++ b/exercises/practice/run-length-encoding/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/say/elm.json
+++ b/exercises/practice/say/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/scrabble-score/elm.json
+++ b/exercises/practice/scrabble-score/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/series/elm.json
+++ b/exercises/practice/series/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/space-age/elm.json
+++ b/exercises/practice/space-age/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/strain/elm.json
+++ b/exercises/practice/strain/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/sublist/elm.json
+++ b/exercises/practice/sublist/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/sum-of-multiples/elm.json
+++ b/exercises/practice/sum-of-multiples/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/transpose/elm.json
+++ b/exercises/practice/transpose/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/triangle/elm.json
+++ b/exercises/practice/triangle/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/twelve-days/elm.json
+++ b/exercises/practice/twelve-days/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/two-fer/elm.json
+++ b/exercises/practice/two-fer/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/word-count/elm.json
+++ b/exercises/practice/word-count/elm.json
@@ -6,24 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.0",
-            "elm/core": "1.0.0",
-            "elm/html": "1.0.0",
-            "elm/regex": "1.0.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
-        "indirect": {
-            "elm/json": "1.0.0",
-            "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.0"
-        }
+        "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0"
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }

--- a/exercises/practice/wordy/elm.json
+++ b/exercises/practice/wordy/elm.json
@@ -6,19 +6,23 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/core": "1.0.0",
-            "elm/parser": "1.1.0"
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
         },
         "indirect": {}
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.0.0",
+            "elm-explorations/test": "1.2.2",
             "rtfeldman/elm-iso8601-date-strings": "1.1.3"
         },
         "indirect": {
-            "elm/random": "1.0.0",
-            "elm/json": "1.1.3"
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
         }
     }
 }


### PR DESCRIPTION
All automatic CI for tests is run based on the packages inside `template/elm.json` to build the test runner docker container. It is thus important than all `elm.json` of exercises use the same config so that we know the test runner will work. This change sync all elm.json files.

We should add a CI check for that such that files are synced when we update that template elm.json. Let's create an issue for that and deal with it later.