### PR TITLE
Add `introduction.md.tpl` files, unify introduction contents

### DIFF
--- a/concepts/booleans/about.md
+++ b/concepts/booleans/about.md
@@ -30,7 +30,7 @@ Booleans are extremely useful to make branches in your code that only get execut
 In Elm, this is done with an `if-then-else` expression, used as follows.
 
 ```elm
-if someCondition then
+if someCondition || (someOtherCondition && anotherCondition) then
     doSomething
 else
     doSomethingElse

--- a/concepts/booleans/introduction.md
+++ b/concepts/booleans/introduction.md
@@ -9,7 +9,7 @@ Booleans are also extremely useful to make branches in your code that only get e
 In Elm, this is done with an `if-then-else` expression, used as follows.
 
 ```elm
-if someCondition then
+if someCondition || (someOtherCondition && anotherCondition) then
     doSomething
 else
     doSomethingElse

--- a/concepts/maybe/about.md
+++ b/concepts/maybe/about.md
@@ -25,7 +25,7 @@ age = Just 29
 ```
 
 The vertical bar `|` in the type definition of `Maybe` means "OR".
-It indicates that it can either be `Nothing` OR be `Just` something.
+It indicates that a value of this type can either be `Nothing` OR be `Just` something of type `a`.
 So imagine that the name and age were not filled by that person, we would have the following.
 
 ```elm
@@ -57,6 +57,24 @@ sayHello Nothing
     --> "Hello, World!"
 ```
 
-Everytime you use a `Maybe` value, the Elm compiler will check that your code handles all possibilities so you can never pattern match a `Maybe` and only handle the case where there is a `Just someValue`.
+Every time you use a `Maybe` value, the Elm compiler will check that your code handles all possibilities so you can never pattern match a `Maybe` and only handle the case where there is a `Just someValue`.
 This may seem annoying at first, but it is one of the greatest strengths of the Elm language.
 This will prevent hundreds of bugs and makes compiler-guided refactoring a fearless and rewarding experience.
+
+## More functions to manipulate `Maybe`
+
+There are also a number of useful functions in the `Maybe` module to manipulate `Maybe` types.
+
+```elm
+sayHelloAgain : Maybe String -> String
+sayHelloAgain name = "Hello, " ++ Maybe.withDefault "World" name ++ "!"
+
+capitalizeName : Maybe String -> Maybe String
+capitalizeName name = Maybe.map String.toUpper name
+
+capitalizeName matthieu
+    --> Just "MATTHIEU"
+
+capitalizeName anon
+    --> Nothing
+```

--- a/concepts/maybe/introduction.md
+++ b/concepts/maybe/introduction.md
@@ -9,7 +9,42 @@ type Maybe a = Nothing | Just a
 ```
 
 This is known as a "custom type" definition in Elm terminology.
-The vertical bar `|` in the type definition of `Maybe` means "OR".
-It indicates that it can either be `Nothing` OR be `Just` something.
+It indicates that a value of this type can either be `Nothing` OR be `Just` something of type `a`.
 Creating a `Maybe` value is done via one of its two constructors `Nothing` and `Just`.
 Reading the content of a `Maybe` is done via pattern matching.
+
+```elm
+matthieu : Maybe String
+matthieu = Just "Matthieu"
+
+anon : Maybe String
+anon = Nothing
+
+sayHello : Maybe String -> String
+sayHello maybeName =
+    case maybeName of
+        Nothing -> "Hello, World!"
+        Just someName -> "Hello, " ++ someName ++ "!"
+
+sayHello matthieu
+    --> "Hello, Matthieu!"
+
+sayHello anon
+    --> "Hello, World!"
+```
+
+There are also a number of useful functions in the `Maybe` module to manipulate `Maybe` types.
+
+```elm
+sayHelloAgain : Maybe String -> String
+sayHelloAgain name = "Hello, " ++ Maybe.withDefault "World" name ++ "!"
+
+capitalizeName : Maybe String -> Maybe String
+capitalizeName name = Maybe.map String.toUpper name
+
+capitalizeName matthieu
+    --> Just "MATTHIEU"
+
+capitalizeName anon
+    --> Nothing
+```

--- a/concepts/records/introduction.md
+++ b/concepts/records/introduction.md
@@ -133,7 +133,7 @@ Beware of the difference between a pipe `|` in a type definition, which is an ex
 point2d = { x = 1, y = 2 }
 point3d = { x = 3, y = 4, z = 7 }
 
-a.x point2d --> 1
+.x point2d --> 1
 .x point3d --> 3
 
 length : { a | x : Float, y : Float } -> Float

--- a/concepts/tuples/about.md
+++ b/concepts/tuples/about.md
@@ -23,60 +23,59 @@ type alias IntStringTuple = (Int, String)
 Tuples are created with parentheses and their elements are separated by commas.
 
 ```elm
+aTuple : IntStringTuple
 aTuple = (123, "elements can be of differing types")
 ```
 
 You can also use `Tuple.pair` to create a tuple with two values.
 
 ```elm
-aTuple = Tuple.pair 123 "elements can be of differing types"
---> (123, "elements can be of differing types")
+anotherTuple : (String, String)
+anotherTuple = Tuple.pair "this time it's" "two strings"
+    --> ("this time it's", "two strings")
 ```
 
 ### Access
+
+There are also functions to access tuple values by position, `Tuple.first` and `Tuple.second`.
+
+```elm
+Tuple.first aTuple
+    --> 123
+
+Tuple.second aTuple
+    --> "elements can be of differing types"
+```
 
 Tuples can be _destructured_ in bindings using tuple pattern matching.
 Destructuring can be done in let expressions, function declarations and case statements.
 
 ```elm
-doSomethingWith: (Int, String) -> Bool
-doSomethingWith aTuple =
+repeatString : (Int, String) -> Bool
+repeatString aTuple =
 let
     (aNumber, aString) = aTuple
 in
-...
-```
+    String.repeat aNumber aString
 
-```elm
-doSomethingWith: (Int, String) -> Bool
-doSomethingWith (aNumber, aString) =
-    ...
+repeatStringAgain : (Int, String) -> Bool
+repeatStringAgain (aNumber, aString) = String.repeat aNumber aString
 ```
 
 Pattern matching in a case statement also allows you to match on content of the values:
 
 ```elm
-doSomethingWith: (Int, String) -> Bool
-doSomethingWith aTuple =
+has123 : (Int, String, Bool) -> Bool
+has123 aTuple =
     case aTuple of
-        (123, _) ->
+        (123, _, _) ->
             True
-        (_, "123") ->
+        (_, "123", _) ->
             True
-        (aNumber, aString) ->
-            ...
-```
-
-There are also functions to access tuple values by position, `Tuple.first` and `Tuple.second`.
-
-```elm
-doSomethingWith: (Int, String) -> Bool
-doSomethingWith aTuple =
-    let
-        aNumber = Tuple.first aTuple
-        aString = Tuple.sceond aTuple
-    in
-    ...
+        (_, _, True) ->
+            True
+        _ ->
+            False
 ```
 
 [tuples-concise]: https://www.bekk.christmas/post/2020/1/once-twice-three-times-a-value

--- a/concepts/tuples/introduction.md
+++ b/concepts/tuples/introduction.md
@@ -4,5 +4,47 @@ Tuples in Elm can hold two or three values, and each value can have any type.
 In Elm, Tuples are mostly used for simple transient types.
 For this reason Tuples have a maximum of 3 values, and as a further encouragement convenience functions are only supplied for 2 values.
 For more complex data, it is best to switch to records.
-A common use is if you need to return more than one value from a function.
-Tuple fields don't have names, they are accessed by destructuring or by position.
+
+```elm
+type alias IntStringTuple = (Int, String)
+
+aTuple : IntStringTuple
+aTuple = (123, "elements can be of differing types")
+
+anotherTuple : (String, String)
+anotherTuple = Tuple.pair "this time it's" "two strings"
+    --> ("this time it's", "two strings")
+
+Tuple.first aTuple
+    --> 123
+
+Tuple.second aTuple
+    --> "elements can be of differing types"
+```
+
+Tuples can be _destructured_ in bindings using tuple pattern matching.
+Destructuring can be done in let expressions, function declarations and case statements.
+
+```elm
+repeatString : (Int, String) -> Bool
+repeatString aTuple =
+let
+    (aNumber, aString) = aTuple
+in
+    String.repeat aNumber aString
+
+repeatStringAgain : (Int, String) -> Bool
+repeatStringAgain (aNumber, aString) = String.repeat aNumber aString
+
+has123 : (Int, String, Bool) -> Bool
+has123 aTuple =
+    case aTuple of
+        (123, _, _) ->
+            True
+        (_, "123", _) ->
+            True
+        (_, _, True) ->
+            True
+        _ ->
+            False
+```

--- a/exercises/concept/annalyns-infiltration/.docs/introduction.md
+++ b/exercises/concept/annalyns-infiltration/.docs/introduction.md
@@ -11,7 +11,7 @@ Booleans are also extremely useful to make branches in your code that only get e
 In Elm, this is done with an `if-then-else` expression, used as follows.
 
 ```elm
-if someCondition then
+if someCondition || (someOtherCondition && anotherCondition) then
     doSomething
 else
     doSomethingElse

--- a/exercises/concept/annalyns-infiltration/.docs/introduction.md
+++ b/exercises/concept/annalyns-infiltration/.docs/introduction.md
@@ -1,32 +1,13 @@
 # Introduction
 
+## Booleans
+
 The `Bool` type is one of the building blocks of the language.
 It aims at describing whether something is true or false, with the respective `True` and `False` values.
-The name `Bool` is short for Boolean, which is a field of mathematics related to logical thinking, named after the work of George Boole.
 
-## Boolean operators
+Booleans can be combined with the `&&` "AND" and the `||` "OR" operators, and negated with the `not` function.
 
-There are two functions and two operators to manipulate values of type `Bool`.
-
-- `not : Bool -> Bool`
-  This function transforms `True` into `False` and `False` into `True`.
-- `(&&) : Bool -> Bool -> Bool`
-  This operator called "AND" takes two booleans and returns `True` if they are both `True`.
-  For example, `True && True` returns `True` but `True && False` returns `False`.
-- `(||) : Bool -> Bool -> Bool`
-  This operator called "OR" takes two booleans and returns `True` if at least one of them is `True`.
-  For example, `False || False` returns `False` but `True || False` returns `True`.
-- `xor : Bool -> Bool -> Bool`
-  This function (not operator) called "XOR" takes two booleans and returns `True` if and only if one is `True` and the other is `False`.
-
-The `&&` and `||` operators do not have the same priority.
-The priority of `&&` is higher than the one of `||`, just like with multiplication `*` and addition `+`.
-As a consequence, the expression `True || False && False` is equivalent to `True || (False && False)` which is different from `(True || False) && False`.
-While the former returns `True` the latter returns `False`.
-
-## Conditional branching
-
-Booleans are extremely useful to make branches in your code that only get executed if certain conditions are met.
+Booleans are also extremely useful to make branches in your code that only get executed if certain conditions are met.
 In Elm, this is done with an `if-then-else` expression, used as follows.
 
 ```elm
@@ -35,8 +16,3 @@ if someCondition then
 else
     doSomethingElse
 ```
-
-The value `someCondition` can be any expression that returns a `Bool`.
-If that boolean value is `True`, the code will execute `doSomething`.
-Otherwise it is `False` and the code will execute `doSomethingElse`.
-The `else` branch is mandatory, contrary to some other programming languages.

--- a/exercises/concept/annalyns-infiltration/.docs/introduction.md.tpl
+++ b/exercises/concept/annalyns-infiltration/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: booleans}

--- a/exercises/concept/bandwagoner/.docs/introduction.md
+++ b/exercises/concept/bandwagoner/.docs/introduction.md
@@ -1,9 +1,11 @@
 # Introduction
 
+## Records
+
 [Records][records] are data structures grouping together related information with labels.
 They are similar to objects in JavaScript or Java, or structs in C or Rust, but with some key distinctions.
 
-## Creating records
+### Creating records
 
 Records are [created][create] with curly brackets and their elements are separated by commas.
 
@@ -51,7 +53,7 @@ firefly : TvSeries
 firefly = TvSeries "Firefly" "Joss Whedon" 14
 ```
 
-## Accessing record fields
+### Accessing record fields
 
 The main way to [access a field value of a record instance][access] is to use the dot-notation such as `firefly.creator`.
 The Elm compiler also supports special accessor functions starting with a dot `.` such as `.creator` that will work on any record with a field of that name.
@@ -73,7 +75,7 @@ firefly.name
     --> "Joss Whedon"
 ```
 
-Records can also be _destructered_ in bindings using the [record pattern matching][pattern-matching].
+Records can also be _destructured_ in bindings using the [record pattern matching][pattern-matching].
 Destructuring works with any record that has fields of the relevant names.
 
 ```elm
@@ -92,7 +94,7 @@ complicatedCopy show =
     }
 ```
 
-## Updating records
+### Updating records
 
 Records are immutable, as everything in Elm, so once a record is defined, its field values can never change.
 There is a [special syntax to create a copy of an existing record, but changing one or more fields][update].
@@ -111,7 +113,7 @@ updatedFirefly =
     { firefly | creator = "J Whedon", episodes = 15 }
 ```
 
-## Comparing records
+### Comparing records
 
 Elm uses [structural equality][equality], which means that two instances of the same record with identical values are equal.
 
@@ -123,7 +125,7 @@ firefly1 == firefly2
     --> True
 ```
 
-## Extensible records
+### Extensible records
 
 Elm also supports [structural typing][structural-typing] meaning that if a function requires a record with an x and y field, it will work with any record that has those fields such as 2D points, 3D points, spaceships, etc.
 Those record types have a pipe `|` in their definition, such as `{ a | x : Float, y : Float }` and are called "extensible records" in Elm terminology.

--- a/exercises/concept/bandwagoner/.docs/introduction.md.tpl
+++ b/exercises/concept/bandwagoner/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: records}

--- a/exercises/concept/bettys-bike-shop/.docs/introduction.md
+++ b/exercises/concept/bettys-bike-shop/.docs/introduction.md
@@ -1,6 +1,8 @@
 # Introduction
 
-## Exporting functions
+## Basics 2
+
+### Exporting functions
 
 Exporting functions was covered in the first concept, here is a quick refresher.
 
@@ -32,7 +34,7 @@ add number1 number2 = number1 + number2
 
 https://elm-lang.org/docs/syntax#modules
 
-## Importing functions from other modules
+### Importing functions from other modules
 
 Accessing functions defined in other modules is done via imports.
 All functions within that module that were exposed by it are made accessible when importing that module.
@@ -58,7 +60,7 @@ import List exposing ( map, foldl )    -- map, foldl, List.concat
 
 https://elm-lang.org/docs/syntax#modules
 
-## Type annotations
+### Type annotations
 
 Type annotations are defined with `name : parameter types -> return type`, parameter types also being separated by `->`.
 
@@ -78,7 +80,7 @@ map charMapperFunction string =
 
 https://elm-lang.org/docs/syntax#type-annotations
 
-## Numbers
+### Numbers
 
 There are two types of numbers available in Elm, defined by the `Int` and `Float` types.
 `Int` corresponds to the set of positive and negative integers.
@@ -88,7 +90,7 @@ There exists functions to convert between the two, such that `toFloat` which con
 
 https://package.elm-lang.org/packages/elm/core/latest/Basics#Int
 
-## String operations
+### String operations
 
 To describe words and sentences in code, Elm has a native `String` type.
 String literals are written between double quotes such as `"Hello World!"`.

--- a/exercises/concept/bettys-bike-shop/.docs/introduction.md.tpl
+++ b/exercises/concept/bettys-bike-shop/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: basics-2}

--- a/exercises/concept/go/.docs/introduction.md
+++ b/exercises/concept/go/.docs/introduction.md
@@ -1,5 +1,7 @@
 # Introduction
 
+## Result
+
 The `Result` type is the solution in the Elm language for error reporting and an enabler for error recovery. It is somewhat similar to the `Maybe` type, but where Maybe can be returned by functions that may fail, it doesn't tell you anything about why it failed. Result includes this context about why something failed.
 
 The `Result` type is defined as follows:

--- a/exercises/concept/go/.docs/introduction.md.tpl
+++ b/exercises/concept/go/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: result}

--- a/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md
@@ -1,6 +1,8 @@
 # Introduction
 
-## Constants and functions
+## Basics 1
+
+### Constants and functions
 
 A constant value is defined with `name = expression`,
 where in Elm, everything except definitions are expressions.
@@ -34,7 +36,7 @@ six = add 2 (1 * 4)
 twelve = add 2 1 * 4
 ```
 
-## Indentation / significant whitespace
+### Indentation / significant whitespace
 
 Elm doesn't use syntactic markers such as curly brackets, parentheses, or semicolons to specify code boundaries. It uses whitespaces and indentations instead.
 
@@ -50,7 +52,7 @@ add number1 number2 =
 
 https://elmprogramming.com/indentation.html
 
-## Modules
+### Modules
 
 Each file in Elm is a module, and must contain a `module` statement before all other code.
 Module names must match their file name, so module `Calculator` must be in file Calculator.elm.
@@ -77,7 +79,7 @@ add number1 number2 = number1 + number2
 
 https://elm-lang.org/docs/syntax#modules
 
-## Comments
+### Comments
 
 A comment is some text within the Elm file that is not interpreted as code.
 It is mainly intented to be read by yourself and other programmers.
@@ -94,7 +96,7 @@ of opening and closing delimiters.
 -}
 ```
 
-## Formatting
+### Formatting
 
 There is a [style guide](https://elm-lang.org/docs/style-guide),
 and [elm-format](https://github.com/avh4/elm-format) can be used to automatically format code.

--- a/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md.tpl
+++ b/exercises/concept/lucians-luscious-lasagna/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: basics-1}

--- a/exercises/concept/marios-marvellous-lasagna/.docs/introduction.md
+++ b/exercises/concept/marios-marvellous-lasagna/.docs/introduction.md
@@ -1,34 +1,14 @@
 # Introduction
 
-Elm is a fully functional language, so there are no statements, just expressions, and functions are always a single expression.
+## Let
 
-This encourages small, simple functions and is generally a good thing, but sometimes functions are unavoidably more complex, and we need a way to ensure that these functions can be written elegantly.
-
-This is where `let` expressions come in. They have two parts, a `let` section where you can create as many definitions as you need, and then an `in` section, which is a single expression that can use these definitions.
-
-In computing terms, `let` creates a scope that is local to the expression in `in`.
-
-The let expression is useful in a few situations:
+The `let` expression is used to create a local scope, and is useful in a few situations:
 
 - For simplifying expressions
 - For naming the results of intermediate expressions
 - Splitting an expression in to smaller bits if it is getting large
 
-You can do most things inside a `let` expression, including destructuring (more details on this in later exercises), however the following are not allowed:
-
-- Custom Types
-- Type Alias'
-- Name shadowing (you cannot redefine / reuse a name that is already in scope)
-
-## Simplifying expressions
-
-This expression defines adds the cube's of 3 numbers, but it is hard to read, and it would be easy for the calculation to be different for the different numbers.
-
-```elm
-(a * a * a) + (b * b * b) + (c * c * c)
-```
-
-We can define a `cube` function in a `let` expressions to make the calculation simpler, more expressive, and safer. This function could have a type annotation, but in idiomatic Elm code this is relatively rare.
+You can do most things inside a `let` expression, including destructuring (more details on this in later exercises), but it isn't possible to define a new Custom Type or Type Alias.
 
 ```elm
 let
@@ -36,26 +16,6 @@ let
 in
   cube a + cube b + cube c
 ```
-
-## Naming the results of intermediate expressions
-
-This code defines sideArea and topArea to make the calculation simpler and more expressive.
-
-```elm
-cylinderArea : Float -> Float -> Float
-cylinderArea radius height =
-    let
-        sideArea = 2 * pi * radius * height
-        topArea = pi * radius ^2
-    in
-        sideArea + 2 * topArea
-```
-
-## Splitting a large expression
-
-This code creates an initial pattern for the [Game of Life](https://playgameoflife.com/) (a common programming example exercise).
-
-It's not important to understand exactly how it works, but hopefully it is obvious that it would be very large if written as a single expression, without `let`.
 
 ```elm
 beginWithPattern : Size -> Padding -> Pattern -> GameOfLife

--- a/exercises/concept/marios-marvellous-lasagna/.docs/introduction.md.tpl
+++ b/exercises/concept/marios-marvellous-lasagna/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: let}

--- a/exercises/concept/role-playing-game/.docs/introduction.md
+++ b/exercises/concept/role-playing-game/.docs/introduction.md
@@ -11,7 +11,42 @@ type Maybe a = Nothing | Just a
 ```
 
 This is known as a "custom type" definition in Elm terminology.
-The vertical bar `|` in the type definition of `Maybe` means "OR".
-It indicates that it can either be `Nothing` OR be `Just` something.
+It indicates that a value of this type can either be `Nothing` OR be `Just` something of type `a`.
 Creating a `Maybe` value is done via one of its two constructors `Nothing` and `Just`.
 Reading the content of a `Maybe` is done via pattern matching.
+
+```elm
+matthieu : Maybe String
+matthieu = Just "Matthieu"
+
+anon : Maybe String
+anon = Nothing
+
+sayHello : Maybe String -> String
+sayHello maybeName =
+    case maybeName of
+        Nothing -> "Hello, World!"
+        Just someName -> "Hello, " ++ someName ++ "!"
+
+sayHello matthieu
+    --> "Hello, Matthieu!"
+
+sayHello anon
+    --> "Hello, World!"
+```
+
+There are also a number of useful functions in the `Maybe` module to manipulate `Maybe` types.
+
+```elm
+sayHelloAgain : Maybe String -> String
+sayHelloAgain name = "Hello, " ++ Maybe.withDefault "World" name ++ "!"
+
+capitalizeName : Maybe String -> Maybe String
+capitalizeName name = Maybe.map String.toUpper name
+
+capitalizeName matthieu
+    --> Just "MATTHIEU"
+
+capitalizeName anon
+    --> Nothing
+```

--- a/exercises/concept/role-playing-game/.docs/introduction.md
+++ b/exercises/concept/role-playing-game/.docs/introduction.md
@@ -1,10 +1,9 @@
 # Introduction
 
+## Maybe
+
 The `Maybe` type is the solution in the Elm language for optional values.
 It is thus present in type signatures of a wide number of core Elm functions and understanding it is crucial.
-
-## Definition and type variable
-
 The `Maybe` type is defined as follows:
 
 ```elm
@@ -12,63 +11,7 @@ type Maybe a = Nothing | Just a
 ```
 
 This is known as a "custom type" definition in Elm terminology.
-Custom types are introduced in details in another concept of this track but we won't need it to understand specifically `Maybe`.
-The `a` in `Maybe a` and `Just a` represents a type variable, meaning it can be any type, such as `Int`, `Bool` or `String`.
-As such, a `Maybe String` is a variable that optionally holds a `String`, while a `Maybe Int` would optionally hold an `Int`.
-
-```elm
-name : Maybe String
-name = Just "Matthieu"
-
-age : Maybe Int
-age = Just 29
-```
-
 The vertical bar `|` in the type definition of `Maybe` means "OR".
 It indicates that it can either be `Nothing` OR be `Just` something.
-So imagine that the name and age were not filled by that person, we would have the following.
-
-```elm
-name : Maybe String
-name = Nothing
-
-age : Maybe Int
-age = Nothing
-```
-
-## Reading the content of a Maybe value
-
-Reading the content of a `Maybe` value is done via "pattern matching".
-Pattern matching is also introduced in more details in another concept, so we just focus on how pattern matching a `Maybe` works.
-Sometimes, we can also avoid pattern matching by using predefined functions such as `Maybe.withDefault`.
-
-```elm
--- This function returns "Hello, <name>!" if the name was provided.
--- Otherwise, it just says "Hello, World!".
-sayHello : Maybe String -> String
-sayHello maybeName =
-    case maybeName of
-        Nothing -> "Hello, World!"
-        Just someName -> "Hello, " ++ someName ++ "!"
-
-sayHello (Just "Matthieu")
-    --> "Hello, Matthieu!"
-
-sayHello Nothing
-    --> "Hello, World!"
-
--- Here we use Maybe.withDefault instead of pattern matching.
-sayHelloAgain : Maybe String -> String
-sayHelloAgain maybeName =
-    let
-        subject : String
-        subject =
-            Maybe.withDefault "World" maybeName
-    in
-    "Hello, " ++ subject ++ "!"
-
-```
-
-Everytime you use a `Maybe` value, the Elm compiler will check that your code handles all possibilities so you can never pattern match a `Maybe` and only handle the case where there is a `Just someValue`.
-This may seem anoying at first, but it is one of the greatest strengths of the Elm language.
-This will prevent hundreds of bugs and makes compiler-guided refactoring a fearless and rewarding experience.
+Creating a `Maybe` value is done via one of its two constructors `Nothing` and `Just`.
+Reading the content of a `Maybe` is done via pattern matching.

--- a/exercises/concept/role-playing-game/.docs/introduction.md.tpl
+++ b/exercises/concept/role-playing-game/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: maybe}

--- a/exercises/concept/ticket-please/.docs/introduction.md
+++ b/exercises/concept/ticket-please/.docs/introduction.md
@@ -1,8 +1,10 @@
 # Introduction
 
+## Pattern Matching
+
 [Pattern matching][pattern-matching] enables expressive branching code and [destructuring][destructuring] brings elegant binding of values to variables.
 
-## Simple pattern matching
+### Simple pattern matching
 
 Pattern matching can bind values to variables, or discard them with the wildcard `_`, with the use of the `case` statement.
 
@@ -22,7 +24,7 @@ hello entity =
         _ -> "Hello stranger!"
 ```
 
-## Destructuring
+### Destructuring
 
 Destructuring can binds values in `let` bindings, function arguments, and of course in case expressions, whenever there is only one shape possible for the data.
 
@@ -80,7 +82,6 @@ smaller reduction ({ radius } as circle) =
     else
         circle
 ```
-
 
 [pattern-matching]: https://guide.elm-lang.org/types/pattern_matching.html
 [destructuring]: https://gist.github.com/yang-wei/4f563fbf81ff843e8b1e

--- a/exercises/concept/ticket-please/.docs/introduction.md.tpl
+++ b/exercises/concept/ticket-please/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: pattern-matching}

--- a/exercises/concept/tisbury-treasure-hunt/.docs/introduction.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/introduction.md
@@ -1,84 +1,10 @@
-# Tuples
+# Introduction
+
+## Tuples
 
 Tuples in Elm can hold two or three values, and each value can have any type.
 In Elm, Tuples are mostly used for simple transient types.
 For this reason Tuples have a maximum of 3 values, and as a further encouragement convenience functions are only supplied for 2 values.
 For more complex data, it is best to switch to records.
 A common use is if you need to return more than one value from a function.
-Tuple fields don't have names, they are accessed by means of destructuring or by position.
-
-You can read a [concise introduction to tuples][tuples-concise].
-There is also a [more in depth introduction][tuples-in-depth], and the [API doc of the Tuple module][tuple-core] contains code examples and detailed documentation.
-
-## Declaration
-
-Types for Tuples are created with parentheses and their element types are separated by commas.
-
-```elm
-type alias IntStringTuple = (Int, String)
-```
-
-## Creation
-
-Tuples are created with parentheses and their elements are separated by commas.
-
-```elm
-aTuple = (123, "elements can be of differing types")
-```
-
-You can also use `Tuple.pair` to create a tuple with two values.
-
-```elm
-aTuple = Tuple.pair 123 "elements can be of differing types"
---> (123, "elements can be of differing types")
-```
-
-## Access
-
-Tuples can be _destructured_ in bindings using tuple pattern matching.
-Destructuring can be done in let expressions, function declarations and case statements.
-
-```elm
-doSomethingWith: (Int, String) -> Bool
-doSomethingWith aTuple =
-let
-    (aNumber, aString) = aTuple
-in
-...
-```
-
-```elm
-doSomethingWith: (Int, String) -> Bool
-doSomethingWith (aNumber, aString) =
-    ...
-```
-
-Pattern matching in a case statement also allows you to match on content of the values:
-
-```elm
-doSomethingWith: (Int, String) -> Bool
-doSomethingWith aTuple =
-    case aTuple of
-        (123, _) ->
-            True
-        (_, "123") ->
-            True
-        (aNumber, aString) ->
-            ...
-```
-
-There are also functions to access tuple values by position, `Tuple.first` and `Tuple.second`.
-
-```elm
-doSomethingWith: (Int, String) -> Bool
-doSomethingWith aTuple =
-    let
-        aNumber = Tuple.first aTuple
-        aString = Tuple.second aTuple
-    in
-    ...
-```
-
-[tuples-concise]: https://www.bekk.christmas/post/2020/1/once-twice-three-times-a-value
-[tuples-in-depth]: https://elmprogramming.com/tuple.html
-[tuple-core]: https://package.elm-lang.org/packages/elm/core/latest/Tuple
+Tuple fields don't have names, they are accessed by destructuring or by position.

--- a/exercises/concept/tisbury-treasure-hunt/.docs/introduction.md
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/introduction.md
@@ -6,5 +6,47 @@ Tuples in Elm can hold two or three values, and each value can have any type.
 In Elm, Tuples are mostly used for simple transient types.
 For this reason Tuples have a maximum of 3 values, and as a further encouragement convenience functions are only supplied for 2 values.
 For more complex data, it is best to switch to records.
-A common use is if you need to return more than one value from a function.
-Tuple fields don't have names, they are accessed by destructuring or by position.
+
+```elm
+type alias IntStringTuple = (Int, String)
+
+aTuple : IntStringTuple
+aTuple = (123, "elements can be of differing types")
+
+anotherTuple : (String, String)
+anotherTuple = Tuple.pair "this time it's" "two strings"
+    --> ("this time it's", "two strings")
+
+Tuple.first aTuple
+    --> 123
+
+Tuple.second aTuple
+    --> "elements can be of differing types"
+```
+
+Tuples can be _destructured_ in bindings using tuple pattern matching.
+Destructuring can be done in let expressions, function declarations and case statements.
+
+```elm
+repeatString : (Int, String) -> Bool
+repeatString aTuple =
+let
+    (aNumber, aString) = aTuple
+in
+    String.repeat aNumber aString
+
+repeatStringAgain : (Int, String) -> Bool
+repeatStringAgain (aNumber, aString) = String.repeat aNumber aString
+
+has123 : (Int, String, Bool) -> Bool
+has123 aTuple =
+    case aTuple of
+        (123, _, _) ->
+            True
+        (_, "123", _) ->
+            True
+        (_, _, True) ->
+            True
+        _ ->
+            False
+```

--- a/exercises/concept/tisbury-treasure-hunt/.docs/introduction.md.tpl
+++ b/exercises/concept/tisbury-treasure-hunt/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: tuples}

--- a/exercises/concept/top-scorers/.docs/introduction.md
+++ b/exercises/concept/top-scorers/.docs/introduction.md
@@ -1,4 +1,6 @@
-# About
+# Introduction
+
+## Dict
 
 A [`Dict`][dict] in Elm is an immutable dictionary of zero or more key-value pairs.
 

--- a/exercises/concept/top-scorers/.docs/introduction.md.tpl
+++ b/exercises/concept/top-scorers/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: dict}

--- a/exercises/concept/tracks-on-tracks-on-tracks/.docs/introduction.md
+++ b/exercises/concept/tracks-on-tracks-on-tracks/.docs/introduction.md
@@ -1,8 +1,8 @@
 # Introduction
 
-A `List` in Elm is an immutable collection of zero or more values of the same type.
-As lists are immutable, once a list has been constructed, its value can never change.
-Any functions/operators that appear to modify a list (such as adding an element), will actually return a new list.
+## Lists
+
+A [`List`][lists] in Elm is an immutable collection of zero or more values of the same type.
 
 Lists can be defined as follows:
 
@@ -19,9 +19,7 @@ twoToFour = [ 2, 3, 4 ]
 oneToFour = 1 :: twoToFour --> [ 1, 2, 3, 4 ]
 ```
 
-Elm list's have a _head_ (the first element) and a _tail_ (everything after the first element).
-The tail of a list is itself a list.
-Lists are either manipulated by functions and operators defined in the `List` module, or manually using pattern matching.
+Lists are manipulated by functions and operators defined in the [`List` module][list-module] or by [pattern matching](list-destructuring)
 
 ```elm
 describe : List String -> String
@@ -40,3 +38,7 @@ describe []                   --> "Empty list"
 describe [ "hello" ]          --> "Singleton list with: hello"
 describe [ "hello", "world" ] --> "Non-empty list with head: hello"
 ```
+
+[lists]: https://elmprogramming.com/list.html
+[list-module]: https://package.elm-lang.org/packages/elm/core/latest/List
+[list-destructuring]: https://www.bekk.christmas/post/2020/8/peeking-inside-lists

--- a/exercises/concept/tracks-on-tracks-on-tracks/.docs/introduction.md.tpl
+++ b/exercises/concept/tracks-on-tracks-on-tracks/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: lists}

--- a/exercises/concept/valentines-day/.docs/introduction.md
+++ b/exercises/concept/valentines-day/.docs/introduction.md
@@ -1,5 +1,7 @@
 # Introduction
 
+## Custom Types
+
 [Custom Types][custom-types] in Elm represent a fixed number of named cases. Each value corresponds to exactly one of the named cases.
 
 A Custom Type is defined using the `type` keyword and requires very little syntax. They are one of the most important techniques in Elm programming, and are used to make the possible values in code exactly match the valid values in real life, which leaves no room for invalid data, and makes [impossible states impossible to represent in the code][impossible-states].

--- a/exercises/concept/valentines-day/.docs/introduction.md.tpl
+++ b/exercises/concept/valentines-day/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: custom-types}


### PR DESCRIPTION
This PR is the equivalent of [this one](https://github.com/exercism/elixir/pull/1151) for Elixir.
The idea is to unify the concept exercise intro to the exercise intro, by adding `introduction.md.tpl` files and generating the intro via `configlet generate`.

Doing that, I have found several exercise that actually used the text from `about.md` instead of `introduction.md`, which is not recommended. I also found some typos that were not consistently fixed everywhere.

Another side effect of this is that a new header with the name of the topic is added (eg `## Tuples`) and all other heading levels are increased.

The reason I'm leaving this in draft is that
- I don't necessarily feel strongly about those changes, so I want to hear opinions about it
- There is a bug with configlet, it doesn't support slugs with numbers like our `basics-1` and `basics-2`, so I've left them alone for now. I've [opened an issue here](https://github.com/exercism/configlet/issues/663), but I wanted to have a branch that @ee7 can checkout for testing purposes.