### PR TITLE
Review test cases not included

### DIFF
--- a/exercises/practice/allergies/.meta/tests.toml
+++ b/exercises/practice/allergies/.meta/tests.toml
@@ -158,4 +158,3 @@ description = "list when: -> no allergen score parts"
 
 [93c2df3e-4f55-4fed-8116-7513092819cd]
 description = "list when: -> no allergen score parts without highest valid score"
-include = false

--- a/exercises/practice/anagram/.meta/tests.toml
+++ b/exercises/practice/anagram/.meta/tests.toml
@@ -52,26 +52,24 @@ description = "anagrams must use all letters exactly once"
 
 [85757361-4535-45fd-ac0e-3810d40debc1]
 description = "words are not anagrams of themselves (case-insensitive)"
+include = false
 
 [68934ed0-010b-4ef9-857a-20c9012d1ebf]
 description = "words are not anagrams of themselves"
-include = false
 reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
 
 [589384f3-4c8a-4e7d-9edc-51c3e5f0c90e]
 description = "words are not anagrams of themselves even if letter case is partially different"
-include = false
 reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
 
 [ba53e423-7e02-41ee-9ae2-71f91e6d18e6]
 description = "words are not anagrams of themselves even if letter case is completely different"
-include = false
 reimplements = "85757361-4535-45fd-ac0e-3810d40debc1"
 
 [a0705568-628c-4b55-9798-82e4acde51ca]
 description = "words other than themselves can be anagrams"
+include = false
 
 [33d3f67e-fbb9-49d3-a90e-0beb00861da7]
 description = "words other than themselves can be anagrams"
-include = false
 reimplements = "a0705568-628c-4b55-9798-82e4acde51ca"

--- a/exercises/practice/anagram/tests/Tests.elm
+++ b/exercises/practice/anagram/tests/Tests.elm
@@ -71,7 +71,22 @@ tests =
             test "does not detect a word as its own anagram" <|
                 \() ->
                     Expect.equal []
+                        (detect "BANANA" [ "BANANA" ])
+        , skip <|
+            test "does not detect a word as its own anagram with small casing difference" <|
+                \() ->
+                    Expect.equal []
                         (detect "banana" [ "Banana" ])
+        , skip <|
+            test "does not detect a word as its own anagram with large casing difference" <|
+                \() ->
+                    Expect.equal []
+                        (detect "banana" [ "BANANA" ])
+        , skip <|
+            test "words other than themselves can be anagrams" <|
+                \() ->
+                    Expect.equal [ "Silent" ]
+                        (detect "LISTEN" [ "LISTEN", "Silent" ])
         , skip <|
             test "does not detect a anagram if the original word is repeated" <|
                 \() ->
@@ -98,12 +113,7 @@ tests =
                     Expect.equal []
                         (detect "ΑΒΓ" [ "ABΓ" ])
         , skip <|
-            test "capital word is not own anagram" <|
-                \() ->
-                    Expect.equal []
-                        (detect "BANANA" [ "Banana" ])
-        , skip <|
-            test "anagrams must use all letters exactly once (banana)" <|
+            test "anagrams must use all letters exactly once" <|
                 \() ->
                     Expect.equal []
                         (detect "patter" [ "tapper" ])

--- a/exercises/practice/space-age/.meta/tests.toml
+++ b/exercises/practice/space-age/.meta/tests.toml
@@ -35,4 +35,5 @@ description = "age on Neptune"
 
 [57b96e2a-1178-40b7-b34d-f3c9c34e4bf4]
 description = "invalid planet causes error"
+comment = "planets are variants therefore cannot be invalid"
 include = false

--- a/exercises/practice/word-count/.meta/config.json
+++ b/exercises/practice/word-count/.meta/config.json
@@ -3,6 +3,7 @@
     "tgecho"
   ],
   "contributors": [
+    "jiegillet",
     "michaelkpfeifer",
     "mpizenberg",
     "nathanielknight",

--- a/exercises/practice/word-count/.meta/src/WordCount.example.elm
+++ b/exercises/practice/word-count/.meta/src/WordCount.example.elm
@@ -41,3 +41,4 @@ wordCount sentence =
                     dict
             )
             Dict.empty
+        |> Dict.remove ""

--- a/exercises/practice/word-count/.meta/tests.toml
+++ b/exercises/practice/word-count/.meta/tests.toml
@@ -35,10 +35,10 @@ description = "normalize case"
 
 [4185a902-bdb0-4074-864c-f416e42a0f19]
 description = "with apostrophes"
+include = false
 
 [4ff6c7d7-fcfc-43ef-b8e7-34ff1837a2d3]
 description = "with apostrophes"
-include = false
 reimplements = "4185a902-bdb0-4074-864c-f416e42a0f19"
 
 [be72af2b-8afe-4337-b151-b297202e4a7b]

--- a/exercises/practice/word-count/tests/Tests.elm
+++ b/exercises/practice/word-count/tests/Tests.elm
@@ -51,8 +51,8 @@ tests =
         , skip <|
             test "with apostrophes" <|
                 \() ->
-                    Expect.equal [ ( "cry", 1 ), ( "don't", 2 ), ( "first", 1 ), ( "laugh", 1 ), ( "then", 1 ) ]
-                        (wordCount "First: don't laugh. Then: don't cry." |> Dict.toList)
+                    Expect.equal [ ( "cry", 1 ), ( "don't", 2 ), ( "first", 1 ), ( "getting", 1 ), ( "it", 1 ), ( "laugh", 1 ), ( "then", 1 ), ( "you're", 1 ) ]
+                        (wordCount "'First: don't laugh. Then: don't cry. You're getting it.'" |> Dict.toList)
         , skip <|
             test "with quotations" <|
                 \() ->


### PR DESCRIPTION
Closes #516.
@ee7 noticed that a PR left tests cases unimplemented, so I reviewed all these cases.

Most were reimplemented by other tests, some tests were already there, one was not included for valid reasons (I added a comment), some were easy to include and one required a simple change in the example solution (I added myself to the contributor list).

@ee7 while going through this, I was thinking that it would be nice for configlet to add a comment to tests reimplemented by other tests (like there is a comment tests that reimlement others).