### PR TITLE
importing dict should be here by default

### DIFF
--- a/exercises/concept/top-scorers/src/TopScorers.elm
+++ b/exercises/concept/top-scorers/src/TopScorers.elm
@@ -1,5 +1,6 @@
 module TopScorers exposing (..)
 
+import Dict exposing (Dict)
 import TopScorersSupport exposing (PlayerName)
 
 


### PR DESCRIPTION
Importing Dict should be here by default, at least. Doing so also avoids errors if running tests without solutions (i.e: will all Debug.todo still in place)