### PR TITLE
Fix very small typo in Tracks on Tracks on Tracks test description

### DIFF
--- a/exercises/concept/tracks-on-tracks-on-tracks/tests/Tests.elm
+++ b/exercises/concept/tracks-on-tracks-on-tracks/tests/Tests.elm
@@ -16,7 +16,7 @@ tests =
                         |> Expect.equal []
             ]
         , describe "2"
-            [ test "existingList should return Elm, Closure and Haskell" <|
+            [ test "existingList should return Elm, Clojure and Haskell" <|
                 \_ ->
                     existingList
                         |> Expect.equal [ "Elm", "Clojure", "Haskell" ]


### PR DESCRIPTION
Fixes a very very small typo in the description of one of the tests of the Tracks on Tracks on Tracks exercise.