### PR TITLE
Sync: re-implement `grade-school` according to new specs

### DIFF
--- a/exercises/practice/grade-school/.docs/instructions.md
+++ b/exercises/practice/grade-school/.docs/instructions.md
@@ -8,7 +8,7 @@ In the end, you should be able to:
 - Add a student's name to the roster for a grade
   - "Add Jim to grade 2."
   - "OK."
-- Get a list of all students enrolled in a grade, sorted alphabetically
+- Get a list of all students enrolled in a grade
   - "Which students are in grade 2?"
   - "We've only got Jim just now."
 - Get a sorted list of all students in all grades.  Grades should sort
@@ -21,8 +21,11 @@ In the end, you should be able to:
   and Jim in grade 5.
   So the answer is: Anna, Barb, Charlie, Alex, Peter, Zoe and Jim"
 
-Note that all our students only have one name.  (It's a small town, what
-do you want?)
+Note that all our students only have one name  (It's a small town, what
+do you want?) and each student cannot be added more than once to a grade or the
+roster.
+In fact, when a test attempts to add the same student more than once, your
+implementation should indicate that this is incorrect.
 
 ## For bonus points
 

--- a/exercises/practice/grade-school/.meta/config.json
+++ b/exercises/practice/grade-school/.meta/config.json
@@ -1,9 +1,10 @@
 {
-  "blurb": "Given students' names along with the grade that they are in, create a roster for the school",
+  "blurb": "Given students' names along with the grade that they are in, create a roster for the school.",
   "authors": [
     "tgecho"
   ],
   "contributors": [
+    "jiegillet",
     "leojpod",
     "nathanielknight",
     "parkerl",

--- a/exercises/practice/grade-school/.meta/src/GradeSchool.example.elm
+++ b/exercises/practice/grade-school/.meta/src/GradeSchool.example.elm
@@ -1,4 +1,4 @@
-module GradeSchool exposing (addStudent, allStudents, empty, studentsInGrade)
+module GradeSchool exposing (Grade, Result(..), School, Student, addStudent, allStudents, emptySchool, studentsInGrade)
 
 import Dict exposing (..)
 
@@ -15,14 +15,23 @@ type alias School =
     Dict Int (List Student)
 
 
-empty : School
-empty =
+type Result
+    = Added
+    | Duplicate
+
+
+emptySchool : School
+emptySchool =
     Dict.empty
 
 
-addStudent : Grade -> Student -> School -> School
+addStudent : Grade -> Student -> School -> ( Result, School )
 addStudent grade student school =
-    Dict.insert grade (List.sort (student :: studentsInGrade grade school)) school
+    if List.member student (allStudents school) then
+        ( Duplicate, school )
+
+    else
+        ( Added, Dict.insert grade (List.sort (student :: studentsInGrade grade school)) school )
 
 
 studentsInGrade : Grade -> School -> List Student
@@ -35,6 +44,8 @@ studentsInGrade grade school =
             []
 
 
-allStudents : School -> List ( Grade, List Student )
+allStudents : School -> List Student
 allStudents school =
-    Dict.toList school |> List.sortBy Tuple.first
+    Dict.toList school
+        |> List.map Tuple.second
+        |> List.concat

--- a/exercises/practice/grade-school/.meta/src/GradeSchool.example.elm
+++ b/exercises/practice/grade-school/.meta/src/GradeSchool.example.elm
@@ -47,5 +47,6 @@ studentsInGrade grade school =
 allStudents : School -> List Student
 allStudents school =
     Dict.toList school
+        -- Dict.toList returns the elements sorted by key
         |> List.map Tuple.second
         |> List.concat

--- a/exercises/practice/grade-school/.meta/tests.toml
+++ b/exercises/practice/grade-school/.meta/tests.toml
@@ -1,24 +1,86 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
-
-[6d0a30e4-1b4e-472e-8e20-c41702125667]
-description = "Adding a student adds them to the sorted roster"
-
-[233be705-dd58-4968-889d-fb3c7954c9cc]
-description = "Adding more student adds them to the sorted roster"
-
-[75a51579-d1d7-407c-a2f8-2166e984e8ab]
-description = "Adding students to different grades adds them to the same sorted roster"
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [a3f0fb58-f240-4723-8ddc-e644666b85cc]
-description = "Roster returns an empty list if there are no students enrolled"
+description = "Roster is empty when no student is added"
+
+[9337267f-7793-4b90-9b4a-8e3978408824]
+description = "Add a student"
+
+[6d0a30e4-1b4e-472e-8e20-c41702125667]
+description = "Student is added to the roster"
+
+[73c3ca75-0c16-40d7-82f5-ed8fe17a8e4a]
+description = "Adding multiple students in the same grade in the roster"
+
+[233be705-dd58-4968-889d-fb3c7954c9cc]
+description = "Multiple students in the same grade are added to the roster"
+
+[87c871c1-6bde-4413-9c44-73d59a259d83]
+description = "Cannot add student to same grade in the roster more than once"
+
+[c125dab7-2a53-492f-a99a-56ad511940d8]
+description = "A student can't be in two different grades"
+include = false
+
+[a0c7b9b8-0e89-47f8-8b4a-c50f885e79d1]
+description = "A student can only be added to the same grade in the roster once"
+include = false
+reimplements = "c125dab7-2a53-492f-a99a-56ad511940d8"
+
+[d7982c4f-1602-49f6-a651-620f2614243a]
+description = "Student not added to same grade in the roster more than once"
+reimplements = "a0c7b9b8-0e89-47f8-8b4a-c50f885e79d1"
+
+[e70d5d8f-43a9-41fd-94a4-1ea0fa338056]
+description = "Adding students in multiple grades"
+
+[75a51579-d1d7-407c-a2f8-2166e984e8ab]
+description = "Students in multiple grades are added to the roster"
+
+[7df542f1-57ce-433c-b249-ff77028ec479]
+description = "Cannot add same student to multiple grades in the roster"
+
+[6a03b61e-1211-4783-a3cc-fc7f773fba3f]
+description = "A student cannot be added to more than one grade in the sorted roster"
+include = false
+reimplements = "c125dab7-2a53-492f-a99a-56ad511940d8"
+
+[c7ec1c5e-9ab7-4d3b-be5c-29f2f7a237c5]
+description = "Student not added to multiple grades in the roster"
+reimplements = "6a03b61e-1211-4783-a3cc-fc7f773fba3f"
+
+[d9af4f19-1ba1-48e7-94d0-dabda4e5aba6]
+description = "Students are sorted by grades in the roster"
+
+[d9fb5bea-f5aa-4524-9d61-c158d8906807]
+description = "Students are sorted by name in the roster"
 
 [180a8ff9-5b94-43fc-9db1-d46b4a8c93b6]
-description = "Student names with grades are displayed in the same sorted roster"
-
-[1bfbcef1-e4a3-49e8-8d22-f6f9f386187e]
-description = "Grade returns the students in that grade in alphabetical order"
+description = "Students are sorted by grades and then by name in the roster"
 
 [5e67aa3c-a3c6-4407-a183-d8fe59cd1630]
-description = "Grade returns an empty list if there are no students in that grade"
+description = "Grade is empty if no students in the roster"
+
+[1e0cf06b-26e0-4526-af2d-a2e2df6a51d6]
+description = "Grade is empty if no students in that grade"
+
+[2bfc697c-adf2-4b65-8d0f-c46e085f796e]
+description = "Student not added to same grade more than once"
+
+[66c8e141-68ab-4a04-a15a-c28bc07fe6b9]
+description = "Student not added to multiple grades"
+
+[c9c1fc2f-42e0-4d2c-b361-99271f03eda7]
+description = "Student not added to other grade for multiple grades"
+
+[1bfbcef1-e4a3-49e8-8d22-f6f9f386187e]
+description = "Students are sorted by name in a grade"

--- a/exercises/practice/grade-school/src/GradeSchool.elm
+++ b/exercises/practice/grade-school/src/GradeSchool.elm
@@ -1,6 +1,6 @@
-module GradeSchool exposing (addStudent, allStudents, empty, studentsInGrade)
+module GradeSchool exposing (Grade, Result(..), School, Student, addStudent, allStudents, emptySchool, studentsInGrade)
 
-import Dict exposing (Dict)
+import Dict exposing (..)
 
 
 type alias Grade =
@@ -12,15 +12,20 @@ type alias Student =
 
 
 type alias School =
-    Dict Grade (List Student)
+    Dict Int (List Student)
 
 
-empty : School
-empty =
-    Dict.empty
+type Result
+    = Added
+    | Duplicate
 
 
-addStudent : Grade -> Student -> School -> School
+emptySchool : School
+emptySchool =
+    Debug.todo "Please implement this function"
+
+
+addStudent : Grade -> Student -> School -> ( Result, School )
 addStudent grade student school =
     Debug.todo "Please implement this function"
 
@@ -30,6 +35,6 @@ studentsInGrade grade school =
     Debug.todo "Please implement this function"
 
 
-allStudents : School -> List ( Grade, List Student )
+allStudents : School -> List Student
 allStudents school =
     Debug.todo "Please implement this function"

--- a/exercises/practice/grade-school/src/GradeSchool.elm
+++ b/exercises/practice/grade-school/src/GradeSchool.elm
@@ -22,19 +22,19 @@ type Result
 
 emptySchool : School
 emptySchool =
-    Debug.todo "Please implement this function"
+    Debug.todo "Please implement emptySchool"
 
 
 addStudent : Grade -> Student -> School -> ( Result, School )
 addStudent grade student school =
-    Debug.todo "Please implement this function"
+    Debug.todo "Please implement addStudent"
 
 
 studentsInGrade : Grade -> School -> List Student
 studentsInGrade grade school =
-    Debug.todo "Please implement this function"
+    Debug.todo "Please implement studentsInGrade"
 
 
 allStudents : School -> List Student
 allStudents school =
-    Debug.todo "Please implement this function"
+    Debug.todo "Please implement allStudents"

--- a/exercises/practice/grade-school/tests/Tests.elm
+++ b/exercises/practice/grade-school/tests/Tests.elm
@@ -8,17 +8,12 @@ import Test exposing (..)
 buildSchoolwithStudents : List ( Student, Grade ) -> ( List Result, School )
 buildSchoolwithStudents students =
     let
-        ( reversedResults, finalSchool ) =
-            List.foldl insert ( [], emptySchool ) students
-
         insert ( student, grade ) ( results, school ) =
-            let
-                ( result, newSchool ) =
-                    addStudent grade student school
-            in
-            ( result :: results, newSchool )
+            addStudent grade student school
+                |> Tuple.mapFirst (\result -> result :: results)
     in
-    ( List.reverse reversedResults, finalSchool )
+    List.foldl insert ( [], emptySchool ) students
+        |> Tuple.mapFirst List.reverse
 
 
 tests : Test
@@ -26,141 +21,137 @@ tests =
     describe "GradeSchool"
         [ test "Roster is empty when no student is added" <|
             \() -> Expect.equal [] (allStudents emptySchool)
-        , test "Add a student" <|
-            \() ->
-                let
-                    ( result, _ ) =
-                        addStudent 2 "Aimee" emptySchool
-                in
-                Expect.equal Added result
-        , test "Student is added to the roster" <|
-            \() ->
-                let
-                    ( _, school ) =
-                        buildSchoolwithStudents [ ( "Aimee", 2 ) ]
-                in
-                Expect.equal [ "Aimee" ] (allStudents school)
-        , test "Adding multiple students in the same grade in the roster" <|
-            \() ->
-                let
-                    ( results, _ ) =
-                        buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "Paul", 2 ) ]
-                in
-                Expect.equal [ Added, Added, Added ] results
-        , test "Multiple students in the same grade are added to the roster" <|
-            \() ->
-                let
-                    ( _, school ) =
-                        buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "Paul", 2 ) ]
-                in
-                Expect.equal [ "Blair", "James", "Paul" ] (allStudents school)
-        , test "Cannot add student to same grade in the roster more than once" <|
-            \() ->
-                let
-                    ( results, _ ) =
-                        buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 2 ), ( "Paul", 2 ) ]
-                in
-                Expect.equal [ Added, Added, Duplicate, Added ] results
-        , test "Student not added to same grade in the roster more than once" <|
-            \() ->
-                let
-                    ( _, school ) =
-                        buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 2 ), ( "Paul", 2 ) ]
-                in
-                Expect.equal [ "Blair", "James", "Paul" ] (allStudents school)
-        , test "Adding students in multiple grades" <|
-            \() ->
-                let
-                    ( results, _ ) =
-                        buildSchoolwithStudents [ ( "Chelsea", 3 ), ( "Logan", 7 ) ]
-                in
-                Expect.equal [ Added, Added ] results
-        , test "Students in multiple grades are added to the roster" <|
-            \() ->
-                let
-                    ( _, school ) =
-                        buildSchoolwithStudents [ ( "Chelsea", 3 ), ( "Logan", 7 ) ]
-                in
-                Expect.equal [ "Chelsea", "Logan" ] (allStudents school)
-        , test "Cannot add same student to multiple grades in the roster" <|
-            \() ->
-                let
-                    ( results, _ ) =
-                        buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 3 ), ( "Paul", 3 ) ]
-                in
-                Expect.equal [ Added, Added, Duplicate, Added ] results
-        , test "Student not added to multiple grades in the roster" <|
-            \() ->
-                let
-                    ( _, school ) =
-                        buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 3 ), ( "Paul", 3 ) ]
-                in
-                Expect.equal [ "Blair", "James", "Paul" ] (allStudents school)
-        , test "Students are sorted by grades in the roster" <|
-            \() ->
-                let
-                    ( _, school ) =
-                        buildSchoolwithStudents [ ( "Jim", 3 ), ( "Peter", 2 ), ( "Anna", 1 ) ]
-                in
-                Expect.equal [ "Anna", "Peter", "Jim" ] (allStudents school)
-        , test "Students are sorted by name in the roster" <|
-            \() ->
-                let
-                    ( _, school ) =
-                        buildSchoolwithStudents [ ( "Peter", 2 ), ( "Zoe", 2 ), ( "Alex", 2 ) ]
-                in
-                Expect.equal [ "Alex", "Peter", "Zoe" ] (allStudents school)
-        , test "Students are sorted by grades and then by name in the roster" <|
-            \() ->
-                let
-                    ( _, school ) =
-                        buildSchoolwithStudents
-                            [ ( "Peter", 2 )
-                            , ( "Anna", 1 )
-                            , ( "Barb", 1 )
-                            , ( "Zoe", 2 )
-                            , ( "Alex", 2 )
-                            , ( "Jim", 3 )
-                            , ( "Charlie", 1 )
-                            ]
-                in
-                Expect.equal [ "Anna", "Barb", "Charlie", "Alex", "Peter", "Zoe", "Jim" ] (allStudents school)
-        , test "Grade is empty if no students in the roster" <|
-            \() ->
-                Expect.equal [] (studentsInGrade 1 emptySchool)
-        , test "Grade is empty if no students in that grade" <|
-            \() ->
-                let
-                    ( _, school ) =
-                        buildSchoolwithStudents [ ( "Peter", 2 ), ( "Zoe", 2 ), ( "Alex", 2 ), ( "Jim", 3 ) ]
-                in
-                Expect.equal [] (studentsInGrade 1 school)
-        , test "Student not added to same grade more than once" <|
-            \() ->
-                let
-                    ( _, school ) =
-                        buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 2 ), ( "Paul", 2 ) ]
-                in
-                Expect.equal [ "Blair", "James", "Paul" ] (studentsInGrade 2 school)
-        , test "Student not added to multiple grades" <|
-            \() ->
-                let
-                    ( _, school ) =
-                        buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 3 ), ( "Paul", 3 ) ]
-                in
-                Expect.equal [ "Blair", "James" ] (studentsInGrade 2 school)
-        , test "Student not added to other grade for multiple grades" <|
-            \() ->
-                let
-                    ( _, school ) =
-                        buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 3 ), ( "Paul", 3 ) ]
-                in
-                Expect.equal [ "Paul" ] (studentsInGrade 3 school)
-        , test "Students are sorted by name in a grade" <|
-            \() ->
-                let
-                    ( _, school ) =
-                        buildSchoolwithStudents [ ( "Franklin", 5 ), ( "Bradley", 5 ), ( "Jeff", 1 ) ]
-                in
-                Expect.equal [ "Bradley", "Franklin" ] (studentsInGrade 5 school)
+        , skip <|
+            test "Add a student" <|
+                \() ->
+                    addStudent 2 "Aimee" emptySchool
+                        |> Tuple.first
+                        |> Expect.equal Added
+        , skip <|
+            test "Student is added to the roster" <|
+                \() ->
+                    addStudent 2 "Aimee" emptySchool
+                        |> Tuple.second
+                        |> allStudents
+                        |> Expect.equal [ "Aimee" ]
+        , skip <|
+            test "Adding multiple students in the same grade in the roster" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "Paul", 2 ) ]
+                        |> Tuple.first
+                        |> Expect.equal [ Added, Added, Added ]
+        , skip <|
+            test "Multiple students in the same grade are added to the roster" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "Paul", 2 ) ]
+                        |> Tuple.second
+                        |> allStudents
+                        |> Expect.equal [ "Blair", "James", "Paul" ]
+        , skip <|
+            test "Cannot add student to same grade in the roster more than once" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 2 ), ( "Paul", 2 ) ]
+                        |> Tuple.first
+                        |> Expect.equal [ Added, Added, Duplicate, Added ]
+        , skip <|
+            test "Student not added to same grade in the roster more than once" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 2 ), ( "Paul", 2 ) ]
+                        |> Tuple.second
+                        |> allStudents
+                        |> Expect.equal [ "Blair", "James", "Paul" ]
+        , skip <|
+            test "Adding students in multiple grades" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Chelsea", 3 ), ( "Logan", 7 ) ]
+                        |> Tuple.first
+                        |> Expect.equal [ Added, Added ]
+        , skip <|
+            test "Students in multiple grades are added to the roster" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Chelsea", 3 ), ( "Logan", 7 ) ]
+                        |> Tuple.second
+                        |> allStudents
+                        |> Expect.equal [ "Chelsea", "Logan" ]
+        , skip <|
+            test "Cannot add same student to multiple grades in the roster" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 3 ), ( "Paul", 3 ) ]
+                        |> Tuple.first
+                        |> Expect.equal [ Added, Added, Duplicate, Added ]
+        , skip <|
+            test "Student not added to multiple grades in the roster" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 3 ), ( "Paul", 3 ) ]
+                        |> Tuple.second
+                        |> allStudents
+                        |> Expect.equal [ "Blair", "James", "Paul" ]
+        , skip <|
+            test "Students are sorted by grades in the roster" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Jim", 3 ), ( "Peter", 2 ), ( "Anna", 1 ) ]
+                        |> Tuple.second
+                        |> allStudents
+                        |> Expect.equal [ "Anna", "Peter", "Jim" ]
+        , skip <|
+            test "Students are sorted by name in the roster" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Peter", 2 ), ( "Zoe", 2 ), ( "Alex", 2 ) ]
+                        |> Tuple.second
+                        |> allStudents
+                        |> Expect.equal [ "Alex", "Peter", "Zoe" ]
+        , skip <|
+            test "Students are sorted by grades and then by name in the roster" <|
+                \() ->
+                    buildSchoolwithStudents
+                        [ ( "Peter", 2 )
+                        , ( "Anna", 1 )
+                        , ( "Barb", 1 )
+                        , ( "Zoe", 2 )
+                        , ( "Alex", 2 )
+                        , ( "Jim", 3 )
+                        , ( "Charlie", 1 )
+                        ]
+                        |> Tuple.second
+                        |> allStudents
+                        |> Expect.equal [ "Anna", "Barb", "Charlie", "Alex", "Peter", "Zoe", "Jim" ]
+        , skip <|
+            test "Grade is empty if no students in the roster" <|
+                \() ->
+                    Expect.equal [] (studentsInGrade 1 emptySchool)
+        , skip <|
+            test "Grade is empty if no students in that grade" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Peter", 2 ), ( "Zoe", 2 ), ( "Alex", 2 ), ( "Jim", 3 ) ]
+                        |> Tuple.second
+                        |> studentsInGrade 1
+                        |> Expect.equal []
+        , skip <|
+            test "Student not added to same grade more than once" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 2 ), ( "Paul", 2 ) ]
+                        |> Tuple.second
+                        |> studentsInGrade 2
+                        |> Expect.equal [ "Blair", "James", "Paul" ]
+        , skip <|
+            test "Student not added to multiple grades" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 3 ), ( "Paul", 3 ) ]
+                        |> Tuple.second
+                        |> studentsInGrade 2
+                        |> Expect.equal [ "Blair", "James" ]
+        , skip <|
+            test "Student not added to other grade for multiple grades" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Blair", 2 ), ( "James", 2 ), ( "James", 3 ), ( "Paul", 3 ) ]
+                        |> Tuple.second
+                        |> studentsInGrade 3
+                        |> Expect.equal [ "Paul" ]
+        , skip <|
+            test "Students are sorted by name in a grade" <|
+                \() ->
+                    buildSchoolwithStudents [ ( "Franklin", 5 ), ( "Bradley", 5 ), ( "Jeff", 1 ) ]
+                        |> Tuple.second
+                        |> studentsInGrade 5
+                        |> Expect.equal [ "Bradley", "Franklin" ]
         ]


### PR DESCRIPTION
This one is the biggest one of the batch.
Some of the specs changed, and the tests insisted on knowing if adding a student succeeded or not, so I re-implemented the example solution and all of the tests. Please review carefully.

All changes:
* synced instructions and metadata (automatic)
* re-implemented all 20 tests requested by configlet
* synced `tests.toml` (automatic)
* updated example solution and stub
* added my name to `config.json`