### PR TITLE
Correct typo

### DIFF
--- a/concepts/tuples/about.md
+++ b/concepts/tuples/about.md
@@ -5,7 +5,7 @@ In Elm, Tuples are mostly used for simple transient types.
 For this reason Tuples have a maximum of 3 values, and as a further encouragement convenience functions are only supplied for 2 values.
 For more complex data, it is best to switch to records.
 A common use is if you need to return more than one value from a function.
-A tuple's fields don't have names, they are accessed by means of destructuring or by position.
+Tuple fields don't have names, they are accessed by means of destructuring or by position.
 
 You can read a [concise introduction to tuples][tuples-concise].
 There is also a [more in depth introduction][tuples-in-depth], and the [API doc of the Tuple module][tuple-core] contains code examples and detailed documentation.

--- a/concepts/tuples/introduction.md
+++ b/concepts/tuples/introduction.md
@@ -5,4 +5,4 @@ In Elm, Tuples are mostly used for simple transient types.
 For this reason Tuples have a maximum of 3 values, and as a further encouragement convenience functions are only supplied for 2 values.
 For more complex data, it is best to switch to records.
 A common use is if you need to return more than one value from a function.
-Tuple's fields don't have names, they are accessed by destructuring or by position.
+Tuple fields don't have names, they are accessed by destructuring or by position.

--- a/concepts/tuples/introduction.md
+++ b/concepts/tuples/introduction.md
@@ -5,4 +5,4 @@ In Elm, Tuples are mostly used for simple transient types.
 For this reason Tuples have a maximum of 3 values, and as a further encouragement convenience functions are only supplied for 2 values.
 For more complex data, it is best to switch to records.
 A common use is if you need to return more than one value from a function.
-A tuple's fields don't have names, they are accessed by destructuring or by position.
+Tuple's fields don't have names, they are accessed by destructuring or by position.

--- a/exercises/concept/tisbury-treasure-hunt/.docs/introduction.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/introduction.md
@@ -5,7 +5,7 @@ In Elm, Tuples are mostly used for simple transient types.
 For this reason Tuples have a maximum of 3 values, and as a further encouragement convenience functions are only supplied for 2 values.
 For more complex data, it is best to switch to records.
 A common use is if you need to return more than one value from a function.
-A tuple's fields don't have names, they are accessed by means of destructuring or by position.
+Tuple fields don't have names, they are accessed by means of destructuring or by position.
 
 You can read a [concise introduction to tuples][tuples-concise].
 There is also a [more in depth introduction][tuples-in-depth], and the [API doc of the Tuple module][tuple-core] contains code examples and detailed documentation.


### PR DESCRIPTION
'Tuple's fields don't have names, [...}' instead of ' A tuple's fields don't have names, [...]