### PR TITLE
Add concept `comparison` and concept exercise `blorkemon-cards`

### DIFF
--- a/bin/generate_concept_exercise.sh
+++ b/bin/generate_concept_exercise.sh
@@ -72,7 +72,7 @@ SOLUTION=$(ls ${exercise_dir}/src)
 jq -n --arg solution "src/${SOLUTION}" \
     '{authors: [], contributors: [], files: {solution: $solution, test: "tests/Tests.elm", exemplar: ".meta/Exemplar.elm"}, blurb: "Learn this by doing that"}' \
     > ${exercise_dir}/.meta/config.json
-printf "# Design\n\n## Goal\n\nThe Goal is to learn X\n\n## ## Learning objectives\n\n- Know what X is\n\n## Out of scope\n\n- This and that\n\n## Concepts\n\nThe concepts this exercise unlock are:\n\n- booleans\n\n## Prerequisites\n\n- booleans\n\n## Analyzer\n\nMake sure that:\n\n- X is called with Y" \
+printf "# Design\n\n## Goal\n\nThe Goal is to learn X\n\n## Learning objectives\n\n- Know what X is\n\n## Out of scope\n\n- This and that\n\n## Concepts\n\nThe concepts this exercise unlock are:\n\n- booleans\n\n## Prerequisites\n\n- booleans\n\n## Analyzer\n\nMake sure that:\n\n- X is called with Y" \
     > ${exercise_dir}/.meta/design.md
 
 # Done

--- a/bin/generate_concept_exercise.sh
+++ b/bin/generate_concept_exercise.sh
@@ -70,7 +70,7 @@ printf "# Instructions\n\nStory goes here\n\n## 1. Task 1 title\n\nDefine the th
 ## .meta
 SOLUTION=$(ls ${exercise_dir}/src)
 jq -n --arg solution "src/${SOLUTION}" \
-    '{authors: [], contributors: [], files: {solution: $solution, test: "tests/Tests.elm", exemplar: ".meta/Exemplar.elm"}, blurb: "Learn this by doing that"}' \
+    '{authors: [], contributors: [], files: {solution: [$solution], test: ["tests/Tests.elm"], exemplar: [".meta/Exemplar.elm"]}, blurb: "Learn this by doing that"}' \
     > ${exercise_dir}/.meta/config.json
 printf "# Design\n\n## Goal\n\nThe Goal is to learn X\n\n## Learning objectives\n\n- Know what X is\n\n## Out of scope\n\n- This and that\n\n## Concepts\n\nThe concepts this exercise unlock are:\n\n- booleans\n\n## Prerequisites\n\n- booleans\n\n## Analyzer\n\nMake sure that:\n\n- X is called with Y" \
     > ${exercise_dir}/.meta/design.md

--- a/concepts/comparison/.meta/config.json
+++ b/concepts/comparison/.meta/config.json
@@ -1,0 +1,10 @@
+{
+  "blurb": "Find out which types can be compared directly",
+  "authors": [
+    "jiegillet"
+  ],
+  "contributors": [
+    "mpizenberg",
+    "ceddlyburge"
+  ]
+}

--- a/concepts/comparison/about.md
+++ b/concepts/comparison/about.md
@@ -92,7 +92,8 @@ List.sortBy String.length ["hi", "hello", "bye", "goodbye"]
     --> ["hi", "bye", "hello", "goodbye"]
 ```
 
-The function `compare` takes to `comparable` values and returns an `Order` (either less than `LT`, equal `EQ` or greater than `GT`).
+The function `compare` takes to `comparable` values and returns an `Order`.
+An `Order` is a type that checks in a in a single operation if a value is greater (`GT`), equal (`EQ`) or less (`LT`) than another.
 
 ```elm
 compare 1 2
@@ -105,7 +106,7 @@ compare [12] []
     --> GT
 ```
 
-Lists of values that can be compared can be sorted with `List.sortWith`:
+Comparison functions can be constructed for arbitrary types and be used, for example, to be sorted with `List.sortWith`:
 
 ```elm
 type Color = Red | Green | Blue

--- a/concepts/comparison/about.md
+++ b/concepts/comparison/about.md
@@ -1,0 +1,122 @@
+# About
+
+## Equality
+
+Elm types can be checked for "being the same" with the [equality operator][equality-operator] `(==)`.
+The inequality operator is `(/=)` (*not* `!=` like in many languages).
+
+```elm
+1 == 2
+    --> False
+
+1 /= 2
+    --> True
+```
+
+Both values being compared have to be of thew same type for the expression to compile.
+The equality operator works on tuples, records and custom types and uses structural equality to verify the values are definitively equal.
+
+```elm
+(1, 2) == (2, 1)
+    --> False
+
+type alias MyRecord = { myInt : Int, myString : String }
+MyRecord (1 + 1) "hello world" == { myInt = 2, myString = String.join " " ["hello", "world"]}
+    --> True
+```
+
+Note that you *should never* compare functions, as this will make the program crash at runtime.
+More information about that limitation [here][equality-operator].
+
+## Comparisons
+
+The [comparison operators][comparison-operators] `(<)`, `(<=)`, `(>)`, `(>=)` and functions `min`, `max`, `compare` work on `comparable` types.
+The `comparable` type is a special type that groups all built-in types that can be compared: numbers, characters, strings, lists of comparable things, and tuples of comparable things.
+Characters are compared from their [unicode codepoints][unicode-codepoint].
+
+```elm
+1 < 1 + 1
+    --> True
+
+'x' < 'X'
+    --> False
+
+'互' < '🙏'
+    --> True
+```
+
+Sequence-like types (strings, lists and tuples) are compared in [lexicographic order][lexicographic-order].
+In a nutshell, sequence element are compared pairwise in order until an element is found smaller or a sequence ends.
+
+```elm
+"abc" < "abz"
+    --> True
+
+"abc" < "abcd"
+    --> True
+
+"abc" < "b"
+    --> True
+
+min [1 , 2, 9000] [10]
+    --> [1 , 2, 9000]
+
+min (1, "hello") (3, "bye")
+    --> (1, "hello")
+
+min (1, ['a', 'b']) (1, ['A', 'B'])
+    --> (1, ['A', 'B'])
+```
+
+Values of other types such as records or custom types cannot be compared directly.
+
+Lists of `comparable` values can be sorted with `List.sort` and lists of values that can be mapped to comparable values can be sorted with `List.sortBy`:
+
+```elm
+List.sort ["hi", "hello", "bye", "goodbye"]
+    --> ["bye", "goodbye", "hello", "hi"]
+
+List.sortBy String.length ["hi", "hello", "bye", "goodbye"]
+    --> ["hi", "bye", "hello", "goodbye"]
+```
+
+The function `compare` takes to `comparable` values and returns an `Order` (either less than `LT`, equal `EQ` or greater than `GT`).
+
+```elm
+compare 1 2
+    --> LT
+
+compare "" ""
+    --> EQ
+
+compare [12] []
+    --> GT
+```
+
+Lists of values that can be compared can be sorted with `List.sortWith`:
+
+```elm
+List.sortWith compare ["hi", "hello", "bye", "goodbye"]
+    --> ["bye", "goodbye", "hello", "hi"]
+
+type Color = Red | Green | Blue
+
+compareColors : Color -> Color -> Order
+compareColors a b =
+  case (a, b) of
+    (Red, Red) -> EQ
+    (Red, _) -> LT
+    (_, Red) -> GT
+    (Green, Green) -> EQ
+    (Green, _) -> LT
+    (_, Green) -> GT
+    (Blue, Blue) -> EQ
+
+List.sortWith compareColors [Blue, Red, Green, Green, Blue]
+    --> [Red, Green, Green, Blue, Blue]
+```
+
+[equality-operator]: https://package.elm-lang.org/packages/elm/core/latest/Basics#(==)
+[comparison-operators]: https://package.elm-lang.org/packages/elm/core/latest/Basics#(%3C)
+[unicode-codepoint]: https://en.wikipedia.org/wiki/Unicode#Architecture_and_terminology
+[lexicographic-order]: https://en.wikipedia.org/wiki/Lexicographic_order

--- a/concepts/comparison/about.md
+++ b/concepts/comparison/about.md
@@ -80,9 +80,11 @@ min (1, ['a', 'b']) (1, ['A', 'B'])
 Values of other types such as records or custom types cannot be compared directly.
 
 Some built-in types require their content to be `comparable`, such as `Set` or `Dict` keys, since their structure relies on an internal ordering.
-That implies that custom types may not be stored in a `Set`, although there are community [alternatives][sort-by]: [`AnySet`][any-set], [`AnyDict`][any-dict], [`Sort`][sort]...
+That implies that custom types may not be stored in a `Set`, although there are community alternatives: [`AnySet`][any-set], [`AnyDict`][any-dict], [`Sort`][sort]...
 
-Lists of `comparable` values can be sorted with `List.sort` and lists of values that can be mapped to comparable values can be sorted with `List.sortBy`:
+Lists of `comparable` values can be sorted with `List.sort` and lists of values that can be mapped to comparable values can be sorted with `List.sortBy`.
+If you need a hierarchical sort (sort by one property, and break ties with another), tuples or lists may be used with `List.sortBy` (among other [alternatives][sort-by]) since tuples and lists are sorted in lexicographic order.
+
 
 ```elm
 List.sort ["hi", "hello", "bye", "goodbye"]
@@ -90,6 +92,10 @@ List.sort ["hi", "hello", "bye", "goodbye"]
 
 List.sortBy String.length ["hi", "hello", "bye", "goodbye"]
     --> ["hi", "bye", "hello", "goodbye"]
+
+-- sort by length, then alphabetically
+List.sortBy (\str -> (String.length str, str)) ["hi", "mum", "hello", "sis", "bye", "dad"]
+    --> ["hi", "bye", "dad", "mum", "sis", "hello"]
 ```
 
 The function `compare` takes to `comparable` values and returns an `Order`.

--- a/concepts/comparison/about.md
+++ b/concepts/comparison/about.md
@@ -13,15 +13,24 @@ The inequality operator is `(/=)` (*not* `!=` like in many languages).
     --> True
 ```
 
-Both values being compared have to be of thew same type for the expression to compile.
-The equality operator works on tuples, records and custom types and uses structural equality to verify the values are definitively equal.
+Both values being compared have to be of thew same type.
+The equality operator works on literals, tuples, records and custom types.
+The operator checks for structural equality, which means that equal values have equal content and deep structure, regardless of type annotation or position in memory.
 
 ```elm
 (1, 2) == (2, 1)
     --> False
 
-type alias MyRecord = { myInt : Int, myString : String }
-MyRecord (1 + 1) "hello world" == { myInt = 2, myString = String.join " " ["hello", "world"]}
+type alias MyRecord = { myInt : Int, myStrings : List String }
+a : MyRecord
+a = MyRecord (1 + 1) ["hello world"]
+
+type alias MyOtherRecord = { myInt : Int, myStrings : List String }
+myStrings =  (String.join " " ["hello", "world"]) :: []
+b : MyOtherRecord
+b = { myInt = 2, myStrings = myStrings}
+
+a == b
     --> True
 ```
 

--- a/concepts/comparison/about.md
+++ b/concepts/comparison/about.md
@@ -80,7 +80,7 @@ min (1, ['a', 'b']) (1, ['A', 'B'])
 Values of other types such as records or custom types cannot be compared directly.
 
 Some built-in types require their content to be `comparable`, such as `Set` or `Dict` keys, since their structure relies on an internal ordering.
-That implies that custom types may not be stored in a `Set`, although there are community alternatives: [`AnySet`][any-set], [`AnyDict`][any-dict], [`Sort`][sort]...
+That implies that custom types may not be stored in a `Set`, although there are community alternatives: [`AnySet`][any-set], [`AnyDict`][any-dict], [`Sort`][sort] and others.
 
 Lists of `comparable` values can be sorted with `List.sort` and lists of values that can be mapped to comparable values can be sorted with `List.sortBy`.
 If you need a hierarchical sort (sort by one property, and break ties with another), tuples or lists may be used with `List.sortBy` (among other [alternatives][sort-by]) since tuples and lists are sorted in lexicographic order.

--- a/concepts/comparison/about.md
+++ b/concepts/comparison/about.md
@@ -79,6 +79,9 @@ min (1, ['a', 'b']) (1, ['A', 'B'])
 
 Values of other types such as records or custom types cannot be compared directly.
 
+Some built-in types require their content to be `comparable`, such as `Set` or `Dict` keys, since their structure relies on an internal ordering.
+That implies that custom types may not be stored in a `Set`, although there are community [alternatives][sort-by]: [`AnySet`][any-set], [`AnyDict`][any-dict], [`Sort`][sort]...
+
 Lists of `comparable` values can be sorted with `List.sort` and lists of values that can be mapped to comparable values can be sorted with `List.sortBy`:
 
 ```elm
@@ -105,9 +108,6 @@ compare [12] []
 Lists of values that can be compared can be sorted with `List.sortWith`:
 
 ```elm
-List.sortWith compare ["hi", "hello", "bye", "goodbye"]
-    --> ["bye", "goodbye", "hello", "hi"]
-
 type Color = Red | Green | Blue
 
 compareColors : Color -> Color -> Order
@@ -129,3 +129,7 @@ List.sortWith compareColors [Blue, Red, Green, Green, Blue]
 [comparison-operators]: https://package.elm-lang.org/packages/elm/core/latest/Basics#(%3C)
 [unicode-codepoint]: https://en.wikipedia.org/wiki/Unicode#Architecture_and_terminology
 [lexicographic-order]: https://en.wikipedia.org/wiki/Lexicographic_order
+[sort-by]: https://github.com/ceddlyburge/elm-league-tables-from-google-sheets/blob/master/src/Calculations/SortBy.elm
+[any-set]: https://package.elm-lang.org/packages/turboMaCk/any-set/latest/
+[any-dict]: https://package.elm-lang.org/packages/turboMaCk/any-dict/latest/
+[sort]: https://package.elm-lang.org/packages/rtfeldman/elm-sorter-experiment/latest/Sort

--- a/concepts/comparison/introduction.md
+++ b/concepts/comparison/introduction.md
@@ -4,7 +4,7 @@
 
 Elm types can be checked for "being the same" with the equality operator `(==)`.
 The inequality operator is `(/=)` (*not* `!=` like in many languages).
-The equality operator works on tuples, records and custom types and uses structural equality to verify the values are definitively equal.
+The equality operator works on literals, tuples, records and custom types.
 
 ```elm
 1 == 2
@@ -16,8 +16,16 @@ The equality operator works on tuples, records and custom types and uses structu
 (1, 2) == (2, 1)
     --> False
 
-type alias MyRecord = { myInt : Int, myString : String }
-MyRecord (1 + 1) "hello world" == { myInt = 2, myString = String.join " " ["hello", "world"]}
+type alias MyRecord = { myInt : Int, myStrings : List String }
+a : MyRecord
+a = MyRecord (1 + 1) ["hello world"]
+
+type alias MyOtherRecord = { myInt : Int, myStrings : List String }
+myStrings =  (String.join " " ["hello", "world"]) :: []
+b : MyOtherRecord
+b = { myInt = 2, myStrings = myStrings}
+
+a == b
     --> True
 ```
 

--- a/concepts/comparison/introduction.md
+++ b/concepts/comparison/introduction.md
@@ -63,7 +63,7 @@ List.sortBy String.length ["hi", "hello", "bye", "goodbye"]
     --> ["hi", "bye", "hello", "goodbye"]
 ```
 
-The function `compare` takes to `comparable` values and returns an `Order` (either less than `LT`, equal `EQ` or greater than `GT`).
+The function `compare` takes two `comparable` values and returns an `Order` (either less than `LT`, equal `EQ` or greater than `GT`).
 
 ```elm
 compare 1 2

--- a/concepts/comparison/introduction.md
+++ b/concepts/comparison/introduction.md
@@ -61,6 +61,8 @@ min (1, "hello") (3, "bye")
 
 Values of other types such as records or custom types cannot be compared directly.
 
+Some built-in types require their content to be `comparable`, such as `Set` or `Dict` keys, since their structure relies on an internal ordering.
+
 Lists of `comparable` values can be sorted with `List.sort` and lists of values that can be mapped to comparable values can be sorted with `List.sortBy`:
 
 ```elm
@@ -87,9 +89,6 @@ compare [12] []
 Lists of values that can be compared can be sorted with `List.sortWith`:
 
 ```elm
-List.sortWith compare ["hi", "hello", "bye", "goodbye"]
-    --> ["bye", "goodbye", "hello", "hi"]
-
 type Color = Red | Green | Blue
 
 compareColors : Color -> Color -> Order

--- a/concepts/comparison/introduction.md
+++ b/concepts/comparison/introduction.md
@@ -73,7 +73,8 @@ List.sortBy String.length ["hi", "hello", "bye", "goodbye"]
     --> ["hi", "bye", "hello", "goodbye"]
 ```
 
-The function `compare` takes two `comparable` values and returns an `Order` (either less than `LT`, equal `EQ` or greater than `GT`).
+The function `compare` takes two `comparable` values and returns an `Order`.
+An `Order` is a type that checks in a in a single operation if a value is greater (`GT`), equal (`EQ`) or less (`LT`) than another.
 
 ```elm
 compare 1 2
@@ -86,7 +87,7 @@ compare [12] []
     --> GT
 ```
 
-Lists of values that can be compared can be sorted with `List.sortWith`:
+Comparison functions can be constructed for arbitrary types and be used, for example, to be sorted with `List.sortWith`:
 
 ```elm
 type Color = Red | Green | Blue

--- a/concepts/comparison/introduction.md
+++ b/concepts/comparison/introduction.md
@@ -1,0 +1,100 @@
+# Introduction
+
+## Equality
+
+Elm types can be checked for "being the same" with the equality operator `(==)`.
+The inequality operator is `(/=)` (*not* `!=` like in many languages).
+The equality operator works on tuples, records and custom types and uses structural equality to verify the values are definitively equal.
+
+```elm
+1 == 2
+    --> False
+
+1 /= 2
+    --> True
+
+(1, 2) == (2, 1)
+    --> False
+
+type alias MyRecord = { myInt : Int, myString : String }
+MyRecord (1 + 1) "hello world" == { myInt = 2, myString = String.join " " ["hello", "world"]}
+    --> True
+```
+
+Note that you *should never* compare functions, as this will make the program crash at runtime.
+
+## Comparisons
+
+The comparison operators `(<)`, `(<=)`, `(>)`, `(>=)` and functions `min`, `max`, `compare` work on `comparable` types.
+The `comparable` type is a special type that groups all built-in types that can be compared: numbers, characters, strings, lists of comparable things, and tuples of comparable things.
+
+```elm
+1 < 1 + 1
+    --> True
+
+'x' < 'X'
+    --> False
+
+"abc" < "abz"
+    --> True
+
+"abc" < "abcd"
+    --> True
+
+"abc" < "b"
+    --> True
+
+min [1 , 2, 9000] [10]
+    --> [1 , 2, 9000]
+
+min (1, "hello") (3, "bye")
+    --> (1, "hello")
+```
+
+Values of other types such as records or custom types cannot be compared directly.
+
+Lists of `comparable` values can be sorted with `List.sort` and lists of values that can be mapped to comparable values can be sorted with `List.sortBy`:
+
+```elm
+List.sort ["hi", "hello", "bye", "goodbye"]
+    --> ["bye", "goodbye", "hello", "hi"]
+
+List.sortBy String.length ["hi", "hello", "bye", "goodbye"]
+    --> ["hi", "bye", "hello", "goodbye"]
+```
+
+The function `compare` takes to `comparable` values and returns an `Order` (either less than `LT`, equal `EQ` or greater than `GT`).
+
+```elm
+compare 1 2
+    --> LT
+
+compare "" ""
+    --> EQ
+
+compare [12] []
+    --> GT
+```
+
+Lists of values that can be compared can be sorted with `List.sortWith`:
+
+```elm
+List.sortWith compare ["hi", "hello", "bye", "goodbye"]
+    --> ["bye", "goodbye", "hello", "hi"]
+
+type Color = Red | Green | Blue
+
+compareColors : Color -> Color -> Order
+compareColors a b =
+  case (a, b) of
+    (Red, Red) -> EQ
+    (Red, _) -> LT
+    (_, Red) -> GT
+    (Green, Green) -> EQ
+    (Green, _) -> LT
+    (_, Green) -> GT
+    (Blue, Blue) -> EQ
+
+List.sortWith compareColors [Blue, Red, Green, Green, Blue]
+    --> [Red, Green, Green, Blue, Blue]
+```

--- a/concepts/comparison/introduction.md
+++ b/concepts/comparison/introduction.md
@@ -63,7 +63,9 @@ Values of other types such as records or custom types cannot be compared directl
 
 Some built-in types require their content to be `comparable`, such as `Set` or `Dict` keys, since their structure relies on an internal ordering.
 
-Lists of `comparable` values can be sorted with `List.sort` and lists of values that can be mapped to comparable values can be sorted with `List.sortBy`:
+Lists of `comparable` values can be sorted with `List.sort` and lists of values that can be mapped to comparable values can be sorted with `List.sortBy`.
+If you need a hierarchical sort (sort by one property, and break ties with another), tuples or lists may also be used with `List.sortBy` since tuples and lists are sorted in lexicographic order.
+
 
 ```elm
 List.sort ["hi", "hello", "bye", "goodbye"]
@@ -71,6 +73,10 @@ List.sort ["hi", "hello", "bye", "goodbye"]
 
 List.sortBy String.length ["hi", "hello", "bye", "goodbye"]
     --> ["hi", "bye", "hello", "goodbye"]
+
+-- sort by length, then alphabetically
+List.sortBy (\str -> (String.length str, str)) ["hi", "mum", "hello", "sis", "bye", "dad"]
+    --> ["hi", "bye", "dad", "mum", "sis", "hello"]
 ```
 
 The function `compare` takes two `comparable` values and returns an `Order`.

--- a/concepts/comparison/links.json
+++ b/concepts/comparison/links.json
@@ -1,0 +1,6 @@
+[
+  {
+    "url": "https://package.elm-lang.org/packages/elm/core/latest/Basics#(%3C)",
+    "description": "Elm comparison operators"
+  }
+]

--- a/concepts/comparison/links.json
+++ b/concepts/comparison/links.json
@@ -2,5 +2,21 @@
   {
     "url": "https://package.elm-lang.org/packages/elm/core/latest/Basics#(%3C)",
     "description": "Elm comparison operators"
+  },
+  {
+    "url": "https://en.wikipedia.org/wiki/Lexicographic_order",
+    "description": "Elm compares values in lexicographic order"
+  },
+  {
+    "url": "https://package.elm-lang.org/packages/rtfeldman/elm-sorter-experiment/latest/Sort",
+    "description": "Explorations on sorting arbitrary types"
+  },
+  {
+    "url": "https://package.elm-lang.org/packages/turboMaCk/any-set/latest/",
+    "description": "Sets for non-comparable types"
+  },
+  {
+    "url": "https://package.elm-lang.org/packages/turboMaCk/any-dict/latest/",
+    "description": "Dict with non-comparable keys"
   }
 ]

--- a/config.json
+++ b/config.json
@@ -138,6 +138,11 @@
       "slug": "parsing",
       "name": "Parsing",
       "uuid": "5842f21e-9fcf-4cf4-a710-19674ecb19c1"
+    },
+    {
+      "slug": "comparison",
+      "name": "Comparison",
+      "uuid": "a5339d63-c63a-491b-996b-6666a2bdea99"
     }
   ],
   "exercises": {
@@ -312,6 +317,21 @@
           "result"
         ],
         "status": "beta"
+      },
+      {
+        "slug": "blorkemon-cards",
+        "name": "Blorkemon Cards",
+        "uuid": "90660cf2-9247-41c0-8849-eee3e7118371",
+        "concepts": [
+          "comparison"
+        ],
+        "prerequisites": [
+          "booleans",
+          "tuples",
+          "lists",
+          "custom-types"
+        ],
+        "status": "beta"
       }
     ],
     "practice": [
@@ -402,8 +422,13 @@
         "slug": "grade-school",
         "name": "Grade School",
         "uuid": "c7749c5a-529e-4e46-8bdb-e33519f6d176",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["dict"],
+        "prerequisites": [
+          "lists",
+          "comparison",
+          "tuple",
+          "maybe"
+        ],
         "difficulty": 2,
         "topics": [
           "maps",
@@ -475,8 +500,8 @@
         "slug": "isogram",
         "name": "Isogram",
         "uuid": "61ef49ef-1086-445b-aa0a-b99de263b728",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["comparison"],
+        "prerequisites": ["boolean"],
         "difficulty": 3,
         "topics": [
           "filtering",
@@ -524,8 +549,8 @@
         "slug": "anagram",
         "name": "Anagram",
         "uuid": "5845a108-d8b2-41dd-b371-cf9eff7a2230",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["comparison"],
+        "prerequisites": ["lists"],
         "difficulty": 4,
         "topics": [
           "filtering",
@@ -648,8 +673,8 @@
         "slug": "binary-search",
         "name": "Binary Search",
         "uuid": "5c859d35-f2fe-455c-a7d7-df9398355403",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["comparison"],
+        "prerequisites": ["maybe"],
         "difficulty": 3,
         "topics": [
           "algorithms",

--- a/config.json
+++ b/config.json
@@ -426,7 +426,7 @@
         "prerequisites": [
           "lists",
           "comparison",
-          "tuple",
+          "tuples",
           "maybe"
         ],
         "difficulty": 2,
@@ -501,7 +501,7 @@
         "name": "Isogram",
         "uuid": "61ef49ef-1086-445b-aa0a-b99de263b728",
         "practices": ["comparison"],
-        "prerequisites": ["boolean"],
+        "prerequisites": ["booleans"],
         "difficulty": 3,
         "topics": [
           "filtering",

--- a/config.json
+++ b/config.json
@@ -329,7 +329,8 @@
           "booleans",
           "tuples",
           "lists",
-          "custom-types"
+          "custom-types",
+          "records"
         ],
         "status": "beta"
       }

--- a/exercises/concept/blorkemon-cards/.docs/hints.md
+++ b/exercises/concept/blorkemon-cards/.docs/hints.md
@@ -4,11 +4,10 @@
 
 - Read the documentation for [comparison operators][comparison-operators]
 - Read the documentation for [sorting lists][list-sort]
-- Remember that you can [pattern match tuples][tuples]
+- Remember how you can [access or pattern match records][records]
 
 ## 1. Compare power levels
 
-- Remember that you can [pattern match tuples][tuples]
 - Use the [`(>)` operator][greater]
 
 ## 2. Find the highest power
@@ -22,12 +21,12 @@
 ## 4. Coolest cards first
 
 - Use the [`List.sortBy`][sort-by] or [`List.sortWith`][sort-with] functions
-- Tuples are compared in the lexicographical order
+- You can use tuples for hierarchical sorts
 
 ## 5. Shiny Power
 
 - You could explicitly define an order or use the [`compare` function][compare] with specific value
-- Tuples are compared in the lexicographical order
+- You can use tuples for hierarchical sorts
 
 ## 6. Place your bets
 
@@ -36,7 +35,7 @@
 
 [comparison-operators]: https://package.elm-lang.org/packages/elm/core/latest/Basics#(%3C)
 [list-sort]: https://package.elm-lang.org/packages/elm/core/latest/List#sort
-[tuples]: https://www.bekk.christmas/post/2020/1/once-twice-three-times-a-value
+[records]: https://elm-lang.org/docs/records
 [greater]: https://package.elm-lang.org/packages/elm/core/latest/Basics#(%3E)
 [max]: https://package.elm-lang.org/packages/elm/core/latest/Basics#max
 [sort-by]: https://package.elm-lang.org/packages/elm/core/latest/List#sortBy

--- a/exercises/concept/blorkemon-cards/.docs/hints.md
+++ b/exercises/concept/blorkemon-cards/.docs/hints.md
@@ -25,7 +25,7 @@
 
 ## 5. Shiny Power
 
-- You could explicitly define an order or use the [`compare` function][compare] with specific value
+- You could explicitly define an order or use the [`compare` function][compare] with a specific value
 - You can use tuples for hierarchical sorts
 
 ## 6. Place your bets

--- a/exercises/concept/blorkemon-cards/.docs/hints.md
+++ b/exercises/concept/blorkemon-cards/.docs/hints.md
@@ -1,0 +1,45 @@
+# Hints
+
+## General
+
+- Read the documentation for [comparison operators][comparison-operators]
+- Read the documentation for [sorting lists][list-sort]
+- Remember that you can [pattern match tuples][tuples]
+
+## 1. Compare power levels
+
+- Remember that you can [pattern match tuples][tuples]
+- Use the [`(>)` operator][greater]
+
+## 2. Find the highest power
+
+- Use the [`max` function][max]
+
+## 3. Sort the cards
+
+- Use the [`List.sortBy` function][sort-by]
+
+## 4. Coolest cards first
+
+- Use the [`List.sortBy`][sort-by] or [`List.sortWith`][sort-with] functions
+- Tuples are compared in the lexicographical order
+
+## 5. Shiny Power
+
+- You could explicitly define an order or use the [`compare` function][compare] with specific value
+- Tuples are compared in the lexicographical order
+
+## 6. Place your bets
+
+- Use `compareShinyPower` in `expectedWinner`
+- Use a `case` to [pattern match the order][pattern-match]
+
+[comparison-operators]: https://package.elm-lang.org/packages/elm/core/latest/Basics#(%3C)
+[list-sort]: https://package.elm-lang.org/packages/elm/core/latest/List#sort
+[tuples]: https://www.bekk.christmas/post/2020/1/once-twice-three-times-a-value
+[greater]: https://package.elm-lang.org/packages/elm/core/latest/Basics#(%3E)
+[max]: https://package.elm-lang.org/packages/elm/core/latest/Basics#max
+[sort-by]: https://package.elm-lang.org/packages/elm/core/latest/List#sortBy
+[sort-with]: https://package.elm-lang.org/packages/elm/core/latest/List#sortWith
+[compare]: https://package.elm-lang.org/packages/elm/core/latest/Basics#compare
+[pattern-match]: https://guide.elm-lang.org/types/pattern_matching.html

--- a/exercises/concept/blorkemon-cards/.docs/instructions.md
+++ b/exercises/concept/blorkemon-cards/.docs/instructions.md
@@ -1,18 +1,18 @@
 # Instructions
 
-You suddenly feel a burst of nostalgia and a strong urge to dust off your old Plokemon™️ cards.
-Mokemon™️ cards is a great, old school card trading game.
-Each `Card` has a Gokemon™️ `Monster` drawn on it, along with an attack `Power` level, and if you are lucky, the card might even be `Shiny`.
+You suddenly feel a burst of nostalgia and a strong urge to dust off your old Blorkemon™️ cards.
+Blorkemon™️ cards is a great, old school card trading game.
+Each `Card` has a Blorkemon™️ monster drawn on it, along with an attack power level, and if you are lucky, the card might even be shiny.
 
 ## 1. Compare power levels
 
-Each Shlokemon™️ card looks more powerful than the next, but you better check.
+Each Blorkemon™️ card looks more powerful than the next, but you better check.
 
 Implement the `isMorePowerful` function. It should return `True` if the card in its first argument is strictly more powerful than the other, and `False` otherwise.
 
 ```elm
-newthree = ("Newthree", 120, False)
-scientuna = ("Scientuna", 6, True)
+newthree = Card "Newthree" 120 False
+scientuna = Card "Scientuna" 6 True
 
 isMorePowerful newthree scientuna
     --> True
@@ -20,7 +20,7 @@ isMorePowerful newthree scientuna
 
 ## 2. Find the highest power
 
-With a hand full of Mokemon™️ cards, you should be able to prepare the most devastating attack.
+With a hand full of Blorkemon™️ cards, you should be able to prepare the most devastating attack.
 
 Implement the `maxPower` function, which returns the highest power level of two cards.
 
@@ -31,36 +31,36 @@ maxPower newthree scientuna
 
 ## 3. Sort the cards
 
-You seem to remember that you had at least one card of each Ryokemon™️, but it's been a while since you last checked, you should sort your cards to compare them to the official listing on Pulpapedia.
+You seem to remember that you had at least one card of each Blorkemon™️, but it's been a while since you last checked, you should sort your cards to compare them to the official listing on Pulpapedia.
 
-Implement the `sortByMonsterName` function, which should take a list of `Cards` and return a list sorted by `Monster` names.
+Implement the `sortByMonsterName` function, which should take a list of `Cards` and return a list sorted by monster names.
 
 ```elm
 sortByMonsterName [newthree, scientuna]
-    --> [("Newthree", 120, False), ("Scientuna", 6, True)]
+    --> [Card "Newthree" 120 False, Card "Scientuna" 6 True]
 ```
 
 ## 4. Coolest cards first
 
-Tokemon™️ are the coolest thing ever.
+Blorkemon™️ are the coolest thing ever.
 You are not using that term lightly, you have a scientific method to demonstrate it.
 
 Implement the `sortByCoolness` function, which sorts a list of cards by placing the coolest ones first.
-The coolness of a card is first determined by its shininess: all `Shiny` cards are way cooler than the others.
-The second factor is the `Power` level, the higher the better.
+The coolness of a card is first determined by its shininess: all shiny cards are way cooler than the others.
+The second factor is the power level, the higher the better.
 
 ```elm
 sortByCoolness [newthree, scientuna]
-    --> [("Scientuna", 6, True), ("Newthree", 120, False)]
+    --> [Card "Scientuna" 6 True, Card "Newthree" 120 False]
 ```
 
 ## 5. Shiny Power
 
-Shininess is not just for show, in a battle of evenly powered Xokemon™️, a `Shiny` one will always prevail.
+Shininess is not just for show, in a battle of evenly powered Blorkemon™️, a shiny one will always prevail.
 This is called the Shiny Power.
 
 Implement the `compareShinyPower` function, which codifies this property.
-The `Order` of two cards is determined by the `Power` levels if they are different, but if they are equal, a `Shiny` card will be greater.
+The `Order` of two cards is determined by the power levels is they are different, but if they are equal, a shiny card will be greater.
 
 ```elm
 compareShinyPower newthree scientuna
@@ -69,10 +69,10 @@ compareShinyPower newthree scientuna
 
 ## 6. Place your bets
 
-In a game of Yokemon™️ cards, anything goes, but there is still a tendency for more powerful cards to win.
+In a game of Blorkemon™️ cards, anything goes, but there is still a tendency for more powerful cards to win.
 
-Implement the `expectedWinner` function that returns the name of the `Monster` most expected to win, as determined by the `compareShinyPower` ordering.
-The function should return the `Monster` name of the expected winner, or "too close to call" if both opponents have the same Shiny Power.
+Implement the `expectedWinner` function that returns the name of the monster most expected to win, as determined by the `compareShinyPower` ordering.
+The function should return the monster name of the expected winner, or "too close to call" if both opponents have the same Shiny Power.
 
 ```elm
 expectedWinner newthree scientuna

--- a/exercises/concept/blorkemon-cards/.docs/instructions.md
+++ b/exercises/concept/blorkemon-cards/.docs/instructions.md
@@ -60,7 +60,7 @@ Shininess is not just for show, in a battle of evenly powered Xokemon™️, a `
 This is called the Shiny Power.
 
 Implement the `compareShinyPower` function, which codifies this property.
-The `Order` of two cards is determined by the `Power` levels is they are different, but if they are equal, a `Shiny` card will be greater.
+The `Order` of two cards is determined by the `Power` levels if they are different, but if they are equal, a `Shiny` card will be greater.
 
 ```elm
 compareShinyPower newthree scientuna

--- a/exercises/concept/blorkemon-cards/.docs/instructions.md
+++ b/exercises/concept/blorkemon-cards/.docs/instructions.md
@@ -1,0 +1,80 @@
+# Instructions
+
+You suddenly feel a burst of nostalgia and a strong urge to dust off your old Plokemon™️ cards.
+Mokemon™️ cards is a great, old school card trading game.
+Each `Card` has a Gokemon™️ `Monster` drawn on it, along with an attack `Power` level, and if you are lucky, the card might even be `Shiny`.
+
+## 1. Compare power levels
+
+Each Shlokemon™️ card looks more powerful than the next, but you better check.
+
+Implement the `isMorePowerful` function. It should return `True` if the card in its first argument is strictly more powerful than the other, and `False` otherwise.
+
+```elm
+newthree = ("Newthree", 120, False)
+scientuna = ("Scientuna", 6, True)
+
+isMorePowerful newthree scientuna
+    --> True
+```
+
+## 2. Find the highest power
+
+With a hand full of Mokemon™️ cards, you should be able to prepare the most devastating attack.
+
+Implement the `maxPower` function, which returns the highest power level of two cards.
+
+```elm
+maxPower newthree scientuna
+    --> 120
+```
+
+## 3. Sort the cards
+
+You seem to remember that you had at least one card of each Ryokemon™️, but it's been a while since you last checked, you should sort your cards to compare them to the official listing on Pulpapedia.
+
+Implement the `sortByMonsterName` function, which should take a list of `Cards` and return a list sorted by `Monster` names.
+
+```elm
+sortByMonsterName [newthree, scientuna]
+    --> [("Newthree", 120, False), ("Scientuna", 6, True)]
+```
+
+## 4. Coolest cards first
+
+Tokemon™️ are the coolest thing ever.
+You are not using that term lightly, you have a scientific method to demonstrate it.
+
+Implement the `sortByCoolness` function, which sorts a list of cards by placing the coolest ones first.
+The coolness of a card is first determined by its shininess: all `Shiny` cards are way cooler than the others.
+The second factor is the `Power` level, the higher the better.
+
+```elm
+sortByCoolness [newthree, scientuna]
+    --> [("Scientuna", 6, True), ("Newthree", 120, False)]
+```
+
+## 5. Shiny Power
+
+Shininess is not just for show, in a battle of evenly powered Xokemon™️, a `Shiny` one will always prevail.
+This is called the Shiny Power.
+
+Implement the `compareShinyPower` function, which codifies this property.
+The `Order` of two cards is determined by the `Power` levels is they are different, but if they are equal, a `Shiny` card will be greater.
+
+```elm
+compareShinyPower newthree scientuna
+    --> GT
+```
+
+## 6. Place your bets
+
+In a game of Yokemon™️ cards, anything goes, but there is still a tendency for more powerful cards to win.
+
+Implement the `expectedWinner` function that returns the name of the `Monster` most expected to win, as determined by the `compareShinyPower` ordering.
+The function should return the `Monster` name of the expected winner, or "too close to call" if both opponents have the same Shiny Power.
+
+```elm
+expectedWinner newthree scientuna
+    --> "Newthree"
+```

--- a/exercises/concept/blorkemon-cards/.docs/introduction.md
+++ b/exercises/concept/blorkemon-cards/.docs/introduction.md
@@ -1,0 +1,116 @@
+# Introduction
+
+## Comparison
+
+### Equality
+
+Elm types can be checked for "being the same" with the equality operator `(==)`.
+The inequality operator is `(/=)` (*not* `!=` like in many languages).
+The equality operator works on literals, tuples, records and custom types.
+
+```elm
+1 == 2
+    --> False
+
+1 /= 2
+    --> True
+
+(1, 2) == (2, 1)
+    --> False
+
+type alias MyRecord = { myInt : Int, myStrings : List String }
+a : MyRecord
+a = MyRecord (1 + 1) ["hello world"]
+
+type alias MyOtherRecord = { myInt : Int, myStrings : List String }
+myStrings =  (String.join " " ["hello", "world"]) :: []
+b : MyOtherRecord
+b = { myInt = 2, myStrings = myStrings}
+
+a == b
+    --> True
+```
+
+Note that you *should never* compare functions, as this will make the program crash at runtime.
+
+### Comparisons
+
+The comparison operators `(<)`, `(<=)`, `(>)`, `(>=)` and functions `min`, `max`, `compare` work on `comparable` types.
+The `comparable` type is a special type that groups all built-in types that can be compared: numbers, characters, strings, lists of comparable things, and tuples of comparable things.
+
+```elm
+1 < 1 + 1
+    --> True
+
+'x' < 'X'
+    --> False
+
+"abc" < "abz"
+    --> True
+
+"abc" < "abcd"
+    --> True
+
+"abc" < "b"
+    --> True
+
+min [1 , 2, 9000] [10]
+    --> [1 , 2, 9000]
+
+min (1, "hello") (3, "bye")
+    --> (1, "hello")
+```
+
+Values of other types such as records or custom types cannot be compared directly.
+
+Some built-in types require their content to be `comparable`, such as `Set` or `Dict` keys, since their structure relies on an internal ordering.
+
+Lists of `comparable` values can be sorted with `List.sort` and lists of values that can be mapped to comparable values can be sorted with `List.sortBy`.
+If you need a hierarchical sort (sort by one property, and break ties with another), tuples or lists may also be used with `List.sortBy` since tuples and lists are sorted in lexicographic order.
+
+
+```elm
+List.sort ["hi", "hello", "bye", "goodbye"]
+    --> ["bye", "goodbye", "hello", "hi"]
+
+List.sortBy String.length ["hi", "hello", "bye", "goodbye"]
+    --> ["hi", "bye", "hello", "goodbye"]
+
+-- sort by length, then alphabetically
+List.sortBy (\str -> (String.length str, str)) ["hi", "mum", "hello", "sis", "bye", "dad"]
+    --> ["hi", "bye", "dad", "mum", "sis", "hello"]
+```
+
+The function `compare` takes two `comparable` values and returns an `Order`.
+An `Order` is a type that checks in a in a single operation if a value is greater (`GT`), equal (`EQ`) or less (`LT`) than another.
+
+```elm
+compare 1 2
+    --> LT
+
+compare "" ""
+    --> EQ
+
+compare [12] []
+    --> GT
+```
+
+Comparison functions can be constructed for arbitrary types and be used, for example, to be sorted with `List.sortWith`:
+
+```elm
+type Color = Red | Green | Blue
+
+compareColors : Color -> Color -> Order
+compareColors a b =
+  case (a, b) of
+    (Red, Red) -> EQ
+    (Red, _) -> LT
+    (_, Red) -> GT
+    (Green, Green) -> EQ
+    (Green, _) -> LT
+    (_, Green) -> GT
+    (Blue, Blue) -> EQ
+
+List.sortWith compareColors [Blue, Red, Green, Green, Blue]
+    --> [Red, Green, Green, Blue, Blue]
+```

--- a/exercises/concept/blorkemon-cards/.docs/introduction.md.tpl
+++ b/exercises/concept/blorkemon-cards/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: comparison}

--- a/exercises/concept/blorkemon-cards/.meta/Exemplar.elm
+++ b/exercises/concept/blorkemon-cards/.meta/Exemplar.elm
@@ -1,5 +1,6 @@
 module BlorkemonCards exposing
-    ( compareShinyPower
+    ( Card
+    , compareShinyPower
     , expectedWinner
     , isMorePowerful
     , maxPower
@@ -8,69 +9,53 @@ module BlorkemonCards exposing
     )
 
 
-type alias Shiny =
-    Bool
-
-
-type alias Monster =
-    String
-
-
-type alias Power =
-    Int
-
-
 type alias Card =
-    ( Monster, Power, Shiny )
+    { monster : String, power : Int, shiny : Bool }
 
 
 isMorePowerful : Card -> Card -> Bool
-isMorePowerful ( _, power1, _ ) ( _, power2, _ ) =
-    power1 > power2
+isMorePowerful card1 card2 =
+    card1.power > card2.power
 
 
-maxPower : Card -> Card -> Power
-maxPower ( _, power1, _ ) ( _, power2, _ ) =
-    max power1 power2
+maxPower : Card -> Card -> Int
+maxPower card1 card2 =
+    max card1.power card2.power
 
 
 sortByMonsterName : List Card -> List Card
 sortByMonsterName =
-    let
-        getName ( name, _, _ ) =
-            name
-    in
-    List.sortBy getName
+    List.sortBy .monster
 
 
 sortByCoolness : List Card -> List Card
 sortByCoolness =
     let
-        coolness ( _, power, shiny ) =
+        coolness { power, shiny } =
             ( negate (shinyValue shiny), negate power )
     in
     List.sortBy coolness
 
 
 compareShinyPower : Card -> Card -> Order
-compareShinyPower ( _, power1, shiny1 ) ( _, power2, shiny2 ) =
-    compare ( power1, shinyValue shiny1 ) ( power2, shinyValue shiny2 )
+compareShinyPower card1 card2 =
+    compare ( card1.power, shinyValue card1.shiny ) ( card2.power, shinyValue card2.shiny )
 
 
-expectedWinner : Card -> Card -> Monster
-expectedWinner (( monster1, _, _ ) as card1) (( monster2, _, _ ) as card2) =
+expectedWinner : Card -> Card -> String
+expectedWinner card1 card2 =
     case compareShinyPower card1 card2 of
         EQ ->
             "too close to call"
 
         LT ->
-            monster2
+            card2.monster
 
         GT ->
-            monster1
+            card1.monster
 
 
-shinyValue : Shiny -> Int
+shinyValue : Bool -> Int
 shinyValue shiny =
     if shiny then
         1

--- a/exercises/concept/blorkemon-cards/.meta/Exemplar.elm
+++ b/exercises/concept/blorkemon-cards/.meta/Exemplar.elm
@@ -1,0 +1,79 @@
+module BlorkemonCards exposing
+    ( compareShinyPower
+    , expectedWinner
+    , isMorePowerful
+    , maxPower
+    , sortByCoolness
+    , sortByMonsterName
+    )
+
+
+type alias Shiny =
+    Bool
+
+
+type alias Monster =
+    String
+
+
+type alias Power =
+    Int
+
+
+type alias Card =
+    ( Monster, Power, Shiny )
+
+
+isMorePowerful : Card -> Card -> Bool
+isMorePowerful ( _, power1, _ ) ( _, power2, _ ) =
+    power1 > power2
+
+
+maxPower : Card -> Card -> Power
+maxPower ( _, power1, _ ) ( _, power2, _ ) =
+    max power1 power2
+
+
+sortByMonsterName : List Card -> List Card
+sortByMonsterName =
+    let
+        getName ( name, _, _ ) =
+            name
+    in
+    List.sortBy getName
+
+
+sortByCoolness : List Card -> List Card
+sortByCoolness =
+    let
+        coolness ( _, power, shiny ) =
+            ( negate (shinyValue shiny), negate power )
+    in
+    List.sortBy coolness
+
+
+compareShinyPower : Card -> Card -> Order
+compareShinyPower ( _, power1, shiny1 ) ( _, power2, shiny2 ) =
+    compare ( power1, shinyValue shiny1 ) ( power2, shinyValue shiny2 )
+
+
+expectedWinner : Card -> Card -> Monster
+expectedWinner (( monster1, _, _ ) as card1) (( monster2, _, _ ) as card2) =
+    case compareShinyPower card1 card2 of
+        EQ ->
+            "too close to call"
+
+        LT ->
+            monster2
+
+        GT ->
+            monster1
+
+
+shinyValue : Shiny -> Int
+shinyValue shiny =
+    if shiny then
+        1
+
+    else
+        0

--- a/exercises/concept/blorkemon-cards/.meta/config.json
+++ b/exercises/concept/blorkemon-cards/.meta/config.json
@@ -1,10 +1,21 @@
 {
-  "authors": [],
-  "contributors": [],
+  "authors": [
+    "jiegillet"
+  ],
+  "contributors": [
+    "mpizenberg",
+    "ceddlyburge"
+  ],
   "files": {
-    "solution": "src/BlorkemonCards.elm",
-    "test": "tests/Tests.elm",
-    "exemplar": ".meta/Exemplar.elm"
+    "solution": [
+      "src/BlorkemonCards.elm"
+    ],
+    "test": [
+      "tests/Tests.elm"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.elm"
+    ]
   },
-  "blurb": "Learn this by doing that"
+  "blurb": "Learn comparisons by playing a vintage trading card game"
 }

--- a/exercises/concept/blorkemon-cards/.meta/config.json
+++ b/exercises/concept/blorkemon-cards/.meta/config.json
@@ -1,0 +1,10 @@
+{
+  "authors": [],
+  "contributors": [],
+  "files": {
+    "solution": "src/BlorkemonCards.elm",
+    "test": "tests/Tests.elm",
+    "exemplar": ".meta/Exemplar.elm"
+  },
+  "blurb": "Learn this by doing that"
+}

--- a/exercises/concept/blorkemon-cards/.meta/design.md
+++ b/exercises/concept/blorkemon-cards/.meta/design.md
@@ -28,6 +28,7 @@ The concept this exercise unlocks is:
 - booleans
 - tuples
 - lists
+- custom types
 
 ## Analyzer
 

--- a/exercises/concept/blorkemon-cards/.meta/design.md
+++ b/exercises/concept/blorkemon-cards/.meta/design.md
@@ -29,12 +29,13 @@ The concept this exercise unlocks is:
 - tuples
 - lists
 - custom types
+- records
 
 ## Analyzer
 
 Make sure that:
 
-- (essential) `sortByMonsterName` uses `List.sort`
-- (essential) `sortByCoolness` uses `List.sort`
+- (essential) `sortByMonsterName` uses `List.sortBy`
+- (essential) `sortByCoolness` uses `List.sortBy`
 - (essential) `expectedWinner` uses `compareShinyPower`
 - (essential) `expectedWinner` uses `case`

--- a/exercises/concept/blorkemon-cards/.meta/design.md
+++ b/exercises/concept/blorkemon-cards/.meta/design.md
@@ -1,0 +1,39 @@
+# Design
+
+## Goal
+
+The Goal is to learn comparisons.
+
+## Learning objectives
+
+- Understand what is the `comparable` type variable.
+- Know about the main operators and functions for comparisons (`<`, `<=`, `>`, `>=`, `min` and `max`).
+- Know about the `compare` function and `Order` type.
+- Understand the ordering of tuples.
+- Understand the ordering of lists.
+- Know about `sort`, `sortBy` and `sortWith` for sorting lists.
+
+## Out of scope
+
+- The notion of constrained type classes
+
+## Concepts
+
+The concept this exercise unlocks is:
+
+- `comparison`
+
+## Prerequisites
+
+- booleans
+- tuples
+- lists
+
+## Analyzer
+
+Make sure that:
+
+- (essential) `sortByMonsterName` uses `List.sort`
+- (essential) `sortByCoolness` uses `List.sort`
+- (essential) `expectedWinner` uses `compareShinyPower`
+- (essential) `expectedWinner` uses `case`

--- a/exercises/concept/blorkemon-cards/elm.json
+++ b/exercises/concept/blorkemon-cards/elm.json
@@ -1,0 +1,28 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
+        },
+        "indirect": {}
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+        },
+        "indirect": {
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
+        }
+    }
+}

--- a/exercises/concept/blorkemon-cards/src/BlorkemonCards.elm
+++ b/exercises/concept/blorkemon-cards/src/BlorkemonCards.elm
@@ -1,5 +1,6 @@
 module BlorkemonCards exposing
-    ( compareShinyPower
+    ( Card
+    , compareShinyPower
     , expectedWinner
     , isMorePowerful
     , maxPower
@@ -8,20 +9,8 @@ module BlorkemonCards exposing
     )
 
 
-type alias Shiny =
-    Bool
-
-
-type alias Monster =
-    String
-
-
-type alias Power =
-    Int
-
-
 type alias Card =
-    ( Monster, Power, Shiny )
+    { monster : String, power : Int, shiny : Bool }
 
 
 isMorePowerful : Card -> Card -> Bool
@@ -29,7 +18,7 @@ isMorePowerful card1 card2 =
     Debug.todo "Please implement this function"
 
 
-maxPower : Card -> Card -> Power
+maxPower : Card -> Card -> Int
 maxPower card1 card2 =
     Debug.todo "Please implement this function"
 
@@ -49,6 +38,6 @@ compareShinyPower card1 card2 =
     Debug.todo "Please implement this function"
 
 
-expectedWinner : Card -> Card -> Monster
+expectedWinner : Card -> Card -> String
 expectedWinner card1 card2 =
     Debug.todo "Please implement this function"

--- a/exercises/concept/blorkemon-cards/src/BlorkemonCards.elm
+++ b/exercises/concept/blorkemon-cards/src/BlorkemonCards.elm
@@ -1,0 +1,54 @@
+module BlorkemonCards exposing
+    ( compareShinyPower
+    , expectedWinner
+    , isMorePowerful
+    , maxPower
+    , sortByCoolness
+    , sortByMonsterName
+    )
+
+
+type alias Shiny =
+    Bool
+
+
+type alias Monster =
+    String
+
+
+type alias Power =
+    Int
+
+
+type alias Card =
+    ( Monster, Power, Shiny )
+
+
+isMorePowerful : Card -> Card -> Bool
+isMorePowerful card1 card2 =
+    Debug.todo "Please implement this function"
+
+
+maxPower : Card -> Card -> Power
+maxPower card1 card2 =
+    Debug.todo "Please implement this function"
+
+
+sortByMonsterName : List Card -> List Card
+sortByMonsterName cards =
+    Debug.todo "Please implement this function"
+
+
+sortByCoolness : List Card -> List Card
+sortByCoolness cards =
+    Debug.todo "Please implement this function"
+
+
+compareShinyPower : Card -> Card -> Order
+compareShinyPower card1 card2 =
+    Debug.todo "Please implement this function"
+
+
+expectedWinner : Card -> Card -> Monster
+expectedWinner card1 card2 =
+    Debug.todo "Please implement this function"

--- a/exercises/concept/blorkemon-cards/tests/Tests.elm
+++ b/exercises/concept/blorkemon-cards/tests/Tests.elm
@@ -1,0 +1,145 @@
+module Tests exposing (tests)
+
+import BlorkemonCards exposing (..)
+import Expect
+import Test exposing (Test, describe, test)
+
+
+tests : Test
+tests =
+    describe "BlorkemonCards"
+        [ describe "1"
+            [ test "First is more powerful" <|
+                \() ->
+                    isMorePowerful ( "Bleakachu", 60, False ) ( "Veevee", 40, True )
+                        |> Expect.equal True
+            , test "Second is more powerful" <|
+                \() ->
+                    isMorePowerful ( "Bleakachu", 50, True ) ( "Veevee", 70, True )
+                        |> Expect.equal False
+            , test "Same power" <|
+                \() ->
+                    isMorePowerful ( "Bleakachu", 55, False ) ( "Veevee", 55, False )
+                        |> Expect.equal False
+            ]
+        , describe "2"
+            [ test "First is more powerful" <|
+                \() ->
+                    maxPower ( "Charilord", 60, True ) ( "Gyros", 40, True )
+                        |> Expect.equal 60
+            , test "Second is more powerful" <|
+                \() ->
+                    maxPower ( "Charilord", 50, True ) ( "Gyros", 70, True )
+                        |> Expect.equal 70
+            , test "Same power" <|
+                \() ->
+                    maxPower ( "Charilord", 55, False ) ( "Gyros", 55, False )
+                        |> Expect.equal 55
+            ]
+        , describe "3"
+            [ test "A bunch of monsters" <|
+                \() ->
+                    sortByMonsterName
+                        [ ( "Wigglycream", 44, True )
+                        , ( "Quarterpie", 12, False )
+                        , ( "Cooltentbrov", 60, False )
+                        , ( "Cooltentbro", 60, False )
+                        , ( "Mayofried", 25, False )
+                        , ( "Shazam", 65, True )
+                        ]
+                        |> Expect.equal
+                            [ ( "Cooltentbro", 60, False )
+                            , ( "Cooltentbrov", 60, False )
+                            , ( "Mayofried", 25, False )
+                            , ( "Quarterpie", 12, False )
+                            , ( "Shazam", 65, True )
+                            , ( "Wigglycream", 44, True )
+                            ]
+            ]
+        , describe "4"
+            [ test "A bunch of monsters" <|
+                \() ->
+                    sortByCoolness
+                        [ ( "Wigglycream", 44, True )
+                        , ( "Quarterpie", 30, False )
+                        , ( "Cooltentbro", 60, False )
+                        , ( "Mayofried", 25, False )
+                        , ( "Shazam", 65, True )
+                        ]
+                        |> Expect.equal
+                            [ ( "Shazam", 65, True )
+                            , ( "Wigglycream", 44, True )
+                            , ( "Cooltentbro", 60, False )
+                            , ( "Quarterpie", 30, False )
+                            , ( "Mayofried", 25, False )
+                            ]
+            ]
+        , describe "5"
+            [ test "First is more powerful" <|
+                \() ->
+                    compareShinyPower ( "Blasturtle", 60, True ) ( "Hitmonchuck", 40, True )
+                        |> Expect.equal GT
+            , test "Second is more powerful" <|
+                \() ->
+                    compareShinyPower ( "Blasturtle", 50, True ) ( "Hitmonchuck", 70, True )
+                        |> Expect.equal LT
+            , test "Same power, no shiny" <|
+                \() ->
+                    compareShinyPower ( "Blasturtle", 55, False ) ( "Hitmonchuck", 55, False )
+                        |> Expect.equal EQ
+            , test "Same power, both shiny" <|
+                \() ->
+                    compareShinyPower ( "Blasturtle", 55, True ) ( "Hitmonchuck", 55, True )
+                        |> Expect.equal EQ
+            , test "Same power, first is shiny" <|
+                \() ->
+                    compareShinyPower ( "Blasturtle", 55, True ) ( "Hitmonchuck", 55, False )
+                        |> Expect.equal GT
+            , test "Same power, second is shiny" <|
+                \() ->
+                    compareShinyPower ( "Blasturtle", 55, False ) ( "Hitmonchuck", 55, True )
+                        |> Expect.equal LT
+            , test "A bunch of monsters" <|
+                \() ->
+                    List.sortWith compareShinyPower
+                        [ ( "Wigglycream", 50, True )
+                        , ( "Quarterpie", 50, False )
+                        , ( "Cooltentbro", 45, False )
+                        , ( "Mayofried", 55, False )
+                        , ( "Shazam", 50, True )
+                        ]
+                        |> Expect.equal
+                            [ ( "Cooltentbro", 45, False )
+                            , ( "Quarterpie", 50, False )
+                            , ( "Wigglycream", 50, True )
+                            , ( "Shazam", 50, True )
+                            , ( "Mayofried", 55, False )
+                            ]
+            ]
+        , describe "6"
+            [ test "First is more powerful" <|
+                \() ->
+                    expectedWinner ( "Phiswan", 60, True ) ( "Zumbat", 40, True )
+                        |> Expect.equal "Phiswan"
+            , test "Second is more powerful" <|
+                \() ->
+                    expectedWinner ( "Phiswan", 50, True ) ( "Zumbat", 70, True )
+                        |> Expect.equal "Zumbat"
+            , test "Same power, no shiny" <|
+                \() ->
+                    expectedWinner ( "Phiswan", 55, False ) ( "Zumbat", 55, False )
+                        |> Expect.equal "too close to call"
+            , test "Same power, both shiny" <|
+                \() ->
+                    expectedWinner ( "Phiswan", 55, True ) ( "Zumbat", 55, True )
+                        |> Expect.equal "too close to call"
+            , test "Same power, first is shiny" <|
+                \() ->
+                    expectedWinner ( "Phiswan", 55, True ) ( "Zumbat", 55, False )
+                        |> Expect.equal "Phiswan"
+            , test "Same power, second is shiny" <|
+                \() ->
+                    expectedWinner ( "Phiswan", 55, False ) ( "Zumbat", 55, True )
+                        |> Expect.equal "Zumbat"
+            ]
+        ]

--- a/exercises/concept/blorkemon-cards/tests/Tests.elm
+++ b/exercises/concept/blorkemon-cards/tests/Tests.elm
@@ -11,135 +11,135 @@ tests =
         [ describe "1"
             [ test "First is more powerful" <|
                 \() ->
-                    isMorePowerful ( "Bleakachu", 60, False ) ( "Veevee", 40, True )
+                    isMorePowerful (Card "Bleakachu" 60 False) (Card "Veevee" 40 True)
                         |> Expect.equal True
             , test "Second is more powerful" <|
                 \() ->
-                    isMorePowerful ( "Bleakachu", 50, True ) ( "Veevee", 70, True )
+                    isMorePowerful (Card "Bleakachu" 50 True) (Card "Veevee" 70 True)
                         |> Expect.equal False
             , test "Same power" <|
                 \() ->
-                    isMorePowerful ( "Bleakachu", 55, False ) ( "Veevee", 55, False )
+                    isMorePowerful (Card "Bleakachu" 55 False) (Card "Veevee" 55 False)
                         |> Expect.equal False
             ]
         , describe "2"
             [ test "First is more powerful" <|
                 \() ->
-                    maxPower ( "Charilord", 60, True ) ( "Gyros", 40, True )
+                    maxPower (Card "Charilord" 60 True) (Card "Gyros" 40 True)
                         |> Expect.equal 60
             , test "Second is more powerful" <|
                 \() ->
-                    maxPower ( "Charilord", 50, True ) ( "Gyros", 70, True )
+                    maxPower (Card "Charilord" 50 True) (Card "Gyros" 70 True)
                         |> Expect.equal 70
             , test "Same power" <|
                 \() ->
-                    maxPower ( "Charilord", 55, False ) ( "Gyros", 55, False )
+                    maxPower (Card "Charilord" 55 False) (Card "Gyros" 55 False)
                         |> Expect.equal 55
             ]
         , describe "3"
             [ test "A bunch of monsters" <|
                 \() ->
                     sortByMonsterName
-                        [ ( "Wigglycream", 44, True )
-                        , ( "Quarterpie", 12, False )
-                        , ( "Cooltentbrov", 60, False )
-                        , ( "Cooltentbro", 60, False )
-                        , ( "Mayofried", 25, False )
-                        , ( "Shazam", 65, True )
+                        [ Card "Wigglycream" 44 True
+                        , Card "Quarterpie" 12 False
+                        , Card "Cooltentbrov" 60 False
+                        , Card "Cooltentbro" 60 False
+                        , Card "Mayofried" 25 False
+                        , Card "Shazam" 65 True
                         ]
                         |> Expect.equal
-                            [ ( "Cooltentbro", 60, False )
-                            , ( "Cooltentbrov", 60, False )
-                            , ( "Mayofried", 25, False )
-                            , ( "Quarterpie", 12, False )
-                            , ( "Shazam", 65, True )
-                            , ( "Wigglycream", 44, True )
+                            [ Card "Cooltentbro" 60 False
+                            , Card "Cooltentbrov" 60 False
+                            , Card "Mayofried" 25 False
+                            , Card "Quarterpie" 12 False
+                            , Card "Shazam" 65 True
+                            , Card "Wigglycream" 44 True
                             ]
             ]
         , describe "4"
             [ test "A bunch of monsters" <|
                 \() ->
                     sortByCoolness
-                        [ ( "Wigglycream", 44, True )
-                        , ( "Quarterpie", 30, False )
-                        , ( "Cooltentbro", 60, False )
-                        , ( "Mayofried", 25, False )
-                        , ( "Shazam", 65, True )
+                        [ Card "Wigglycream" 44 True
+                        , Card "Quarterpie" 30 False
+                        , Card "Cooltentbro" 60 False
+                        , Card "Mayofried" 25 False
+                        , Card "Shazam" 65 True
                         ]
                         |> Expect.equal
-                            [ ( "Shazam", 65, True )
-                            , ( "Wigglycream", 44, True )
-                            , ( "Cooltentbro", 60, False )
-                            , ( "Quarterpie", 30, False )
-                            , ( "Mayofried", 25, False )
+                            [ Card "Shazam" 65 True
+                            , Card "Wigglycream" 44 True
+                            , Card "Cooltentbro" 60 False
+                            , Card "Quarterpie" 30 False
+                            , Card "Mayofried" 25 False
                             ]
             ]
         , describe "5"
             [ test "First is more powerful" <|
                 \() ->
-                    compareShinyPower ( "Blasturtle", 60, True ) ( "Hitmonchuck", 40, True )
+                    compareShinyPower (Card "Blasturtle" 60 True) (Card "Hitmonchuck" 40 True)
                         |> Expect.equal GT
             , test "Second is more powerful" <|
                 \() ->
-                    compareShinyPower ( "Blasturtle", 50, True ) ( "Hitmonchuck", 70, True )
+                    compareShinyPower (Card "Blasturtle" 50 True) (Card "Hitmonchuck" 70 True)
                         |> Expect.equal LT
             , test "Same power, no shiny" <|
                 \() ->
-                    compareShinyPower ( "Blasturtle", 55, False ) ( "Hitmonchuck", 55, False )
+                    compareShinyPower (Card "Blasturtle" 55 False) (Card "Hitmonchuck" 55 False)
                         |> Expect.equal EQ
             , test "Same power, both shiny" <|
                 \() ->
-                    compareShinyPower ( "Blasturtle", 55, True ) ( "Hitmonchuck", 55, True )
+                    compareShinyPower (Card "Blasturtle" 55 True) (Card "Hitmonchuck" 55 True)
                         |> Expect.equal EQ
             , test "Same power, first is shiny" <|
                 \() ->
-                    compareShinyPower ( "Blasturtle", 55, True ) ( "Hitmonchuck", 55, False )
+                    compareShinyPower (Card "Blasturtle" 55 True) (Card "Hitmonchuck" 55 False)
                         |> Expect.equal GT
             , test "Same power, second is shiny" <|
                 \() ->
-                    compareShinyPower ( "Blasturtle", 55, False ) ( "Hitmonchuck", 55, True )
+                    compareShinyPower (Card "Blasturtle" 55 False) (Card "Hitmonchuck" 55 True)
                         |> Expect.equal LT
             , test "A bunch of monsters" <|
                 \() ->
                     List.sortWith compareShinyPower
-                        [ ( "Wigglycream", 50, True )
-                        , ( "Quarterpie", 50, False )
-                        , ( "Cooltentbro", 45, False )
-                        , ( "Mayofried", 55, False )
-                        , ( "Shazam", 50, True )
+                        [ Card "Wigglycream" 50 True
+                        , Card "Quarterpie" 50 False
+                        , Card "Cooltentbro" 45 False
+                        , Card "Mayofried" 55 False
+                        , Card "Shazam" 50 True
                         ]
                         |> Expect.equal
-                            [ ( "Cooltentbro", 45, False )
-                            , ( "Quarterpie", 50, False )
-                            , ( "Wigglycream", 50, True )
-                            , ( "Shazam", 50, True )
-                            , ( "Mayofried", 55, False )
+                            [ Card "Cooltentbro" 45 False
+                            , Card "Quarterpie" 50 False
+                            , Card "Wigglycream" 50 True
+                            , Card "Shazam" 50 True
+                            , Card "Mayofried" 55 False
                             ]
             ]
         , describe "6"
             [ test "First is more powerful" <|
                 \() ->
-                    expectedWinner ( "Phiswan", 60, True ) ( "Zumbat", 40, True )
+                    expectedWinner (Card "Phiswan" 60 True) (Card "Zumbat" 40 True)
                         |> Expect.equal "Phiswan"
             , test "Second is more powerful" <|
                 \() ->
-                    expectedWinner ( "Phiswan", 50, True ) ( "Zumbat", 70, True )
+                    expectedWinner (Card "Phiswan" 50 True) (Card "Zumbat" 70 True)
                         |> Expect.equal "Zumbat"
             , test "Same power, no shiny" <|
                 \() ->
-                    expectedWinner ( "Phiswan", 55, False ) ( "Zumbat", 55, False )
+                    expectedWinner (Card "Phiswan" 55 False) (Card "Zumbat" 55 False)
                         |> Expect.equal "too close to call"
             , test "Same power, both shiny" <|
                 \() ->
-                    expectedWinner ( "Phiswan", 55, True ) ( "Zumbat", 55, True )
+                    expectedWinner (Card "Phiswan" 55 True) (Card "Zumbat" 55 True)
                         |> Expect.equal "too close to call"
             , test "Same power, first is shiny" <|
                 \() ->
-                    expectedWinner ( "Phiswan", 55, True ) ( "Zumbat", 55, False )
+                    expectedWinner (Card "Phiswan" 55 True) (Card "Zumbat" 55 False)
                         |> Expect.equal "Phiswan"
             , test "Same power, second is shiny" <|
                 \() ->
-                    expectedWinner ( "Phiswan", 55, False ) ( "Zumbat", 55, True )
+                    expectedWinner (Card "Phiswan" 55 False) (Card "Zumbat" 55 True)
                         |> Expect.equal "Zumbat"
             ]
         ]

--- a/exercises/concept/paolas-prestigious-pizza/.docs/introduction.md
+++ b/exercises/concept/paolas-prestigious-pizza/.docs/introduction.md
@@ -38,7 +38,7 @@ versionP =
 
 `versionP` is built using a _parser pipeline_.
 The `(|.)` operator means "parse the string but throw away the result" and `(|=)` means "parse the string and keep the result".
-In this example, `Parser.keyword "HAI"` will consume a "HAI", but that result is ignored. 
+In this example, `Parser.keyword "HAI"` will consume a "HAI", but that result is ignored.
 `Parser.spaces` will consume any number of  ' ', '\n', and '\r' characters, but that will also be ignored.
 `Parser.int` will parse an integer, and the value of that integer (say 1) will be passed to the topmost `Parser.succeed Version` and the parser will succeed in returning the value `Version 1`.
 
@@ -85,9 +85,9 @@ In this case, we would like to normalize the package names, so we use `Parser.ma
 
 ```elm
 Parser.run importP "CAN HAS STDIO?"
-    --> Ok (Import "stdio") 
+    --> Ok (Import "stdio")
 Parser.run importP "CAN HAS StDiO?"
-    --> Ok (Import "stdio") 
+    --> Ok (Import "stdio")
 Parser.run importP "CAN HAS STDIO"
     -->  Err [{ problem = ExpectingSymbol "?", col = 14, row = 1 }]
 ```
@@ -134,7 +134,7 @@ If all parsers fail, `Parser.oneOf` fails.
 Parser.run commandP "HAI 2"
     --> Ok (Version 2)
 Parser.run commandP "CAN HAS STDIO?"
-    --> Ok (Import "stdio") 
+    --> Ok (Import "stdio")
 Parser.run commandP "VISIBLE \"HAI WORLD!\""
     --> Ok (Print "HAI WORLD!")
 Parser.run commandP "O NOES"
@@ -200,7 +200,7 @@ fullProgramP =
 Parser.run fullProgramP "HAI 2\nCAN HAS STDIO?\nKTHXBYE"
     --> Ok [Version 2, Import "stdio"]
 Parser.run fullProgramP "HAI 2\nCAN HAS STDIO?\nKTHXBYE\nBTW VISIBLE \"U SEE NOTHING\""
-    --> Err [{ problem = ExpectingEnd, col = 1, row = 4 }]    
+    --> Err [{ problem = ExpectingEnd, col = 1, row = 4 }]
 ```
 
 Finally, we sometimes need to make a decision to fail a parser depending on its parsed content.


### PR DESCRIPTION
Closes #423.

I originally thought of teaching `comparison` and `set` together in the same exercise, but by the time I was happy with the exercise coverage for `comparison`, I realized I had more than enough for this concept alone.

I went with a humorous tone for the instructions, let me know if it's more distracting than funny.

The CI will fail because I haven't generated the exercise intro.