### PR TITLE
Rewrite `robot-simulator` tests that the Elm test runner can't parse

### DIFF
--- a/exercises/practice/robot-simulator/tests/Tests.elm
+++ b/exercises/practice/robot-simulator/tests/Tests.elm
@@ -1,4 +1,4 @@
-module Tests exposing (assertionList, tests)
+module Tests exposing (tests)
 
 import Expect
 import RobotSimulator exposing (Bearing(..), Robot, advance, defaultRobot, simulate, turnLeft, turnRight)
@@ -28,22 +28,17 @@ tests =
                             |> Expect.equal South
                 ]
         , skip <|
-            describe "turn right"
-                (List.range 1 3
-                    |> scanl (\_ r -> turnRight r) defaultRobot
-                    |> List.map .bearing
-                    |> assertionList [ North, East, South, West ]
-                    |> List.indexedMap (\i e -> test ("step " ++ String.fromInt i) (\() -> e))
-                )
+            test "turn right" <|
+                \() ->
+                    [ identity, turnRight, turnRight >> turnRight, turnRight >> turnRight >> turnRight ]
+                        |> List.map (\turn -> turn defaultRobot |> .bearing)
+                        |> Expect.equal [ North, East, South, West ]
         , skip <|
-            describe
-                "turn left"
-                (List.range 1 3
-                    |> scanl (\_ r -> turnLeft r) defaultRobot
-                    |> List.map .bearing
-                    |> assertionList [ North, West, South, East ]
-                    |> List.indexedMap (\i e -> test ("step " ++ String.fromInt i) (\() -> e))
-                )
+            test "turn left" <|
+                \() ->
+                    [ identity, turnLeft, turnLeft >> turnLeft, turnLeft >> turnLeft >> turnLeft ]
+                        |> List.map (\turn -> turn defaultRobot |> .bearing)
+                        |> Expect.equal [ North, West, South, East ]
         , skip <|
             describe "advance positive north"
                 [ test "coordinates" <|
@@ -150,33 +145,6 @@ tests =
                             |> Expect.equal North
                 ]
         ]
-
-
-{-| Given a list of values and another list of expected values,
-generate a list of Assert Equal assertions.
--}
-assertionList : List a -> List a -> List Expect.Expectation
-assertionList xs ys =
-    List.map2 Expect.equal xs ys
-
-
-{-| Taken from 0.18's List.scanl for easier upgrade to 0.19
-<https://github.com/elm-lang/core/blob/5.1.1/src/List.elm#L171>
--}
-scanl : (a -> b -> b) -> b -> List a -> List b
-scanl f b xs =
-    let
-        scan1 x accAcc =
-            case accAcc of
-                acc :: _ ->
-                    f x acc :: accAcc
-
-                [] ->
-                    []
-
-        -- impossible
-    in
-    List.reverse (List.foldl scan1 [ b ] xs)
 
 
 anyBearing =


### PR DESCRIPTION
Solves [this issue](https://github.com/exercism/elm-test-runner/issues/33). 
Copy of the explanation: 

> [The test runner] code extractor fails on the current tests in `describe "right"` and `describe "left"`, because of this line
> 
> ```elm
> |> List.indexedMap (\i e -> test ("step " ++ String.fromInt i) (\() -> e))
> ```
> 
> The code extractor cannot work with `test ("step " ++ String.fromInt i)` it can only deal with a single string literal (like `test "step 1"`). Changing the code extractor to deal with this would be very complex, and even if it did manage to extract the code, it would display `e`, which is fairly useless, so I think we should rewrite those tests instead.

This should solve the problem. I opted to remove `scanl` for simplicity, but I can put it back if it's easier to read. My weapon of choice would have been `List.Extra.iterate` for this one.