### PR TITLE
Add labels for priorities of issues

### DIFF
--- a/.appends/.github/labels.yml
+++ b/.appends/.github/labels.yml
@@ -14,3 +14,11 @@
 - name: "wontfix"
   description: ""
   color: "ffffff"
+
+- name: "x:priority/high"
+  description: "Has a higher priority than other issues"
+  color: "8FDAF8"
+
+- name: "x:priority/low"
+  description: "Has a lower priority than other issues"
+  color: "8FDAF9"


### PR DESCRIPTION
This formalizes the `x:priority/high` and `x:priority/low` labels that I've created manually.