### PR TITLE
Sync: minor changes

### DIFF
--- a/exercises/practice/bowling/.meta/config.json
+++ b/exercises/practice/bowling/.meta/config.json
@@ -20,6 +20,6 @@
       ".meta/src/Bowling.example.elm"
     ]
   },
-  "source": "The Bowling Game Kata at but UncleBob",
+  "source": "The Bowling Game Kata from UncleBob",
   "source_url": "http://butunclebob.com/ArticleS.UncleBob.TheBowlingGameKata"
 }

--- a/exercises/practice/luhn/.meta/tests.toml
+++ b/exercises/practice/luhn/.meta/tests.toml
@@ -60,6 +60,9 @@ description = "input digit 9 is correctly converted to output digit 9"
 [b9887ee8-8337-46c5-bc45-3bcab51bc36f]
 description = "very long input is valid"
 
+[8a7c0e24-85ea-4154-9cf1-c2db90eabc08]
+description = "valid luhn with an odd number of digits and non zero first digit"
+
 [39a06a5a-5bad-4e0f-b215-b042d46209b1]
 description = "using ascii value for non-doubled non-digit isn't allowed"
 

--- a/exercises/practice/phone-number/.meta/tests.toml
+++ b/exercises/practice/phone-number/.meta/tests.toml
@@ -1,6 +1,13 @@
-# This is an auto-generated file. Regular comments will be removed when this
-# file is regenerated. Regenerating will not touch any manually added keys,
-# so comments can be added in a "comment" key.
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
 
 [79666dce-e0f1-46de-95a1-563802913c35]
 description = "cleans the number"
@@ -28,9 +35,19 @@ description = "invalid when more than 11 digits"
 
 [63f38f37-53f6-4a5f-bd86-e9b404f10a60]
 description = "invalid with letters"
+include = false
+
+[eb8a1fc0-64e5-46d3-b0c6-33184208e28a]
+description = "invalid with letters"
+reimplements = "63f38f37-53f6-4a5f-bd86-e9b404f10a60"
 
 [4bd97d90-52fd-45d3-b0db-06ab95b1244e]
 description = "invalid with punctuations"
+include = false
+
+[065f6363-8394-4759-b080-e6c8c351dd1f]
+description = "invalid with punctuations"
+reimplements = "4bd97d90-52fd-45d3-b0db-06ab95b1244e"
 
 [d77d07f8-873c-4b17-8978-5f66139bf7d7]
 description = "invalid if area code starts with 0"

--- a/exercises/practice/phone-number/tests/Tests.elm
+++ b/exercises/practice/phone-number/tests/Tests.elm
@@ -33,10 +33,10 @@ tests =
                 \() -> Expect.equal Nothing (getNumber "321234567890")
         , skip <|
             test "invalid with letters" <|
-                \() -> Expect.equal Nothing (getNumber "123-abc-7890")
+                \() -> Expect.equal Nothing (getNumber "523-abc-7890")
         , skip <|
             test "invalid with punctuations" <|
-                \() -> Expect.equal Nothing (getNumber "123-@:!-7890")
+                \() -> Expect.equal Nothing (getNumber "523-@:!-7890")
         , skip <|
             test "invalid if area code starts with 0" <|
                 \() -> Expect.equal Nothing (getNumber "(023) 456-7890")


### PR DESCRIPTION
Small sync update.

- @ceddlyburge's change in metadata for `bowling`.
- Change in `luhn`'s `tests.toml`, add tests already implemented.
- Update 2 tests in `phone-number` to fail with only one error (but inconsequential for this track since we return `Nothing` anyway)