### PR TITLE
Sync: update `bowling` with configlet

### DIFF
--- a/exercises/practice/bowling/.docs/instructions.md
+++ b/exercises/practice/bowling/.docs/instructions.md
@@ -12,15 +12,15 @@ The game consists of 10 frames. A frame is composed of one or two ball
 throws with 10 pins standing at frame initialization. There are three
 cases for the tabulation of a frame.
 
-- An open frame is where a score of less than 10 is recorded for the
+* An open frame is where a score of less than 10 is recorded for the
   frame. In this case the score for the frame is the number of pins
   knocked down.
 
-- A spare is where all ten pins are knocked down by the second
+* A spare is where all ten pins are knocked down by the second
   throw. The total value of a spare is 10 plus the number of pins
   knocked down in their next throw.
 
-- A strike is where all ten pins are knocked down by the first
+* A strike is where all ten pins are knocked down by the first
   throw. The total value of a strike is 10 plus the number of pins
   knocked down in the next two throws. If a strike is immediately
   followed by a second strike, then the value of the first strike
@@ -28,9 +28,9 @@ cases for the tabulation of a frame.
 
 Here is a three frame example:
 
-|  Frame 1   |  Frame 2   |     Frame 3      |
-| :--------: | :--------: | :--------------: |
-| X (strike) | 5/ (spare) | 9 0 (open frame) |
+| Frame 1         | Frame 2       | Frame 3                |
+| :-------------: |:-------------:| :---------------------:|
+| X (strike)      | 5/ (spare)    | 9 0 (open frame)       |
 
 Frame 1 is (10 + 5 + 5) = 20
 
@@ -52,7 +52,10 @@ For a tenth frame of XXX (three strikes), the total value is 30.
 
 ## Requirements
 
-Write code to keep track of the score of a game of bowling.
+Write code to keep track of the score of a game of bowling. It should
+support two operations:
 
-- `score : List Int -> Maybe Int` is called only at the very end of the game. It
+* `roll(pins : int)` is called each time the player rolls a ball.  The
+  argument is the number of pins knocked down.
+* `score() : int` is called only at the very end of the game.  It
   returns the total score for that game.

--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -1,10 +1,11 @@
 {
-  "blurb": "Score a bowling game",
+  "blurb": "Score a bowling game.",
   "authors": [
     "leojpod"
   ],
   "contributors": [
-    "ceddlyburge"
+    "ceddlyburge",
+    "jiegillet"
   ],
   "files": {
     "solution": [
@@ -19,6 +20,6 @@
       ".meta/src/Bowling.example.elm"
     ]
   },
-  "source": "Inspired by Uncle Bob's Bowling Game Kata",
+  "source": "The Bowling Game Kata at but UncleBob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"
 }

--- a/exercises/practice/bowling/.meta/tests.toml
+++ b/exercises/practice/bowling/.meta/tests.toml
@@ -1,0 +1,103 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[656ae006-25c2-438c-a549-f338e7ec7441]
+description = "should be able to score a game with all zeros"
+
+[f85dcc56-cd6b-4875-81b3-e50921e3597b]
+description = "should be able to score a game with no strikes or spares"
+
+[d1f56305-3ac2-4fe0-8645-0b37e3073e20]
+description = "a spare followed by zeros is worth ten points"
+
+[0b8c8bb7-764a-4287-801a-f9e9012f8be4]
+description = "points scored in the roll after a spare are counted twice"
+
+[4d54d502-1565-4691-84cd-f29a09c65bea]
+description = "consecutive spares each get a one roll bonus"
+
+[e5c9cf3d-abbe-4b74-ad48-34051b2b08c0]
+description = "a spare in the last frame gets a one roll bonus that is counted once"
+
+[75269642-2b34-4b72-95a4-9be28ab16902]
+description = "a strike earns ten points in a frame with a single roll"
+
+[037f978c-5d01-4e49-bdeb-9e20a2e6f9a6]
+description = "points scored in the two rolls after a strike are counted twice as a bonus"
+
+[1635e82b-14ec-4cd1-bce4-4ea14bd13a49]
+description = "consecutive strikes each get the two roll bonus"
+
+[e483e8b6-cb4b-4959-b310-e3982030d766]
+description = "a strike in the last frame gets a two roll bonus that is counted once"
+
+[9d5c87db-84bc-4e01-8e95-53350c8af1f8]
+description = "rolling a spare with the two roll bonus does not get a bonus roll"
+
+[576faac1-7cff-4029-ad72-c16bcada79b5]
+description = "strikes with the two roll bonus do not get bonus rolls"
+
+[efb426ec-7e15-42e6-9b96-b4fca3ec2359]
+description = "last two strikes followed by only last bonus with non strike points"
+
+[72e24404-b6c6-46af-b188-875514c0377b]
+description = "a strike with the one roll bonus after a spare in the last frame does not get a bonus"
+
+[62ee4c72-8ee8-4250-b794-234f1fec17b1]
+description = "all strikes is a perfect game"
+
+[1245216b-19c6-422c-b34b-6e4012d7459f]
+description = "rolls cannot score negative points"
+
+[5fcbd206-782c-4faa-8f3a-be5c538ba841]
+description = "a roll cannot score more than 10 points"
+
+[fb023c31-d842-422d-ad7e-79ce1db23c21]
+description = "two rolls in a frame cannot score more than 10 points"
+
+[6082d689-d677-4214-80d7-99940189381b]
+description = "bonus roll after a strike in the last frame cannot score more than 10 points"
+
+[e9565fe6-510a-4675-ba6b-733a56767a45]
+description = "two bonus rolls after a strike in the last frame cannot score more than 10 points"
+
+[2f6acf99-448e-4282-8103-0b9c7df99c3d]
+description = "two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike"
+
+[6380495a-8bc4-4cdb-a59f-5f0212dbed01]
+description = "the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike"
+
+[2b2976ea-446c-47a3-9817-42777f09fe7e]
+description = "second bonus roll after a strike in the last frame cannot score more than 10 points"
+
+[29220245-ac8d-463d-bc19-98a94cfada8a]
+description = "an unstarted game cannot be scored"
+
+[4473dc5d-1f86-486f-bf79-426a52ddc955]
+description = "an incomplete game cannot be scored"
+
+[2ccb8980-1b37-4988-b7d1-e5701c317df3]
+description = "cannot roll if game already has ten frames"
+
+[4864f09b-9df3-4b65-9924-c595ed236f1b]
+description = "bonus rolls for a strike in the last frame must be rolled before score can be calculated"
+
+[537f4e37-4b51-4d1c-97e2-986eb37b2ac1]
+description = "both bonus rolls for a strike in the last frame must be rolled before score can be calculated"
+
+[8134e8c1-4201-4197-bf9f-1431afcde4b9]
+description = "bonus roll for a spare in the last frame must be rolled before score can be calculated"
+
+[9d4a9a55-134a-4bad-bae8-3babf84bd570]
+description = "cannot roll after bonus roll for spare"
+
+[d3e02652-a799-4ae3-b53b-68582cc604be]
+description = "cannot roll after bonus rolls for strike"

--- a/exercises/practice/bowling/tests/Tests.elm
+++ b/exercises/practice/bowling/tests/Tests.elm
@@ -12,120 +12,154 @@ tests =
             \_ ->
                 score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
                     |> Expect.equal (Just 0)
-        , test "should be able to score a game with no strikes or spares" <|
-            \_ ->
-                score [ 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6 ]
-                    |> Expect.equal (Just 90)
-        , test "a spare followed by zeros is worth ten points" <|
-            \_ ->
-                score [ 6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
-                    |> Expect.equal (Just 10)
-        , test "points scored in the roll after a spare are counted twice" <|
-            \_ ->
-                score [ 6, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
-                    |> Expect.equal (Just 16)
-        , test "consecutive spares each get a one roll bonus" <|
-            \_ ->
-                score [ 5, 5, 3, 7, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
-                    |> Expect.equal (Just 31)
-        , test "a spare in the last frame gets a one roll bonus that is counted once" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 7 ]
-                    |> Expect.equal (Just 17)
-        , test "a strike earns ten points in a frame with a single roll" <|
-            \_ ->
-                score [ 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
-                    |> Expect.equal (Just 10)
-        , test "points scored in the two rolls after a strike are counted twice as a bonus" <|
-            \_ ->
-                score [ 10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
-                    |> Expect.equal (Just 26)
-        , test "consecutive strikes each get the two roll bonus" <|
-            \_ ->
-                score [ 10, 10, 10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
-                    |> Expect.equal (Just 81)
-        , test "a strike in the last frame gets a two roll bonus that is counted once" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 1 ]
-                    |> Expect.equal (Just 18)
-        , test "rolling a spare with the two roll bonus does not get a bonus roll" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 3 ]
-                    |> Expect.equal (Just 20)
-        , test "strikes with the two roll bonus do not get bonus rolls" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 10 ]
-                    |> Expect.equal (Just 30)
-        , test "a strike with the one roll bonus after a spare in the last frame does not get a bonus" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 10 ]
-                    |> Expect.equal (Just 20)
-        , test "all strikes is a perfect game" <|
-            \_ ->
-                score [ 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10 ]
-                    |> Expect.equal (Just 300)
-        , test "rolls cannot score negative points" <|
-            \_ ->
-                score [ -1 ]
-                    |> Expect.equal Nothing
-        , test "a roll cannot score more than 10 points" <|
-            \_ ->
-                score [ 11 ]
-                    |> Expect.equal Nothing
-        , test "two rolls in a frame cannot score more than 10 points" <|
-            \_ ->
-                score [ 5, 6 ]
-                    |> Expect.equal Nothing
-        , test "bonus roll after a strike in the last frame cannot score more than 10 points" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 11 ]
-                    |> Expect.equal Nothing
-        , test "two bonus rolls after a strike in the last frame cannot score more than 10 points" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5, 6 ]
-                    |> Expect.equal Nothing
-        , test "two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 6 ]
-                    |> Expect.equal (Just 26)
-        , test "the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6, 10 ]
-                    |> Expect.equal Nothing
-        , test "second bonus roll after a strike in the last frame cannot score more than 10 points" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 11 ]
-                    |> Expect.equal Nothing
-        , test "an unstarted game cannot be scored" <|
-            \_ ->
-                score []
-                    |> Expect.equal Nothing
-        , test "an incomplete game cannot be scored" <|
-            \_ ->
-                score [ 0, 0 ]
-                    |> Expect.equal Nothing
-        , test "cannot roll if game already has ten frames" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
-                    |> Expect.equal Nothing
-        , test "bonus rolls for a strike in the last frame must be rolled before score can be calculated" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10 ]
-                    |> Expect.equal Nothing
-        , test "both bonus rolls for a strike in the last frame must be rolled before score can be calculated" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10 ]
-                    |> Expect.equal Nothing
-        , test "bonus roll for a spare in the last frame must be rolled before score can be calculated" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3 ]
-                    |> Expect.equal Nothing
-        , test "cannot roll after bonus roll for spare" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 2, 2 ]
-                    |> Expect.equal Nothing
-        , test "cannot roll after bonus rolls for strike" <|
-            \_ ->
-                score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 3, 2, 2 ]
-                    |> Expect.equal Nothing
+        , skip <|
+            test "should be able to score a game with no strikes or spares" <|
+                \_ ->
+                    score [ 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6, 3, 6 ]
+                        |> Expect.equal (Just 90)
+        , skip <|
+            test "a spare followed by zeros is worth ten points" <|
+                \_ ->
+                    score [ 6, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+                        |> Expect.equal (Just 10)
+        , skip <|
+            test "points scored in the roll after a spare are counted twice" <|
+                \_ ->
+                    score [ 6, 4, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+                        |> Expect.equal (Just 16)
+        , skip <|
+            test "consecutive spares each get a one roll bonus" <|
+                \_ ->
+                    score [ 5, 5, 3, 7, 4, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+                        |> Expect.equal (Just 31)
+        , skip <|
+            test "a spare in the last frame gets a one roll bonus that is counted once" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 7 ]
+                        |> Expect.equal (Just 17)
+        , skip <|
+            test "a strike earns ten points in a frame with a single roll" <|
+                \_ ->
+                    score [ 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+                        |> Expect.equal (Just 10)
+        , skip <|
+            test "points scored in the two rolls after a strike are counted twice as a bonus" <|
+                \_ ->
+                    score [ 10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+                        |> Expect.equal (Just 26)
+        , skip <|
+            test "consecutive strikes each get the two roll bonus" <|
+                \_ ->
+                    score [ 10, 10, 10, 5, 3, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+                        |> Expect.equal (Just 81)
+        , skip <|
+            test "a strike in the last frame gets a two roll bonus that is counted once" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 1 ]
+                        |> Expect.equal (Just 18)
+        , skip <|
+            test "rolling a spare with the two roll bonus does not get a bonus roll" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 7, 3 ]
+                        |> Expect.equal (Just 20)
+        , skip <|
+            test "strikes with the two roll bonus do not get bonus rolls" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 10 ]
+                        |> Expect.equal (Just 30)
+        , skip <|
+            test "last two strikes followed by only last bonus with non strike points" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 0, 1 ]
+                        |> Expect.equal (Just 31)
+        , skip <|
+            test "a strike with the one roll bonus after a spare in the last frame does not get a bonus" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 10 ]
+                        |> Expect.equal (Just 20)
+        , skip <|
+            test "all strikes is a perfect game" <|
+                \_ ->
+                    score [ 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10 ]
+                        |> Expect.equal (Just 300)
+        , skip <|
+            test "rolls cannot score negative points" <|
+                \_ ->
+                    score [ -1 ]
+                        |> Expect.equal Nothing
+        , skip <|
+            test "a roll cannot score more than 10 points" <|
+                \_ ->
+                    score [ 11 ]
+                        |> Expect.equal Nothing
+        , skip <|
+            test "two rolls in a frame cannot score more than 10 points" <|
+                \_ ->
+                    score [ 5, 6 ]
+                        |> Expect.equal Nothing
+        , skip <|
+            test "bonus roll after a strike in the last frame cannot score more than 10 points" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 11 ]
+                        |> Expect.equal Nothing
+        , skip <|
+            test "two bonus rolls after a strike in the last frame cannot score more than 10 points" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 5, 6 ]
+                        |> Expect.equal Nothing
+        , skip <|
+            test "two bonus rolls after a strike in the last frame can score more than 10 points if one is a strike" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 6 ]
+                        |> Expect.equal (Just 26)
+        , skip <|
+            test "the second bonus rolls after a strike in the last frame cannot be a strike if the first one is not a strike" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 6, 10 ]
+                        |> Expect.equal Nothing
+        , skip <|
+            test "second bonus roll after a strike in the last frame cannot score more than 10 points" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10, 11 ]
+                        |> Expect.equal Nothing
+        , skip <|
+            test "an unstarted game cannot be scored" <|
+                \_ ->
+                    score []
+                        |> Expect.equal Nothing
+        , skip <|
+            test "an incomplete game cannot be scored" <|
+                \_ ->
+                    score [ 0, 0 ]
+                        |> Expect.equal Nothing
+        , skip <|
+            test "cannot roll if game already has ten frames" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 ]
+                        |> Expect.equal Nothing
+        , skip <|
+            test "bonus rolls for a strike in the last frame must be rolled before score can be calculated" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10 ]
+                        |> Expect.equal Nothing
+        , skip <|
+            test "both bonus rolls for a strike in the last frame must be rolled before score can be calculated" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 10 ]
+                        |> Expect.equal Nothing
+        , skip <|
+            test "bonus roll for a spare in the last frame must be rolled before score can be calculated" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3 ]
+                        |> Expect.equal Nothing
+        , skip <|
+            test "cannot roll after bonus roll for spare" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 7, 3, 2, 2 ]
+                        |> Expect.equal Nothing
+        , skip <|
+            test "cannot roll after bonus rolls for strike" <|
+                \_ ->
+                    score [ 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 10, 3, 2, 2 ]
+                        |> Expect.equal Nothing
         ]


### PR DESCRIPTION
I ran `configlet sync` on the track and saw a bunch of things that could be fixed, so I'd like to work through these if it's OK.
Some syncs involve adding new tests, I'll make separate PRs for those, starting with this one.

For the `bowling` exercise:
* synced `instructions.md` (automated)
* added `tests.tom` (automated)
* added the `skip <|` in the tests to match the template
* added one new test ("last two strikes followed by only last bonus with non strike points") from latest specs in problem-specifications. Sorry it's impossible to notice in the diff because of the added `skip <|`.
* synced `config.json` (automated + I added my name as a contributor since I added a test)