### PR TITLE
Add task ID tags to concept exercise tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install elm + tools and cache the ELM_HOME directory
-        uses: mpizenberg/elm-tooling-action@v1.2
+        uses: mpizenberg/elm-tooling-action@v1.3
         with:
           cache-key: elm-${{ matrix.node-version }}-${{ hashFiles('elm-tooling.json', 'template/elm.json') }}
           cache-restore-key: elm-${{ matrix.node-version }}

--- a/bin/build.sh
+++ b/bin/build.sh
@@ -41,10 +41,8 @@ cp template/elm.json build/
 for example_file in exercises/concept/**/.meta/*.elm
 do
   exercise_dir=$(dirname $(dirname $example_file))
-  # This code works if there is only one file in src, or if the first file
-  # returned by ls is the correct one (the one that Examplar.elm should replace)
+  # get kebab-case slug and transform it to PascalCase
   exercise_name=$(basename $exercise_dir | sed -r 's/(^|-)([a-z])/\U\2/g')
-  echo $exercise_name
   # TODO: check that all exercise_name are unique
   cp $exercise_dir/src/*.elm "build/src/"
   cp $example_file "build/src/$exercise_name.elm"

--- a/elm-tooling.json
+++ b/elm-tooling.json
@@ -2,6 +2,6 @@
     "tools": {
         "elm": "0.19.1",
         "elm-format": "0.8.5",
-        "elm-test-rs": "1.0.0"
+        "elm-test-rs": "2.0.0"
     }
 }

--- a/exercises/concept/annalyns-infiltration/tests/Tests.elm
+++ b/exercises/concept/annalyns-infiltration/tests/Tests.elm
@@ -2,13 +2,12 @@ module Tests exposing (tests)
 
 import AnnalynsInfiltration exposing (canFastAttack, canFreePrisoner, canSignalPrisoner, canSpy, stealthAttackDamage)
 import Expect
-import Fuzz
 import Test exposing (..)
 
 
 tests : Test
 tests =
-    describe "AnnalynsInfiltration"
+    [ describe "1"
         [ test "Cannot execute fast attack if knight is awake" <|
             \_ ->
                 let
@@ -25,7 +24,9 @@ tests =
                 in
                 canFastAttack knightIsAwake
                     |> Expect.equal True
-        , test "Cannot spy if everyone is sleeping" <|
+        ]
+    , describe "2"
+        [ test "Cannot spy if everyone is sleeping" <|
             \_ ->
                 let
                     knightIsAwake =
@@ -137,7 +138,9 @@ tests =
                 in
                 canSpy knightIsAwake archerIsAwake prisonerIsAwake
                     |> Expect.equal True
-        , test "Can signal prisoner if archer is sleeping and prisoner is awake" <|
+        ]
+    , describe "3"
+        [ test "Can signal prisoner if archer is sleeping and prisoner is awake" <|
             \_ ->
                 let
                     archerIsAwake =
@@ -181,7 +184,9 @@ tests =
                 in
                 canSignalPrisoner archerIsAwake prisonerIsAwake
                     |> Expect.equal False
-        , test "Cannot release prisoner if everyone is awake and pet dog is present" <|
+        ]
+    , describe "4"
+        [ test "Cannot release prisoner if everyone is awake and pet dog is present" <|
             \_ ->
                 let
                     knightIsAwake =
@@ -453,7 +458,9 @@ tests =
                 in
                 canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
                     |> Expect.equal False
-        , test "Annalyn does 12 damage if undetected" <|
+        ]
+    , describe "5"
+        [ test "Annalyn does 12 damage if undetected" <|
             \_ ->
                 let
                     annalynIsDetected =
@@ -470,3 +477,5 @@ tests =
                 stealthAttackDamage annalynIsDetected
                     |> Expect.equal 7
         ]
+    ]
+        |> describe "AnnalynsInfiltration"

--- a/exercises/concept/annalyns-infiltration/tests/Tests.elm
+++ b/exercises/concept/annalyns-infiltration/tests/Tests.elm
@@ -7,475 +7,475 @@ import Test exposing (..)
 
 tests : Test
 tests =
-    [ describe "1"
-        [ test "Cannot execute fast attack if knight is awake" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        True
-                in
-                canFastAttack knightIsAwake
-                    |> Expect.equal False
-        , test "Can execute fast attack if knight is sleeping" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        False
-                in
-                canFastAttack knightIsAwake
-                    |> Expect.equal True
+    describe "AnnalynsInfiltration"
+        [ describe "1"
+            [ test "Cannot execute fast attack if knight is awake" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            True
+                    in
+                    canFastAttack knightIsAwake
+                        |> Expect.equal False
+            , test "Can execute fast attack if knight is sleeping" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            False
+                    in
+                    canFastAttack knightIsAwake
+                        |> Expect.equal True
+            ]
+        , describe "2"
+            [ test "Cannot spy if everyone is sleeping" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            False
+
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            False
+                    in
+                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                        |> Expect.equal False
+            , test "Can spy if everyone but knight is sleeping" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            True
+
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            False
+                    in
+                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                        |> Expect.equal True
+            , test "Can spy if everyone but archer is sleeping" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            False
+
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            False
+                    in
+                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                        |> Expect.equal True
+            , test "Can spy if everyone but prisoner is sleeping" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            False
+
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            True
+                    in
+                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                        |> Expect.equal True
+            , test "Can spy if only knight is sleeping" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            False
+
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            True
+                    in
+                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                        |> Expect.equal True
+            , test "Can spy if only archer is sleeping" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            True
+
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            True
+                    in
+                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                        |> Expect.equal True
+            , test "Can spy if only prisoner is sleeping" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            True
+
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            False
+                    in
+                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                        |> Expect.equal True
+            , test "Can spy if everyone is awake" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            True
+
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            True
+                    in
+                    canSpy knightIsAwake archerIsAwake prisonerIsAwake
+                        |> Expect.equal True
+            ]
+        , describe "3"
+            [ test "Can signal prisoner if archer is sleeping and prisoner is awake" <|
+                \_ ->
+                    let
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            True
+                    in
+                    canSignalPrisoner archerIsAwake prisonerIsAwake
+                        |> Expect.equal True
+            , test "Cannot signal prisoner if archer is awake and prisoner is sleeping" <|
+                \_ ->
+                    let
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            False
+                    in
+                    canSignalPrisoner archerIsAwake prisonerIsAwake
+                        |> Expect.equal False
+            , test "Cannot signal prisoner if archer and prisoner are both sleeping" <|
+                \_ ->
+                    let
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            False
+                    in
+                    canSignalPrisoner archerIsAwake prisonerIsAwake
+                        |> Expect.equal False
+            , test "Cannot signal prisoner if archer and prisoner are both awake" <|
+                \_ ->
+                    let
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            True
+                    in
+                    canSignalPrisoner archerIsAwake prisonerIsAwake
+                        |> Expect.equal False
+            ]
+        , describe "4"
+            [ test "Cannot release prisoner if everyone is awake and pet dog is present" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            True
+
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            True
+
+                        petDogIsPresent =
+                            True
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal False
+            , test "Cannot release prisoner if everyone is awake and pet dog is absent" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            True
+
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            True
+
+                        petDogIsPresent =
+                            False
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal False
+            , test "Can release prisoner if everyone is asleep and pet dog is present" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            False
+
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            False
+
+                        petDogIsPresent =
+                            True
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal True
+            , test "Cannot release prisoner if everyone is asleep and pet dog is absent" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            False
+
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            False
+
+                        petDogIsPresent =
+                            False
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal False
+            , test "Can release prisoner if only prisoner is awake and pet dog is present" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            False
+
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            True
+
+                        petDogIsPresent =
+                            True
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal True
+            , test "Can release prisoner if only prisoner is awake and pet dog is absent" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            False
+
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            True
+
+                        petDogIsPresent =
+                            False
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal True
+            , test "Cannot release prisoner if only archer is awake and pet dog is present" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            False
+
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            False
+
+                        petDogIsPresent =
+                            True
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal False
+            , test "Cannot release prisoner if only archer is awake and pet dog is absent" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            False
+
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            False
+
+                        petDogIsPresent =
+                            False
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal False
+            , test "Can release prisoner if only knight is awake and pet dog is present" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            True
+
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            False
+
+                        petDogIsPresent =
+                            True
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal True
+            , test "Cannot release prisoner if only knight is awake and pet dog is absent" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            True
+
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            False
+
+                        petDogIsPresent =
+                            False
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal False
+            , test "Cannot release prisoner if only knight is asleep and pet dog is present" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            False
+
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            True
+
+                        petDogIsPresent =
+                            True
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal False
+            , test "Cannot release prisoner if only knight is asleep and pet dog is absent" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            False
+
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            True
+
+                        petDogIsPresent =
+                            False
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal False
+            , test "Can release prisoner if only archer is asleep and pet dog is present" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            True
+
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            True
+
+                        petDogIsPresent =
+                            True
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal True
+            , test "Cannot release prisoner if only archer is asleep and pet dog is absent" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            True
+
+                        archerIsAwake =
+                            False
+
+                        prisonerIsAwake =
+                            True
+
+                        petDogIsPresent =
+                            False
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal False
+            , test "Cannot release prisoner if only prisoner is asleep and pet dog is present" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            True
+
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            False
+
+                        petDogIsPresent =
+                            True
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal False
+            , test "Cannot release prisoner if only prisoner is asleep and pet dog is absent" <|
+                \_ ->
+                    let
+                        knightIsAwake =
+                            True
+
+                        archerIsAwake =
+                            True
+
+                        prisonerIsAwake =
+                            False
+
+                        petDogIsPresent =
+                            False
+                    in
+                    canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
+                        |> Expect.equal False
+            ]
+        , describe "5"
+            [ test "Annalyn does 12 damage if undetected" <|
+                \_ ->
+                    let
+                        annalynIsDetected =
+                            False
+                    in
+                    stealthAttackDamage annalynIsDetected
+                        |> Expect.equal 12
+            , test "Annalyn does 7 damage if detected" <|
+                \_ ->
+                    let
+                        annalynIsDetected =
+                            True
+                    in
+                    stealthAttackDamage annalynIsDetected
+                        |> Expect.equal 7
+            ]
         ]
-    , describe "2"
-        [ test "Cannot spy if everyone is sleeping" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        False
-
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        False
-                in
-                canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                    |> Expect.equal False
-        , test "Can spy if everyone but knight is sleeping" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        True
-
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        False
-                in
-                canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                    |> Expect.equal True
-        , test "Can spy if everyone but archer is sleeping" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        False
-
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        False
-                in
-                canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                    |> Expect.equal True
-        , test "Can spy if everyone but prisoner is sleeping" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        False
-
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        True
-                in
-                canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                    |> Expect.equal True
-        , test "Can spy if only knight is sleeping" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        False
-
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        True
-                in
-                canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                    |> Expect.equal True
-        , test "Can spy if only archer is sleeping" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        True
-
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        True
-                in
-                canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                    |> Expect.equal True
-        , test "Can spy if only prisoner is sleeping" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        True
-
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        False
-                in
-                canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                    |> Expect.equal True
-        , test "Can spy if everyone is awake" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        True
-
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        True
-                in
-                canSpy knightIsAwake archerIsAwake prisonerIsAwake
-                    |> Expect.equal True
-        ]
-    , describe "3"
-        [ test "Can signal prisoner if archer is sleeping and prisoner is awake" <|
-            \_ ->
-                let
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        True
-                in
-                canSignalPrisoner archerIsAwake prisonerIsAwake
-                    |> Expect.equal True
-        , test "Cannot signal prisoner if archer is awake and prisoner is sleeping" <|
-            \_ ->
-                let
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        False
-                in
-                canSignalPrisoner archerIsAwake prisonerIsAwake
-                    |> Expect.equal False
-        , test "Cannot signal prisoner if archer and prisoner are both sleeping" <|
-            \_ ->
-                let
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        False
-                in
-                canSignalPrisoner archerIsAwake prisonerIsAwake
-                    |> Expect.equal False
-        , test "Cannot signal prisoner if archer and prisoner are both awake" <|
-            \_ ->
-                let
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        True
-                in
-                canSignalPrisoner archerIsAwake prisonerIsAwake
-                    |> Expect.equal False
-        ]
-    , describe "4"
-        [ test "Cannot release prisoner if everyone is awake and pet dog is present" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        True
-
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        True
-
-                    petDogIsPresent =
-                        True
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal False
-        , test "Cannot release prisoner if everyone is awake and pet dog is absent" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        True
-
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        True
-
-                    petDogIsPresent =
-                        False
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal False
-        , test "Can release prisoner if everyone is asleep and pet dog is present" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        False
-
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        False
-
-                    petDogIsPresent =
-                        True
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal True
-        , test "Cannot release prisoner if everyone is asleep and pet dog is absent" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        False
-
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        False
-
-                    petDogIsPresent =
-                        False
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal False
-        , test "Can release prisoner if only prisoner is awake and pet dog is present" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        False
-
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        True
-
-                    petDogIsPresent =
-                        True
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal True
-        , test "Can release prisoner if only prisoner is awake and pet dog is absent" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        False
-
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        True
-
-                    petDogIsPresent =
-                        False
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal True
-        , test "Cannot release prisoner if only archer is awake and pet dog is present" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        False
-
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        False
-
-                    petDogIsPresent =
-                        True
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal False
-        , test "Cannot release prisoner if only archer is awake and pet dog is absent" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        False
-
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        False
-
-                    petDogIsPresent =
-                        False
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal False
-        , test "Can release prisoner if only knight is awake and pet dog is present" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        True
-
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        False
-
-                    petDogIsPresent =
-                        True
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal True
-        , test "Cannot release prisoner if only knight is awake and pet dog is absent" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        True
-
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        False
-
-                    petDogIsPresent =
-                        False
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal False
-        , test "Cannot release prisoner if only knight is asleep and pet dog is present" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        False
-
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        True
-
-                    petDogIsPresent =
-                        True
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal False
-        , test "Cannot release prisoner if only knight is asleep and pet dog is absent" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        False
-
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        True
-
-                    petDogIsPresent =
-                        False
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal False
-        , test "Can release prisoner if only archer is asleep and pet dog is present" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        True
-
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        True
-
-                    petDogIsPresent =
-                        True
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal True
-        , test "Cannot release prisoner if only archer is asleep and pet dog is absent" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        True
-
-                    archerIsAwake =
-                        False
-
-                    prisonerIsAwake =
-                        True
-
-                    petDogIsPresent =
-                        False
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal False
-        , test "Cannot release prisoner if only prisoner is asleep and pet dog is present" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        True
-
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        False
-
-                    petDogIsPresent =
-                        True
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal False
-        , test "Cannot release prisoner if only prisoner is asleep and pet dog is absent" <|
-            \_ ->
-                let
-                    knightIsAwake =
-                        True
-
-                    archerIsAwake =
-                        True
-
-                    prisonerIsAwake =
-                        False
-
-                    petDogIsPresent =
-                        False
-                in
-                canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
-                    |> Expect.equal False
-        ]
-    , describe "5"
-        [ test "Annalyn does 12 damage if undetected" <|
-            \_ ->
-                let
-                    annalynIsDetected =
-                        False
-                in
-                stealthAttackDamage annalynIsDetected
-                    |> Expect.equal 12
-        , test "Annalyn does 7 damage if detected" <|
-            \_ ->
-                let
-                    annalynIsDetected =
-                        True
-                in
-                stealthAttackDamage annalynIsDetected
-                    |> Expect.equal 7
-        ]
-    ]
-        |> describe "AnnalynsInfiltration"

--- a/exercises/concept/bandwagoner/tests/Tests.elm
+++ b/exercises/concept/bandwagoner/tests/Tests.elm
@@ -7,7 +7,7 @@ import Test exposing (..)
 
 tests : Test
 tests =
-    describe "Bandwagoner"
+    [ describe "1"
         [ test "has Coach type alias with correct fields in correct order" <|
             \_ ->
                 Coach "Steve Kerr" True
@@ -29,7 +29,9 @@ tests =
                         { name = "Boston Celtics", coach = coach, stats = stats }
                 in
                 Expect.equal team (Team "Boston Celtics" coach stats)
-        , test "createTeam creates a Team structural type" <|
+        ]
+    , describe "2"
+        [ test "createTeam creates a Team structural type" <|
             \_ ->
                 let
                     coach =
@@ -42,7 +44,9 @@ tests =
                         createTeam "Boston Celtics" stats coach
                 in
                 Expect.equal team (Team "Boston Celtics" coach stats)
-        , test "can replace coach for a team" <|
+        ]
+    , describe "3"
+        [ test "can replace coach for a team" <|
             \_ ->
                 let
                     coach =
@@ -61,7 +65,9 @@ tests =
                         replaceCoach newCoach team
                 in
                 Expect.equal newTeam (Team "New York Knicks" newCoach stats)
-        , test "should root for teams that have more wins than losses" <|
+        ]
+    , describe "4"
+        [ test "should root for teams that have more wins than losses" <|
             \_ ->
                 Team "" (Coach "" True) (Stats 1 0)
                     |> rootForTeam
@@ -82,3 +88,5 @@ tests =
                     |> rootForTeam
                     |> Expect.equal True
         ]
+    ]
+        |> describe "Bandwagoner"

--- a/exercises/concept/bandwagoner/tests/Tests.elm
+++ b/exercises/concept/bandwagoner/tests/Tests.elm
@@ -7,86 +7,86 @@ import Test exposing (..)
 
 tests : Test
 tests =
-    [ describe "1"
-        [ test "has Coach type alias with correct fields in correct order" <|
-            \_ ->
-                Coach "Steve Kerr" True
-                    |> Expect.equal { name = "Steve Kerr", formerPlayer = True }
-        , test "has Stats type alias with correct fields in correct order" <|
-            \_ ->
-                Stats 55 27
-                    |> Expect.equal { wins = 55, losses = 27 }
-        , test "has Team type alias with correct fields in correct order" <|
-            \_ ->
-                let
-                    coach =
-                        Coach "Red Auerbach" False
+    describe "Bandwagoner"
+        [ describe "1"
+            [ test "has Coach type alias with correct fields in correct order" <|
+                \_ ->
+                    Coach "Steve Kerr" True
+                        |> Expect.equal { name = "Steve Kerr", formerPlayer = True }
+            , test "has Stats type alias with correct fields in correct order" <|
+                \_ ->
+                    Stats 55 27
+                        |> Expect.equal { wins = 55, losses = 27 }
+            , test "has Team type alias with correct fields in correct order" <|
+                \_ ->
+                    let
+                        coach =
+                            Coach "Red Auerbach" False
 
-                    stats =
-                        Stats 58 22
+                        stats =
+                            Stats 58 22
 
-                    team =
-                        { name = "Boston Celtics", coach = coach, stats = stats }
-                in
-                Expect.equal team (Team "Boston Celtics" coach stats)
+                        team =
+                            { name = "Boston Celtics", coach = coach, stats = stats }
+                    in
+                    Expect.equal team (Team "Boston Celtics" coach stats)
+            ]
+        , describe "2"
+            [ test "createTeam creates a Team structural type" <|
+                \_ ->
+                    let
+                        coach =
+                            Coach "Red Auerbach" False
+
+                        stats =
+                            Stats 58 22
+
+                        team =
+                            createTeam "Boston Celtics" stats coach
+                    in
+                    Expect.equal team (Team "Boston Celtics" coach stats)
+            ]
+        , describe "3"
+            [ test "can replace coach for a team" <|
+                \_ ->
+                    let
+                        coach =
+                            Coach "Willis Reed" True
+
+                        newCoach =
+                            Coach "Red Holzman" True
+
+                        stats =
+                            Stats 6 8
+
+                        team =
+                            Team "New York Knicks" coach stats
+
+                        newTeam =
+                            replaceCoach newCoach team
+                    in
+                    Expect.equal newTeam (Team "New York Knicks" newCoach stats)
+            ]
+        , describe "4"
+            [ test "should root for teams that have more wins than losses" <|
+                \_ ->
+                    Team "" (Coach "" True) (Stats 1 0)
+                        |> rootForTeam
+                        |> Expect.equal True
+            , test "should not root for teams that lose more than they win" <|
+                \_ ->
+                    Team "" (Coach "" True) (Stats 43 44)
+                        |> rootForTeam
+                        |> Expect.equal False
+            , test "should not root for teams that have equal losses and wins" <|
+                \_ ->
+                    Team "" (Coach "" True) (Stats 143 143)
+                        |> rootForTeam
+                        |> Expect.equal False
+            , test "should root for extended teams that have more wins than losses" <|
+                \_ ->
+                    { name = "", coach = Coach "" True, stats = Stats 1 0, someOtherField = "" }
+                        |> rootForTeam
+                        |> Expect.equal True
+            ]
         ]
-    , describe "2"
-        [ test "createTeam creates a Team structural type" <|
-            \_ ->
-                let
-                    coach =
-                        Coach "Red Auerbach" False
-
-                    stats =
-                        Stats 58 22
-
-                    team =
-                        createTeam "Boston Celtics" stats coach
-                in
-                Expect.equal team (Team "Boston Celtics" coach stats)
-        ]
-    , describe "3"
-        [ test "can replace coach for a team" <|
-            \_ ->
-                let
-                    coach =
-                        Coach "Willis Reed" True
-
-                    newCoach =
-                        Coach "Red Holzman" True
-
-                    stats =
-                        Stats 6 8
-
-                    team =
-                        Team "New York Knicks" coach stats
-
-                    newTeam =
-                        replaceCoach newCoach team
-                in
-                Expect.equal newTeam (Team "New York Knicks" newCoach stats)
-        ]
-    , describe "4"
-        [ test "should root for teams that have more wins than losses" <|
-            \_ ->
-                Team "" (Coach "" True) (Stats 1 0)
-                    |> rootForTeam
-                    |> Expect.equal True
-        , test "should not root for teams that lose more than they win" <|
-            \_ ->
-                Team "" (Coach "" True) (Stats 43 44)
-                    |> rootForTeam
-                    |> Expect.equal False
-        , test "should not root for teams that have equal losses and wins" <|
-            \_ ->
-                Team "" (Coach "" True) (Stats 143 143)
-                    |> rootForTeam
-                    |> Expect.equal False
-        , test "should root for extended teams that have more wins than losses" <|
-            \_ ->
-                { name = "", coach = Coach "" True, stats = Stats 1 0, someOtherField = "" }
-                    |> rootForTeam
-                    |> Expect.equal True
-        ]
-    ]
-        |> describe "Bandwagoner"

--- a/exercises/concept/bettys-bike-shop/tests/Tests.elm
+++ b/exercises/concept/bettys-bike-shop/tests/Tests.elm
@@ -7,7 +7,7 @@ import Test exposing (..)
 
 tests : Test
 tests =
-    describe "BettysBikeShop"
+    [ describe "1"
         [ test "599 pence should be 5.99 pounds" <|
             \_ ->
                 penceToPounds 599
@@ -16,7 +16,9 @@ tests =
             \_ ->
                 penceToPounds 33
                     |> Expect.within (Absolute 0.001) 0.33
-        , test "5.99 pounds should be formatted as £5.99" <|
+        ]
+    , describe "2"
+        [ test "5.99 pounds should be formatted as £5.99" <|
             \_ ->
                 poundsToString 5.99
                     |> Expect.equal "£5.99"
@@ -25,3 +27,5 @@ tests =
                 poundsToString 0.33
                     |> Expect.equal "£0.33"
         ]
+    ]
+        |> describe "BettysBikeShop"

--- a/exercises/concept/bettys-bike-shop/tests/Tests.elm
+++ b/exercises/concept/bettys-bike-shop/tests/Tests.elm
@@ -7,25 +7,25 @@ import Test exposing (..)
 
 tests : Test
 tests =
-    [ describe "1"
-        [ test "599 pence should be 5.99 pounds" <|
-            \_ ->
-                penceToPounds 599
-                    |> Expect.within (Absolute 0.001) 5.99
-        , test "33 pence should be 0.33 pounds" <|
-            \_ ->
-                penceToPounds 33
-                    |> Expect.within (Absolute 0.001) 0.33
+    describe "BettysBikeShop"
+        [ describe "1"
+            [ test "599 pence should be 5.99 pounds" <|
+                \_ ->
+                    penceToPounds 599
+                        |> Expect.within (Absolute 0.001) 5.99
+            , test "33 pence should be 0.33 pounds" <|
+                \_ ->
+                    penceToPounds 33
+                        |> Expect.within (Absolute 0.001) 0.33
+            ]
+        , describe "2"
+            [ test "5.99 pounds should be formatted as £5.99" <|
+                \_ ->
+                    poundsToString 5.99
+                        |> Expect.equal "£5.99"
+            , test "0.33 pounds should be formatted as £0.33" <|
+                \_ ->
+                    poundsToString 0.33
+                        |> Expect.equal "£0.33"
+            ]
         ]
-    , describe "2"
-        [ test "5.99 pounds should be formatted as £5.99" <|
-            \_ ->
-                poundsToString 5.99
-                    |> Expect.equal "£5.99"
-        , test "0.33 pounds should be formatted as £0.33" <|
-            \_ ->
-                poundsToString 0.33
-                    |> Expect.equal "£0.33"
-        ]
-    ]
-        |> describe "BettysBikeShop"

--- a/exercises/concept/go/tests/Tests.elm
+++ b/exercises/concept/go/tests/Tests.elm
@@ -43,7 +43,7 @@ addWhiteCapturedStone game =
 
 tests : Test
 tests =
-    describe "applyRules"
+    describe "1"
         [ test "should change the player if all rules pass" <|
             \() ->
                 applyRules vanillaGame identityRule identity identityRule identityRule
@@ -75,3 +75,4 @@ tests =
                     |> Expect.equal
                         { vanillaGame | error = koRule }
         ]
+|>     describe "applyRules"

--- a/exercises/concept/go/tests/Tests.elm
+++ b/exercises/concept/go/tests/Tests.elm
@@ -43,36 +43,37 @@ addWhiteCapturedStone game =
 
 tests : Test
 tests =
-    describe "1"
-        [ test "should change the player if all rules pass" <|
-            \() ->
-                applyRules vanillaGame identityRule identity identityRule identityRule
-                    |> Expect.equal
-                        (changePlayer vanillaGame)
-        , test "should retain the error and player if koRule fails" <|
-            \() ->
-                applyRules vanillaGame identityRule identity identityRule (errRule koRule)
-                    |> Expect.equal
-                        { vanillaGame | error = koRule }
-        , test "should retain the error and player if libertyRule fails" <|
-            \() ->
-                applyRules vanillaGame identityRule identity (errRule libertyRule) identityRule
-                    |> Expect.equal
-                        { vanillaGame | error = libertyRule }
-        , test "should retain the error and player if oneStonePerPointRule fails" <|
-            \() ->
-                applyRules vanillaGame (errRule oneStonePerPointRule) identity identityRule identityRule
-                    |> Expect.equal
-                        { vanillaGame | error = oneStonePerPointRule }
-        , test "should retain changes from captureRule and change player" <|
-            \() ->
-                applyRules vanillaGame identityRule addWhiteCapturedStone identityRule identityRule
-                    |> Expect.equal
-                        (vanillaGame |> addWhiteCapturedStone |> changePlayer)
-        , test "should discard changes from captureRule if subsequent rule fails" <|
-            \() ->
-                applyRules vanillaGame identityRule addWhiteCapturedStone identityRule (errRule koRule)
-                    |> Expect.equal
-                        { vanillaGame | error = koRule }
+    describe "Go"
+        [ describe "1"
+            [ test "should change the player if all rules pass" <|
+                \() ->
+                    applyRules vanillaGame identityRule identity identityRule identityRule
+                        |> Expect.equal
+                            (changePlayer vanillaGame)
+            , test "should retain the error and player if koRule fails" <|
+                \() ->
+                    applyRules vanillaGame identityRule identity identityRule (errRule koRule)
+                        |> Expect.equal
+                            { vanillaGame | error = koRule }
+            , test "should retain the error and player if libertyRule fails" <|
+                \() ->
+                    applyRules vanillaGame identityRule identity (errRule libertyRule) identityRule
+                        |> Expect.equal
+                            { vanillaGame | error = libertyRule }
+            , test "should retain the error and player if oneStonePerPointRule fails" <|
+                \() ->
+                    applyRules vanillaGame (errRule oneStonePerPointRule) identity identityRule identityRule
+                        |> Expect.equal
+                            { vanillaGame | error = oneStonePerPointRule }
+            , test "should retain changes from captureRule and change player" <|
+                \() ->
+                    applyRules vanillaGame identityRule addWhiteCapturedStone identityRule identityRule
+                        |> Expect.equal
+                            (vanillaGame |> addWhiteCapturedStone |> changePlayer)
+            , test "should discard changes from captureRule if subsequent rule fails" <|
+                \() ->
+                    applyRules vanillaGame identityRule addWhiteCapturedStone identityRule (errRule koRule)
+                        |> Expect.equal
+                            { vanillaGame | error = koRule }
+            ]
         ]
-|>     describe "applyRules"

--- a/exercises/concept/lucians-luscious-lasagna/tests/Tests.elm
+++ b/exercises/concept/lucians-luscious-lasagna/tests/Tests.elm
@@ -7,12 +7,14 @@ import Test exposing (..)
 
 tests : Test
 tests =
-    describe "LuciansLusciousLasagna"
+    [ describe "1"
         [ test "The expected amount of time in the oven is 40 minutes" <|
             \_ ->
                 expectedMinutesInOven
                     |> Expect.equal 40
-        , test "For 2 layers, the preparation time is 4 minutes" <|
+        ]
+    , describe "2"
+        [ test "For 2 layers, the preparation time is 4 minutes" <|
             \_ ->
                 preparationTimeInMinutes 2
                     |> Expect.equal 4
@@ -20,7 +22,9 @@ tests =
             \_ ->
                 preparationTimeInMinutes 5
                     |> Expect.equal 10
-        , test "For a 3-layers lasagna already in the oven for 10 minutes, you've spent 16 minutes cooking" <|
+        ]
+    , describe "3"
+        [ test "For a 3-layers lasagna already in the oven for 10 minutes, you've spent 16 minutes cooking" <|
             \_ ->
                 elapsedTimeInMinutes 3 10
                     |> Expect.equal 16
@@ -29,3 +33,5 @@ tests =
                 elapsedTimeInMinutes 6 30
                     |> Expect.equal 42
         ]
+    ]
+        |> describe "LuciansLusciousLasagna"

--- a/exercises/concept/lucians-luscious-lasagna/tests/Tests.elm
+++ b/exercises/concept/lucians-luscious-lasagna/tests/Tests.elm
@@ -7,31 +7,31 @@ import Test exposing (..)
 
 tests : Test
 tests =
-    [ describe "1"
-        [ test "The expected amount of time in the oven is 40 minutes" <|
-            \_ ->
-                expectedMinutesInOven
-                    |> Expect.equal 40
+    describe "LuciansLusciousLasagna"
+        [ describe "1"
+            [ test "The expected amount of time in the oven is 40 minutes" <|
+                \_ ->
+                    expectedMinutesInOven
+                        |> Expect.equal 40
+            ]
+        , describe "2"
+            [ test "For 2 layers, the preparation time is 4 minutes" <|
+                \_ ->
+                    preparationTimeInMinutes 2
+                        |> Expect.equal 4
+            , test "For 5 layers, the preparation time is 10 minutes" <|
+                \_ ->
+                    preparationTimeInMinutes 5
+                        |> Expect.equal 10
+            ]
+        , describe "3"
+            [ test "For a 3-layers lasagna already in the oven for 10 minutes, you've spent 16 minutes cooking" <|
+                \_ ->
+                    elapsedTimeInMinutes 3 10
+                        |> Expect.equal 16
+            , test "For a 6-layers lasagna already in the oven for 30 minutes, you've spent 42 minutes cooking" <|
+                \_ ->
+                    elapsedTimeInMinutes 6 30
+                        |> Expect.equal 42
+            ]
         ]
-    , describe "2"
-        [ test "For 2 layers, the preparation time is 4 minutes" <|
-            \_ ->
-                preparationTimeInMinutes 2
-                    |> Expect.equal 4
-        , test "For 5 layers, the preparation time is 10 minutes" <|
-            \_ ->
-                preparationTimeInMinutes 5
-                    |> Expect.equal 10
-        ]
-    , describe "3"
-        [ test "For a 3-layers lasagna already in the oven for 10 minutes, you've spent 16 minutes cooking" <|
-            \_ ->
-                elapsedTimeInMinutes 3 10
-                    |> Expect.equal 16
-        , test "For a 6-layers lasagna already in the oven for 30 minutes, you've spent 42 minutes cooking" <|
-            \_ ->
-                elapsedTimeInMinutes 6 30
-                    |> Expect.equal 42
-        ]
-    ]
-        |> describe "LuciansLusciousLasagna"

--- a/exercises/concept/luigis-luscious-lasagna/tests/Tests.elm
+++ b/exercises/concept/luigis-luscious-lasagna/tests/Tests.elm
@@ -7,15 +7,15 @@ import Test exposing (..)
 
 tests : Test
 tests =
-    [ describe "1"
-        [ test "For a 3-layers lasagna started 10 minutes ago, there are 36 minutes remaining" <|
-            \_ ->
-                remainingTimeInMinutes 3 10
-                    |> Expect.equal ((3 * 2) + 40 - 10)
-        , test "For a 6-layers lasagna started 30 minutes ago, there are 22 minutes remaining" <|
-            \_ ->
-                remainingTimeInMinutes 6 30
-                    |> Expect.equal ((6 * 2) + 40 - 30)
+    describe "LuigisLusciousLasagna"
+        [ describe "1"
+            [ test "For a 3-layers lasagna started 10 minutes ago, there are 36 minutes remaining" <|
+                \_ ->
+                    remainingTimeInMinutes 3 10
+                        |> Expect.equal ((3 * 2) + 40 - 10)
+            , test "For a 6-layers lasagna started 30 minutes ago, there are 22 minutes remaining" <|
+                \_ ->
+                    remainingTimeInMinutes 6 30
+                        |> Expect.equal ((6 * 2) + 40 - 30)
+            ]
         ]
-    ]
-        |> describe "LuigisLusciousLasagna"

--- a/exercises/concept/luigis-luscious-lasagna/tests/Tests.elm
+++ b/exercises/concept/luigis-luscious-lasagna/tests/Tests.elm
@@ -7,7 +7,7 @@ import Test exposing (..)
 
 tests : Test
 tests =
-    describe "LuigisLusciousLasagna"
+    [ describe "1"
         [ test "For a 3-layers lasagna started 10 minutes ago, there are 36 minutes remaining" <|
             \_ ->
                 remainingTimeInMinutes 3 10
@@ -17,3 +17,5 @@ tests =
                 remainingTimeInMinutes 6 30
                     |> Expect.equal ((6 * 2) + 40 - 30)
         ]
+    ]
+        |> describe "LuigisLusciousLasagna"

--- a/exercises/concept/role-playing-game/tests/Tests.elm
+++ b/exercises/concept/role-playing-game/tests/Tests.elm
@@ -8,37 +8,43 @@ import Test exposing (..)
 tests : Test
 tests =
     describe "RolePlayingGame"
-        [ test "Introducing someone with their name" <|
-            \() ->
-                Expect.equal (introduce { name = Just "Gandalf", level = 1, health = 42, mana = Nothing }) "Gandalf"
-        , test "Introducing an unidentified player should return 'Mighty Magician'" <|
-            \() ->
-                Expect.equal (introduce { name = Nothing, level = 1, health = 42, mana = Nothing }) "Mighty Magician"
-        , test "Attempting to revive a player that is alive should return Nothing" <|
-            \() ->
-                Expect.equal (revive { name = Nothing, level = 12, health = 42, mana = Just 7 }) Nothing
-        , test "Reviving a low level player resets its health to 100" <|
-            \() ->
-                Expect.equal (revive { name = Nothing, level = 3, health = 0, mana = Nothing })
-                    (Just { name = Nothing, level = 3, health = 100, mana = Nothing })
-        , test "Reviving a high level player resets both its health and mana" <|
-            \() ->
-                Expect.equal (revive { name = Nothing, level = 10, health = 0, mana = Just 14 })
-                    (Just { name = Nothing, level = 10, health = 100, mana = Just 100 })
-        , test "Casting a spell spends double the mana" <|
-            \() ->
-                Expect.equal (castSpell 9 { name = Nothing, level = 10, health = 69, mana = Just 20 })
-                    ( { name = Nothing, level = 10, health = 69, mana = Just 11 }, 18 )
-        , test "Attempting to cast a spell with insufficient mana does nothing" <|
-            \() ->
-                Expect.equal (castSpell 39 { name = Nothing, level = 10, health = 69, mana = Just 20 })
-                    ( { name = Nothing, level = 10, health = 69, mana = Just 20 }, 0 )
-        , test "Attempting to cast a spell without a mana pool decreases the player's health" <|
-            \() ->
-                Expect.equal (castSpell 7 { name = Nothing, level = 5, health = 58, mana = Nothing })
-                    ( { name = Nothing, level = 5, health = 51, mana = Nothing }, 0 )
-        , test "A player's health cannot go below 0" <|
-            \() ->
-                Expect.equal (castSpell 12 { name = Nothing, level = 5, health = 6, mana = Nothing })
-                    ( { name = Nothing, level = 5, health = 0, mana = Nothing }, 0 )
+        [ describe "1"
+            [ test "Introducing someone with their name" <|
+                \() ->
+                    Expect.equal (introduce { name = Just "Gandalf", level = 1, health = 42, mana = Nothing }) "Gandalf"
+            , test "Introducing an unidentified player should return 'Mighty Magician'" <|
+                \() ->
+                    Expect.equal (introduce { name = Nothing, level = 1, health = 42, mana = Nothing }) "Mighty Magician"
+            ]
+        , describe "2"
+            [ test "Attempting to revive a player that is alive should return Nothing" <|
+                \() ->
+                    Expect.equal (revive { name = Nothing, level = 12, health = 42, mana = Just 7 }) Nothing
+            , test "Reviving a low level player resets its health to 100" <|
+                \() ->
+                    Expect.equal (revive { name = Nothing, level = 3, health = 0, mana = Nothing })
+                        (Just { name = Nothing, level = 3, health = 100, mana = Nothing })
+            , test "Reviving a high level player resets both its health and mana" <|
+                \() ->
+                    Expect.equal (revive { name = Nothing, level = 10, health = 0, mana = Just 14 })
+                        (Just { name = Nothing, level = 10, health = 100, mana = Just 100 })
+            ]
+        , describe "3"
+            [ test "Casting a spell spends double the mana" <|
+                \() ->
+                    Expect.equal (castSpell 9 { name = Nothing, level = 10, health = 69, mana = Just 20 })
+                        ( { name = Nothing, level = 10, health = 69, mana = Just 11 }, 18 )
+            , test "Attempting to cast a spell with insufficient mana does nothing" <|
+                \() ->
+                    Expect.equal (castSpell 39 { name = Nothing, level = 10, health = 69, mana = Just 20 })
+                        ( { name = Nothing, level = 10, health = 69, mana = Just 20 }, 0 )
+            , test "Attempting to cast a spell without a mana pool decreases the player's health" <|
+                \() ->
+                    Expect.equal (castSpell 7 { name = Nothing, level = 5, health = 58, mana = Nothing })
+                        ( { name = Nothing, level = 5, health = 51, mana = Nothing }, 0 )
+            , test "A player's health cannot go below 0" <|
+                \() ->
+                    Expect.equal (castSpell 12 { name = Nothing, level = 5, health = 6, mana = Nothing })
+                        ( { name = Nothing, level = 5, health = 0, mana = Nothing }, 0 )
+            ]
         ]

--- a/exercises/concept/ticket-please/tests/Tests.elm
+++ b/exercises/concept/ticket-please/tests/Tests.elm
@@ -18,7 +18,7 @@ newTicket =
 tests : Test
 tests =
     describe "TicketPlease "
-        [ describe "Task 1: TicketPlease.emptyComment"
+        [ describe "1"
             [ test "emptyComment should detect an empty comment" <|
                 \() ->
                     emptyComment ( User "Alice", "" )
@@ -41,7 +41,7 @@ tests =
                             , ( User "Bob", "hi!" )
                             ]
             ]
-        , describe "Task 2: TicketPlease.numberOfCreatorComments"
+        , describe "2"
             [ test "numberOfCreatorComments with no comment" <|
                 \() ->
                     Ticket { newTicket | createdBy = ( User "John", 1 ), comments = [] }
@@ -80,7 +80,7 @@ tests =
                         |> numberOfCreatorComments
                         |> Expect.equal 2
             ]
-        , describe "Task 3: TicketPlease.assignedToDevTeam"
+        , describe "3"
             [ test "assignedToDevTeam with no one assigned" <|
                 \() ->
                     Ticket { newTicket | assignedTo = Nothing }
@@ -107,7 +107,7 @@ tests =
                         |> assignedToDevTeam
                         |> Expect.true "Expected ticket assigned to Charlie from dev team"
             ]
-        , describe "Task 4: TicketPlease.assignTicketTo"
+        , describe "4"
             [ test "assign new, unassigned ticket to Roy" <|
                 \() ->
                     Ticket { newTicket | status = New, assignedTo = Nothing }

--- a/exercises/concept/tisbury-treasure-hunt/tests/Tests.elm
+++ b/exercises/concept/tisbury-treasure-hunt/tests/Tests.elm
@@ -8,80 +8,88 @@ import TisburyTreasureHunt exposing (..)
 tests : Test
 tests =
     describe "TisburyTreasureHunt"
-        [ test "placeLocationToTreasureLocation should convert PlaceLocation to TreasureLocation" <|
-            \_ ->
-                placeLocationToTreasureLocation ( 'C', 1 )
-                    |> Expect.equal ( 1, 'C' )
-        , test "1,F is not at Seaside Cottages" <|
-            \_ ->
-                treasureLocationMatchesPlaceLocation ( 'C', 1 ) ( 1, 'F' )
-                    |> Expect.equal False
-        , test "1, F is at Aqua Lagoon" <|
-            \_ ->
-                treasureLocationMatchesPlaceLocation ( 'F', 1 ) ( 1, 'F' )
-                    |> Expect.equal True
-        , test "places should know how many treasures are available" <|
-            \_ ->
-                countPlaceTreasures
-                    ( "Aqua Lagoon (Island of Mystery)", ( 'F', 1 ) )
-                    [ ( "Amethyst Octopus", ( 1, 'F' ) )
-                    , ( "Scrimshaw Whale's Tooth", ( 1, 'F' ) )
-                    ]
-                    |> Expect.equal 2
-        , test "can swap Amethyst Octopus for Crystal Crab at Stormy Breakwater" <|
-            \_ ->
-                specialCaseSwapPossible
-                    ( "Amethyst Octopus", ( 1, 'F' ) )
-                    ( "Stormy Breakwater", ( 'B', 5 ) )
-                    ( "Crystal Crab", ( 6, 'A' ) )
-                    |> Expect.equal True
-        , test "can swap Amethyst Octopus for Glass Starfish at Stormy Breakwater" <|
-            \_ ->
-                specialCaseSwapPossible
-                    ( "Amethyst Octopus", ( 1, 'F' ) )
-                    ( "Stormy Breakwater", ( 'B', 5 ) )
-                    ( "Glass Starfish", ( 6, 'D' ) )
-                    |> Expect.equal True
-        , test "cannot swap Amethyst Octopus for Angry Monkey Figurine at Stormy Breakwater" <|
-            \_ ->
-                specialCaseSwapPossible
-                    ( "Amethyst Octopus", ( 1, 'F' ) )
-                    ( "Stormy Breakwater", ( 'B', 5 ) )
-                    ( "Angry Monkey Figurine", ( 5, 'B' ) )
-                    |> Expect.equal False
-        , test "can swap Vintage Pirate Hat for Model Ship in Large Bottle at Harbor Managers Office" <|
-            \_ ->
-                specialCaseSwapPossible
-                    ( "Vintage Pirate Hat", ( 7, 'E' ) )
-                    ( "Harbor Managers Office", ( 'A', 8 ) )
-                    ( "Model Ship in Large Bottle", ( 8, 'A' ) )
-                    |> Expect.equal True
-        , test "can swap Vintage Pirate Hat for Antique Glass Fishnet Float at Harbor Managers Office" <|
-            \_ ->
-                specialCaseSwapPossible
-                    ( "Vintage Pirate Hat", ( 7, 'E' ) )
-                    ( "Harbor Managers Office", ( 'A', 8 ) )
-                    ( "Antique Glass Fishnet Float", ( 3, 'D' ) )
-                    |> Expect.equal True
-        , test "cannot swap Vintage Pirate Hat for Carved Wooden Elephant at Harbor Managers Office" <|
-            \_ ->
-                specialCaseSwapPossible
-                    ( "Vintage Pirate Hat", ( 7, 'E' ) )
-                    ( "Harbor Managers Office", ( 'A', 8 ) )
-                    ( "Carved Wooden Elephant", ( 8, 'C' ) )
-                    |> Expect.equal False
-        , test "can swap Brass Spyglass for Robot Parrot at Abandoned Lighthouse" <|
-            \_ ->
-                specialCaseSwapPossible
-                    ( "Brass Spyglass", ( 4, 'B' ) )
-                    ( "Abandoned Lighthouse", ( 'B', 4 ) )
-                    ( "Robot Parrot", ( 1, 'C' ) )
-                    |> Expect.equal True
-        , test "cannot swap Vintage Pirate Hat for Model Ship in Large Bottle at Old Schooner" <|
-            \_ ->
-                specialCaseSwapPossible
-                    ( "Vintage Pirate Hat", ( 7, 'E' ) )
-                    ( "Old Schooner", ( 'A', 6 ) )
-                    ( "Model Ship in Large Bottle", ( 8, 'A' ) )
-                    |> Expect.equal False
+        [ describe "1"
+            [ test "placeLocationToTreasureLocation should convert PlaceLocation to TreasureLocation" <|
+                \_ ->
+                    placeLocationToTreasureLocation ( 'C', 1 )
+                        |> Expect.equal ( 1, 'C' )
+            ]
+        , describe "2"
+            [ test "1,F is not at Seaside Cottages" <|
+                \_ ->
+                    treasureLocationMatchesPlaceLocation ( 'C', 1 ) ( 1, 'F' )
+                        |> Expect.equal False
+            , test "1, F is at Aqua Lagoon" <|
+                \_ ->
+                    treasureLocationMatchesPlaceLocation ( 'F', 1 ) ( 1, 'F' )
+                        |> Expect.equal True
+            ]
+        , describe "3"
+            [ test "places should know how many treasures are available" <|
+                \_ ->
+                    countPlaceTreasures
+                        ( "Aqua Lagoon (Island of Mystery)", ( 'F', 1 ) )
+                        [ ( "Amethyst Octopus", ( 1, 'F' ) )
+                        , ( "Scrimshaw Whale's Tooth", ( 1, 'F' ) )
+                        ]
+                        |> Expect.equal 2
+            ]
+        , describe "4"
+            [ test "can swap Amethyst Octopus for Crystal Crab at Stormy Breakwater" <|
+                \_ ->
+                    specialCaseSwapPossible
+                        ( "Amethyst Octopus", ( 1, 'F' ) )
+                        ( "Stormy Breakwater", ( 'B', 5 ) )
+                        ( "Crystal Crab", ( 6, 'A' ) )
+                        |> Expect.equal True
+            , test "can swap Amethyst Octopus for Glass Starfish at Stormy Breakwater" <|
+                \_ ->
+                    specialCaseSwapPossible
+                        ( "Amethyst Octopus", ( 1, 'F' ) )
+                        ( "Stormy Breakwater", ( 'B', 5 ) )
+                        ( "Glass Starfish", ( 6, 'D' ) )
+                        |> Expect.equal True
+            , test "cannot swap Amethyst Octopus for Angry Monkey Figurine at Stormy Breakwater" <|
+                \_ ->
+                    specialCaseSwapPossible
+                        ( "Amethyst Octopus", ( 1, 'F' ) )
+                        ( "Stormy Breakwater", ( 'B', 5 ) )
+                        ( "Angry Monkey Figurine", ( 5, 'B' ) )
+                        |> Expect.equal False
+            , test "can swap Vintage Pirate Hat for Model Ship in Large Bottle at Harbor Managers Office" <|
+                \_ ->
+                    specialCaseSwapPossible
+                        ( "Vintage Pirate Hat", ( 7, 'E' ) )
+                        ( "Harbor Managers Office", ( 'A', 8 ) )
+                        ( "Model Ship in Large Bottle", ( 8, 'A' ) )
+                        |> Expect.equal True
+            , test "can swap Vintage Pirate Hat for Antique Glass Fishnet Float at Harbor Managers Office" <|
+                \_ ->
+                    specialCaseSwapPossible
+                        ( "Vintage Pirate Hat", ( 7, 'E' ) )
+                        ( "Harbor Managers Office", ( 'A', 8 ) )
+                        ( "Antique Glass Fishnet Float", ( 3, 'D' ) )
+                        |> Expect.equal True
+            , test "cannot swap Vintage Pirate Hat for Carved Wooden Elephant at Harbor Managers Office" <|
+                \_ ->
+                    specialCaseSwapPossible
+                        ( "Vintage Pirate Hat", ( 7, 'E' ) )
+                        ( "Harbor Managers Office", ( 'A', 8 ) )
+                        ( "Carved Wooden Elephant", ( 8, 'C' ) )
+                        |> Expect.equal False
+            , test "can swap Brass Spyglass for Robot Parrot at Abandoned Lighthouse" <|
+                \_ ->
+                    specialCaseSwapPossible
+                        ( "Brass Spyglass", ( 4, 'B' ) )
+                        ( "Abandoned Lighthouse", ( 'B', 4 ) )
+                        ( "Robot Parrot", ( 1, 'C' ) )
+                        |> Expect.equal True
+            , test "cannot swap Vintage Pirate Hat for Model Ship in Large Bottle at Old Schooner" <|
+                \_ ->
+                    specialCaseSwapPossible
+                        ( "Vintage Pirate Hat", ( 7, 'E' ) )
+                        ( "Old Schooner", ( 'A', 6 ) )
+                        ( "Model Ship in Large Bottle", ( 8, 'A' ) )
+                        |> Expect.equal False
+            ]
         ]

--- a/exercises/concept/tracks-on-tracks-on-tracks/tests/Tests.elm
+++ b/exercises/concept/tracks-on-tracks-on-tracks/tests/Tests.elm
@@ -9,106 +9,118 @@ import TracksOnTracksOnTracks exposing (..)
 tests : Test
 tests =
     describe "TracksOnTracksOnTracks"
-        [ test "newList should return an empty list" <|
-            \_ ->
-                newList
-                    |> Expect.equal []
-        , test "existingList should return Elm, Closure and Haskell" <|
-            \_ ->
-                existingList
-                    |> Expect.equal [ "Elm", "Clojure", "Haskell" ]
-        , test "addLanguage adds language to empty list" <|
-            \_ ->
-                newList
-                    |> addLanguage "Scala"
-                    |> Expect.equal [ "Scala" ]
-        , test "addLanguage adds language to existing list" <|
-            \_ ->
-                existingList
-                    |> addLanguage "Common Lisp"
-                    |> Expect.equal [ "Common Lisp", "Elm", "Clojure", "Haskell" ]
-        , test "addLanguage adds language to custom list" <|
-            \_ ->
-                addLanguage "Racket" [ "Scheme" ]
-                    |> Expect.equal [ "Racket", "Scheme" ]
-        , test "Count languages on new list" <|
-            \_ ->
-                newList
-                    |> countLanguages
-                    |> Expect.equal 0
-        , test "Count languages on existing list" <|
-            \_ ->
-                existingList
-                    |> countLanguages
-                    |> Expect.equal 3
-        , test "Count languages on custom list" <|
-            \_ ->
-                countLanguages [ "Python", "JavaScript" ]
-                    |> Expect.equal 2
-        , test "Reverse order of new list" <|
-            \_ ->
-                newList
-                    |> reverseList
-                    |> Expect.equal []
-        , test "Reverse order of existing list" <|
-            \_ ->
-                existingList
-                    |> reverseList
-                    |> Expect.equal (List.reverse existingList)
-        , test "Reverse order of custom list" <|
-            \_ ->
-                reverseList [ "Kotlin", "Java", "Scala", "Clojure" ]
-                    |> Expect.equal [ "Clojure", "Scala", "Java", "Kotlin" ]
-        , test "Empty list is not exciting" <|
-            \_ ->
-                excitingList []
-                    |> Expect.equal False
-        , test "Singleton list with Elm is exciting" <|
-            \_ ->
-                excitingList [ "Elm" ]
-                    |> Expect.equal True
-        , test "Singleton list without Elm is not exciting" <|
-            \_ ->
-                excitingList [ "C#" ]
-                    |> Expect.equal False
-        , test "Two-item list with Elm as first item is exciting" <|
-            \_ ->
-                excitingList [ "Elm", "Clojure" ]
-                    |> Expect.equal True
-        , test "Two-item list with Elm as second item is exciting" <|
-            \_ ->
-                excitingList [ "Nim", "Elm" ]
-                    |> Expect.equal True
-        , test "Two-item list without Elm is not exciting" <|
-            \_ ->
-                excitingList [ "Python", "Go" ]
-                    |> Expect.equal False
-        , test "Three-item list with Elm as first item is exciting" <|
-            \_ ->
-                excitingList [ "Elm", "Lisp", "Clojure" ]
-                    |> Expect.equal True
-        , test "Three-item list with Elm as second item is exciting" <|
-            \_ ->
-                excitingList [ "Java", "Elm", "C#" ]
-                    |> Expect.equal True
-        , test "Three-item list with Elm as third item is not exciting" <|
-            \_ ->
-                excitingList [ "Julia", "Assembly", "Elm" ]
-                    |> Expect.equal False
-        , test "Four-item list with Elm as first item is exciting" <|
-            \_ ->
-                excitingList [ "Elm", "C", "C++", "C#" ]
-                    |> Expect.equal True
-        , test "Four-item list with Elm as second item is not exciting" <|
-            \_ ->
-                excitingList [ "Erlang", "Elm", "C#", "Scheme" ]
-                    |> Expect.equal False
-        , test "Four-item list with Elm as third item is not exciting" <|
-            \_ ->
-                excitingList [ "Erlang", "C#", "Elm", "Scheme" ]
-                    |> Expect.equal False
-        , test "Four-item list with Elm as fourth item is not exciting" <|
-            \_ ->
-                excitingList [ "Erlang", "C#", "Scheme", "Elm" ]
-                    |> Expect.equal False
+        [ describe "1"
+            [ test "newList should return an empty list" <|
+                \_ ->
+                    newList
+                        |> Expect.equal []
+            ]
+        , describe "2"
+            [ test "existingList should return Elm, Closure and Haskell" <|
+                \_ ->
+                    existingList
+                        |> Expect.equal [ "Elm", "Clojure", "Haskell" ]
+            , test "addLanguage adds language to empty list" <|
+                \_ ->
+                    newList
+                        |> addLanguage "Scala"
+                        |> Expect.equal [ "Scala" ]
+            , test "addLanguage adds language to existing list" <|
+                \_ ->
+                    existingList
+                        |> addLanguage "Common Lisp"
+                        |> Expect.equal [ "Common Lisp", "Elm", "Clojure", "Haskell" ]
+            ]
+        , describe "3"
+            [ test "addLanguage adds language to custom list" <|
+                \_ ->
+                    addLanguage "Racket" [ "Scheme" ]
+                        |> Expect.equal [ "Racket", "Scheme" ]
+            ]
+        , describe "4"
+            [ test "Count languages on new list" <|
+                \_ ->
+                    newList
+                        |> countLanguages
+                        |> Expect.equal 0
+            , test "Count languages on existing list" <|
+                \_ ->
+                    existingList
+                        |> countLanguages
+                        |> Expect.equal 3
+            , test "Count languages on custom list" <|
+                \_ ->
+                    countLanguages [ "Python", "JavaScript" ]
+                        |> Expect.equal 2
+            ]
+        , describe "5"
+            [ test "Reverse order of new list" <|
+                \_ ->
+                    newList
+                        |> reverseList
+                        |> Expect.equal []
+            , test "Reverse order of existing list" <|
+                \_ ->
+                    existingList
+                        |> reverseList
+                        |> Expect.equal (List.reverse existingList)
+            , test "Reverse order of custom list" <|
+                \_ ->
+                    reverseList [ "Kotlin", "Java", "Scala", "Clojure" ]
+                        |> Expect.equal [ "Clojure", "Scala", "Java", "Kotlin" ]
+            ]
+        , describe "6"
+            [ test "Empty list is not exciting" <|
+                \_ ->
+                    excitingList []
+                        |> Expect.equal False
+            , test "Singleton list with Elm is exciting" <|
+                \_ ->
+                    excitingList [ "Elm" ]
+                        |> Expect.equal True
+            , test "Singleton list without Elm is not exciting" <|
+                \_ ->
+                    excitingList [ "C#" ]
+                        |> Expect.equal False
+            , test "Two-item list with Elm as first item is exciting" <|
+                \_ ->
+                    excitingList [ "Elm", "Clojure" ]
+                        |> Expect.equal True
+            , test "Two-item list with Elm as second item is exciting" <|
+                \_ ->
+                    excitingList [ "Nim", "Elm" ]
+                        |> Expect.equal True
+            , test "Two-item list without Elm is not exciting" <|
+                \_ ->
+                    excitingList [ "Python", "Go" ]
+                        |> Expect.equal False
+            , test "Three-item list with Elm as first item is exciting" <|
+                \_ ->
+                    excitingList [ "Elm", "Lisp", "Clojure" ]
+                        |> Expect.equal True
+            , test "Three-item list with Elm as second item is exciting" <|
+                \_ ->
+                    excitingList [ "Java", "Elm", "C#" ]
+                        |> Expect.equal True
+            , test "Three-item list with Elm as third item is not exciting" <|
+                \_ ->
+                    excitingList [ "Julia", "Assembly", "Elm" ]
+                        |> Expect.equal False
+            , test "Four-item list with Elm as first item is exciting" <|
+                \_ ->
+                    excitingList [ "Elm", "C", "C++", "C#" ]
+                        |> Expect.equal True
+            , test "Four-item list with Elm as second item is not exciting" <|
+                \_ ->
+                    excitingList [ "Erlang", "Elm", "C#", "Scheme" ]
+                        |> Expect.equal False
+            , test "Four-item list with Elm as third item is not exciting" <|
+                \_ ->
+                    excitingList [ "Erlang", "C#", "Elm", "Scheme" ]
+                        |> Expect.equal False
+            , test "Four-item list with Elm as fourth item is not exciting" <|
+                \_ ->
+                    excitingList [ "Erlang", "C#", "Scheme", "Elm" ]
+                        |> Expect.equal False
+            ]
         ]

--- a/exercises/concept/valentines-day/tests/Tests.elm
+++ b/exercises/concept/valentines-day/tests/Tests.elm
@@ -8,36 +8,38 @@ import ValentinesDay exposing (..)
 tests : Test
 tests =
     describe "ValentinesDay"
-        [ test "board game rated no" <|
-            \_ ->
-                rateActivity BoardGame
-                    |> Expect.equal No
-        , test "chill rated no" <|
-            \_ ->
-                rateActivity Chill
-                    |> Expect.equal No
-        , test "crime movie rated no" <|
-            \_ ->
-                rateActivity (Movie Crime)
-                    |> Expect.equal No
-        , test "horror movie rated no" <|
-            \_ ->
-                rateActivity (Movie Horror)
-                    |> Expect.equal No
-        , test "romance movie rated yes" <|
-            \_ ->
-                rateActivity (Movie Romance)
-                    |> Expect.equal Yes
-        , test "thriller movie rated no" <|
-            \_ ->
-                rateActivity (Movie Thriller)
-                    |> Expect.equal No
-        , test "korean restaurant rated no" <|
-            \_ ->
-                rateActivity (Restaurant Korean)
-                    |> Expect.equal Yes
-        , test "turkish restaurant rated maybe" <|
-            \_ ->
-                rateActivity (Restaurant Turkish)
-                    |> Expect.equal Maybe
+        [ describe "5"
+            [ test "board game rated no" <|
+                \_ ->
+                    rateActivity BoardGame
+                        |> Expect.equal No
+            , test "chill rated no" <|
+                \_ ->
+                    rateActivity Chill
+                        |> Expect.equal No
+            , test "crime movie rated no" <|
+                \_ ->
+                    rateActivity (Movie Crime)
+                        |> Expect.equal No
+            , test "horror movie rated no" <|
+                \_ ->
+                    rateActivity (Movie Horror)
+                        |> Expect.equal No
+            , test "romance movie rated yes" <|
+                \_ ->
+                    rateActivity (Movie Romance)
+                        |> Expect.equal Yes
+            , test "thriller movie rated no" <|
+                \_ ->
+                    rateActivity (Movie Thriller)
+                        |> Expect.equal No
+            , test "korean restaurant rated no" <|
+                \_ ->
+                    rateActivity (Restaurant Korean)
+                        |> Expect.equal Yes
+            , test "turkish restaurant rated maybe" <|
+                \_ ->
+                    rateActivity (Restaurant Turkish)
+                        |> Expect.equal Maybe
+            ]
         ]


### PR DESCRIPTION
[Linked to this PR](https://github.com/exercism/elm-test-runner/pull/36).

This PR tags concept exercise tests to their task ID, by grouping them with `describe "N"` where `N` is the task number. `elm-test-rs` v2.0 will use that description to assign tags in the test runner.

Make sure to use the "Hide whitespace" option, otherwise it will impossible to review.
<img width="713" alt="Screen Shot 2022-03-26 at 22 13 16" src="https://user-images.githubusercontent.com/16929078/160241129-3534c043-fa3e-4dde-8070-cc4241f930c1.png">

The PR also updates the version of  `elm-test-rs` to v2.0 to match the test runner and cleans up outdated comments in `bin/build.sh`.