### PR TITLE
Add generics concept and concept exercise

### DIFF
--- a/concepts/generics/.meta/config.json
+++ b/concepts/generics/.meta/config.json
@@ -1,0 +1,5 @@
+{
+  "blurb": "Learn how to create and use Elm code that is generic.",
+  "authors": ["ceddlyburge"],
+  "contributors": ["mpizenberg", "jiegillet"]
+}

--- a/concepts/generics/about.md
+++ b/concepts/generics/about.md
@@ -1,0 +1,77 @@
+# About
+
+# Introduction
+
+Generics are a language feature that enable code reuse.
+For example, it should not matter what type a list holds in order to compute its length.
+That is why the `length` function uses a generic type parameter `a` in its type signature.
+
+```elm
+length : List a -> Int
+```
+
+## Parameters in types
+
+When a type is generic over another type, we use a lowercase name for that other type, and call it a type parameter.
+Two very common examples are the `List` and `Maybe` types.
+
+```elm
+-- Maybe is generic over the type a
+type Maybe a
+    = Nothing
+    | Just a
+
+someString : Maybe String
+someString = Just "hello"
+
+someInt : Maybe Int
+someInt = Just 42
+```
+
+A type can be generic over multiple other types, and thus have multiple type parameters.
+In that case, every independant type gets a different lowercase name.
+Being independant does not prevent them from becoming the same type, it just enables them to be different.
+
+```elm
+type alias Pair a b =
+    { first : a
+    , second : b
+    }
+
+person : Pair String Int
+person = { first = "Jane", second = 18 }
+
+coordinates : Pair Int Int
+coordinates = { first = -3, second = 15 }
+```
+
+One important remark about names of type parameters, is that they can be multiple characters long.
+The only constraint is that they must be lowercase names.
+As such, when useful, we tend to give them descriptive names.
+
+> This is why the `Html` package defines the `Html msg` type, with one type parameter named `msg`.
+> The elm architecture guides you towards creation of a custom type `Msg` describing all messages that your web page can trigger.
+> As a result, your code will be building views of the type `Html Msg` where `Msg` is the concrete type that you defined.
+> Beginners are sometimes confused between errors mentioning `Html msg` (lowercase) and errors with `Html Msg`.
+> Now you know!
+> The difference is that the first one is generic over any `msg` type, while the second is specific to your `Msg` type.
+
+## Type parameters in functions
+
+Since types can be generic, so can functions.
+Functions handling generic types can be writen, such as the `List.length` function that we mentioned at the beginning.
+
+```elm
+length : List a -> Int
+length list =
+    case list of
+        [] ->
+            0
+        _ :: restOfTheList ->
+            1 + length restOfTheList
+```
+
+Type parameters can appear both in the inputs and in the output of a function, and genericity enabled by type parameters is usually called **parametric polymorphism**.
+This is in contrast with ad hoc polymorphism also known as function overloading, where the same function name can be used on multiple implementation where the types differ.
+This also contrasts with subtype polymorphism, where types can be defined in a hierarchy, and functions defined on a type can also be called with arguments of its subtypes.
+In elm, the only available mechanism for genericity is parametric polymorphism.

--- a/concepts/generics/introduction.md
+++ b/concepts/generics/introduction.md
@@ -1,0 +1,1 @@
+TODO: copy from about.md when it has been finalized

--- a/concepts/generics/links.json
+++ b/concepts/generics/links.json
@@ -1,0 +1,6 @@
+[
+  {
+    "url": "https://elmprogramming.com/type-system.html",
+    "description": "Elm type system"
+  }
+]

--- a/config.json
+++ b/config.json
@@ -19,18 +19,10 @@
     "analyzer": true
   },
   "files": {
-    "solution": [
-      "src/%{pascal_slug}.elm"
-    ],
-    "test": [
-      "tests/Tests.elm"
-    ],
-    "example": [
-      ".meta/src/%{pascal_slug}.example.elm"
-    ],
-    "exemplar": [
-      ".meta/Exemplar.elm"
-    ]
+    "solution": ["src/%{pascal_slug}.elm"],
+    "test": ["tests/Tests.elm"],
+    "example": [".meta/src/%{pascal_slug}.example.elm"],
+    "exemplar": [".meta/Exemplar.elm"]
   },
   "tags": [
     "paradigm/declarative",
@@ -154,6 +146,11 @@
       "slug": "set",
       "name": "Set",
       "uuid": "cfa44843-b783-4366-a198-f0e99e632143"
+    },
+    {
+      "slug": "generics",
+      "name": "Generics",
+      "uuid": "a967b004-e754-4664-8103-6a98be4d00e5"
     }
   ],
   "exercises": {
@@ -163,9 +160,7 @@
         "slug": "lucians-luscious-lasagna",
         "name": "Lucian's Luscious Lasagna",
         "uuid": "54b70493-702b-4577-9d47-ec5ede4cc2c1",
-        "concepts": [
-          "basics-1"
-        ],
+        "concepts": ["basics-1"],
         "prerequisites": [],
         "status": "beta"
       },
@@ -173,94 +168,63 @@
         "slug": "bettys-bike-shop",
         "name": "Betty's Bike Shop",
         "uuid": "88818c16-fff8-4964-b9a4-c799833ff970",
-        "concepts": [
-          "basics-2"
-        ],
-        "prerequisites": [
-          "basics-1"
-        ],
+        "concepts": ["basics-2"],
+        "prerequisites": ["basics-1"],
         "status": "beta"
       },
       {
         "slug": "annalyns-infiltration",
         "name": "Annalyn's Infiltration",
         "uuid": "9f501a73-14e3-4ada-8359-fe051530554a",
-        "concepts": [
-          "booleans"
-        ],
-        "prerequisites": [
-          "basics-2"
-        ],
+        "concepts": ["booleans"],
+        "prerequisites": ["basics-2"],
         "status": "beta"
       },
       {
         "slug": "tracks-on-tracks-on-tracks",
         "name": "Tracks on Tracks on Tracks",
         "uuid": "07b1a020-d534-4449-8698-2006e1176b3a",
-        "concepts": [
-          "lists"
-        ],
-        "prerequisites": [
-          "basics-2"
-        ],
+        "concepts": ["lists"],
+        "prerequisites": ["basics-2"],
         "status": "beta"
       },
       {
         "slug": "bandwagoner",
         "name": "Bandwagoner",
         "uuid": "af1cc0cd-b9f8-46ef-b4bf-7a5a17b1c8d6",
-        "concepts": [
-          "records"
-        ],
-        "prerequisites": [
-          "basics-2"
-        ],
+        "concepts": ["records"],
+        "prerequisites": ["basics-2"],
         "status": "beta"
       },
       {
         "slug": "valentines-day",
         "name": "Valentines Day",
         "uuid": "2ce85ab7-35a0-4566-803f-e60397a2391d",
-        "concepts": [
-          "custom-types"
-        ],
-        "prerequisites": [
-          "basics-2"
-        ],
+        "concepts": ["custom-types"],
+        "prerequisites": ["basics-2"],
         "status": "beta"
       },
       {
         "slug": "tisbury-treasure-hunt",
         "name": "Tisbury Treasure Hunt",
         "uuid": "d88d7e37-f52b-4999-b7df-bf0db09e7ac5",
-        "concepts": [
-          "tuples"
-        ],
-        "prerequisites": [
-          "lists",
-          "partial-application-composition"
-        ],
+        "concepts": ["tuples"],
+        "prerequisites": ["lists", "partial-application-composition"],
         "status": "beta"
       },
       {
         "slug": "role-playing-game",
         "name": "Role Playing Game",
         "uuid": "c62c5128-5733-4187-b46a-80660d9b5725",
-        "concepts": [
-          "maybe"
-        ],
-        "prerequisites": [
-          "records"
-        ],
+        "concepts": ["maybe"],
+        "prerequisites": ["records"],
         "status": "beta"
       },
       {
         "slug": "go",
         "name": "Go",
         "uuid": "33c34af3-26fa-4e18-8bb3-8af688069c9e",
-        "concepts": [
-          "result"
-        ],
+        "concepts": ["result"],
         "prerequisites": [
           "maybe",
           "basics-2",
@@ -275,9 +239,7 @@
         "slug": "ticket-please",
         "name": "Ticket, Please!",
         "uuid": "58f70123-5e59-4bac-b1e0-3b8504de360b",
-        "concepts": [
-          "pattern-matching"
-        ],
+        "concepts": ["pattern-matching"],
         "prerequisites": [
           "maybe",
           "records",
@@ -292,21 +254,15 @@
         "slug": "marios-marvellous-lasagna",
         "name": "Mario's marvellous lasagna",
         "uuid": "8b5b43a1-79ec-4f2f-a8ac-8aa2955a4674",
-        "concepts": [
-          "let"
-        ],
-        "prerequisites": [
-          "basics-2"
-        ],
+        "concepts": ["let"],
+        "prerequisites": ["basics-2"],
         "status": "beta"
       },
       {
         "slug": "top-scorers",
         "name": "Top Scorers",
         "uuid": "67b35178-0a74-4265-84a7-276c018cc3a5",
-        "concepts": [
-          "dict"
-        ],
+        "concepts": ["dict"],
         "prerequisites": [
           "booleans",
           "maybe",
@@ -319,9 +275,7 @@
         "slug": "paolas-prestigious-pizza",
         "name": "Paola's Prestigious Pizza",
         "uuid": "9ecdb4fc-d175-4058-9167-948b2a88fa1b",
-        "concepts": [
-          "parsing"
-        ],
+        "concepts": ["parsing"],
         "prerequisites": [
           "basics-1",
           "basics-2",
@@ -337,22 +291,14 @@
         "slug": "monster-attack",
         "name": "Monster Attack",
         "uuid": "c8abe3c6-44f8-49cd-b8e4-9951c77ddbd9",
-        "concepts": [
-          "partial-application-composition"
-        ],
-        "prerequisites": [
-          "basics-1",
-          "basics-2",
-          "let"
-        ]
+        "concepts": ["partial-application-composition"],
+        "prerequisites": ["basics-1", "basics-2", "let"]
       },
       {
         "slug": "blorkemon-cards",
         "name": "Blorkemon Cards",
         "uuid": "90660cf2-9247-41c0-8849-eee3e7118371",
-        "concepts": [
-          "comparison"
-        ],
+        "concepts": ["comparison"],
         "prerequisites": [
           "booleans",
           "tuples",
@@ -366,15 +312,16 @@
         "slug": "gotta-snatch-em-all",
         "name": "Gotta Snatch'Em All",
         "uuid": "a019f08f-b20e-4430-b01a-26b25a2bd0bb",
-        "concepts": [
-          "set"
-        ],
-        "prerequisites": [
-          "booleans",
-          "tuples",
-          "lists",
-          "comparison"
-        ],
+        "concepts": ["set"],
+        "prerequisites": ["booleans", "tuples", "lists", "comparison"],
+        "status": "beta"
+      },
+      {
+        "slug": "treasure-chest",
+        "name": "Treasure Chest",
+        "uuid": "dbfbca75-01c6-487e-8bb7-22854453489e",
+        "concepts": ["generics"],
+        "prerequisites": ["custom-types", "maybe", "pattern-matching"],
         "status": "beta"
       }
     ],
@@ -386,9 +333,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "strings"
-        ]
+        "topics": ["strings"]
       },
       {
         "slug": "two-fer",
@@ -397,9 +342,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "strings"
-        ]
+        "topics": ["strings"]
       },
       {
         "slug": "bob",
@@ -408,11 +351,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "conditionals",
-          "strings",
-          "text_formatting"
-        ]
+        "topics": ["conditionals", "strings", "text_formatting"]
       },
       {
         "slug": "leap",
@@ -421,10 +360,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "conditionals",
-          "integers"
-        ]
+        "topics": ["conditionals", "integers"]
       },
       {
         "slug": "space-age",
@@ -433,9 +369,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "floating_point_numbers"
-        ]
+        "topics": ["floating_point_numbers"]
       },
       {
         "slug": "sum-of-multiples",
@@ -444,11 +378,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "lists",
-          "math",
-          "transforming"
-        ]
+        "topics": ["lists", "math", "transforming"]
       },
       {
         "slug": "accumulate",
@@ -457,29 +387,16 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "recursion",
-          "transforming"
-        ]
+        "topics": ["recursion", "transforming"]
       },
       {
         "slug": "grade-school",
         "name": "Grade School",
         "uuid": "c7749c5a-529e-4e46-8bdb-e33519f6d176",
-        "practices": [
-          "dict"
-        ],
-        "prerequisites": [
-          "lists",
-          "comparison",
-          "tuples",
-          "maybe"
-        ],
+        "practices": ["dict"],
+        "prerequisites": ["lists", "comparison", "tuples", "maybe"],
         "difficulty": 2,
-        "topics": [
-          "maps",
-          "sorting"
-        ]
+        "topics": ["maps", "sorting"]
       },
       {
         "slug": "raindrops",
@@ -488,10 +405,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "filtering",
-          "text_formatting"
-        ]
+        "topics": ["filtering", "text_formatting"]
       },
       {
         "slug": "robot-simulator",
@@ -500,10 +414,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "records",
-          "tuples"
-        ]
+        "topics": ["records", "tuples"]
       },
       {
         "slug": "allergies",
@@ -512,11 +423,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "bitwise_operations",
-          "enumerations",
-          "filtering"
-        ]
+        "topics": ["bitwise_operations", "enumerations", "filtering"]
       },
       {
         "slug": "hamming",
@@ -525,10 +432,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "filtering",
-          "strings"
-        ]
+        "topics": ["filtering", "strings"]
       },
       {
         "slug": "pangram",
@@ -537,26 +441,16 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "booleans",
-          "strings"
-        ]
+        "topics": ["booleans", "strings"]
       },
       {
         "slug": "isogram",
         "name": "Isogram",
         "uuid": "61ef49ef-1086-445b-aa0a-b99de263b728",
-        "practices": [
-          "comparison"
-        ],
-        "prerequisites": [
-          "booleans"
-        ],
+        "practices": ["comparison"],
+        "prerequisites": ["booleans"],
         "difficulty": 3,
-        "topics": [
-          "filtering",
-          "strings"
-        ]
+        "topics": ["filtering", "strings"]
       },
       {
         "slug": "phone-number",
@@ -565,10 +459,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "parsing",
-          "transforming"
-        ]
+        "topics": ["parsing", "transforming"]
       },
       {
         "slug": "twelve-days",
@@ -577,11 +468,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "conditionals",
-          "strings",
-          "text_formatting"
-        ]
+        "topics": ["conditionals", "strings", "text_formatting"]
       },
       {
         "slug": "acronym",
@@ -590,26 +477,16 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "strings",
-          "transforming"
-        ]
+        "topics": ["strings", "transforming"]
       },
       {
         "slug": "anagram",
         "name": "Anagram",
         "uuid": "5845a108-d8b2-41dd-b371-cf9eff7a2230",
-        "practices": [
-          "comparison"
-        ],
-        "prerequisites": [
-          "lists"
-        ],
+        "practices": ["comparison"],
+        "prerequisites": ["lists"],
         "difficulty": 4,
-        "topics": [
-          "filtering",
-          "strings"
-        ]
+        "topics": ["filtering", "strings"]
       },
       {
         "slug": "series",
@@ -618,11 +495,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "lists",
-          "strings",
-          "transforming"
-        ]
+        "topics": ["lists", "strings", "transforming"]
       },
       {
         "slug": "atbash-cipher",
@@ -631,11 +504,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "strings",
-          "transforming"
-        ]
+        "topics": ["algorithms", "strings", "transforming"]
       },
       {
         "slug": "luhn",
@@ -644,11 +513,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "strings",
-          "transforming"
-        ]
+        "topics": ["algorithms", "strings", "transforming"]
       },
       {
         "slug": "grains",
@@ -657,9 +522,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "integers"
-        ]
+        "topics": ["integers"]
       },
       {
         "slug": "all-your-base",
@@ -668,11 +531,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "integers",
-          "math",
-          "transforming"
-        ]
+        "topics": ["integers", "math", "transforming"]
       },
       {
         "slug": "largest-series-product",
@@ -681,24 +540,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "integers",
-          "math",
-          "strings",
-          "transforming"
-        ]
+        "topics": ["integers", "math", "strings", "transforming"]
       },
       {
         "slug": "triangle",
         "name": "Triangle",
         "uuid": "767f6825-8736-4307-85c7-090a9a327fd9",
-        "practices": [
-          "set"
-        ],
-        "prerequisites": [
-          "comparison",
-          "booleans"
-        ],
+        "practices": ["set"],
+        "prerequisites": ["comparison", "booleans"],
         "difficulty": 3,
         "topics": []
       },
@@ -709,13 +558,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "conditionals",
-          "loops",
-          "integers",
-          "math"
-        ]
+        "topics": ["algorithms", "conditionals", "loops", "integers", "math"]
       },
       {
         "slug": "collatz-conjecture",
@@ -724,38 +567,25 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "math"
-        ]
+        "topics": ["math"]
       },
       {
         "slug": "binary-search",
         "name": "Binary Search",
         "uuid": "5c859d35-f2fe-455c-a7d7-df9398355403",
-        "practices": [
-          "comparison"
-        ],
-        "prerequisites": [
-          "maybe"
-        ],
+        "practices": ["comparison"],
+        "prerequisites": ["maybe"],
         "difficulty": 3,
-        "topics": [
-          "algorithms",
-          "lists",
-          "recursion"
-        ]
+        "topics": ["algorithms", "lists", "recursion"]
       },
       {
         "slug": "list-ops",
         "name": "List Ops",
         "uuid": "114b5717-0d82-459e-90c4-f00d8b6beb5b",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["generics"],
+        "prerequisites": ["generics"],
         "difficulty": 4,
-        "topics": [
-          "lists",
-          "recursion"
-        ]
+        "topics": ["lists", "recursion"]
       },
       {
         "slug": "pascals-triangle",
@@ -764,11 +594,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "lists",
-          "math",
-          "recursion"
-        ]
+        "topics": ["lists", "math", "recursion"]
       },
       {
         "slug": "roman-numerals",
@@ -777,10 +603,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "recursion",
-          "transforming"
-        ]
+        "topics": ["recursion", "transforming"]
       },
       {
         "slug": "etl",
@@ -789,10 +612,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "maps",
-          "transforming"
-        ]
+        "topics": ["maps", "transforming"]
       },
       {
         "slug": "nucleotide-count",
@@ -801,10 +621,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 2,
-        "topics": [
-          "maps",
-          "strings"
-        ]
+        "topics": ["maps", "strings"]
       },
       {
         "slug": "word-count",
@@ -813,11 +630,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 4,
-        "topics": [
-          "maps",
-          "strings",
-          "transforming"
-        ]
+        "topics": ["maps", "strings", "transforming"]
       },
       {
         "slug": "strain",
@@ -826,10 +639,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "filtering",
-          "sequences"
-        ]
+        "topics": ["filtering", "sequences"]
       },
       {
         "slug": "say",
@@ -838,23 +648,14 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "strings",
-          "text_formatting",
-          "transforming"
-        ]
+        "topics": ["strings", "text_formatting", "transforming"]
       },
       {
         "slug": "wordy",
         "name": "Wordy",
         "uuid": "7fcc7c1e-c8d4-4701-8be7-06ab6e039885",
-        "practices": [
-          "parsing"
-        ],
-        "prerequisites": [
-          "maybe",
-          "parsing"
-        ],
+        "practices": ["parsing"],
+        "prerequisites": ["maybe", "parsing"],
         "difficulty": 8
       },
       {
@@ -864,10 +665,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "integers",
-          "math"
-        ]
+        "topics": ["integers", "math"]
       },
       {
         "slug": "gigasecond",
@@ -876,9 +674,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "dates"
-        ]
+        "topics": ["dates"]
       },
       {
         "slug": "rna-transcription",
@@ -887,10 +683,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 1,
-        "topics": [
-          "strings",
-          "transforming"
-        ]
+        "topics": ["strings", "transforming"]
       },
       {
         "slug": "armstrong-numbers",
@@ -899,13 +692,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "strings",
-          "integers",
-          "lists",
-          "algorithms",
-          "math"
-        ]
+        "topics": ["strings", "integers", "lists", "algorithms", "math"]
       },
       {
         "slug": "scrabble-score",
@@ -914,9 +701,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 3,
-        "topics": [
-          "transforming"
-        ]
+        "topics": ["transforming"]
       },
       {
         "slug": "run-length-encoding",
@@ -925,10 +710,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 5,
-        "topics": [
-          "algorithms",
-          "transforming"
-        ]
+        "topics": ["algorithms", "transforming"]
       },
       {
         "slug": "transpose",
@@ -937,9 +719,7 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 6,
-        "topics": [
-          "matrices"
-        ]
+        "topics": ["matrices"]
       },
       {
         "slug": "matching-brackets",
@@ -948,22 +728,16 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 7,
-        "topics": [
-          "parsing",
-          "stacks"
-        ]
+        "topics": ["parsing", "stacks"]
       },
       {
         "slug": "sublist",
         "name": "Sublist",
         "uuid": "8e1cb827-2fa9-46a4-ac50-7f8b3ba66809",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["generics"],
+        "prerequisites": ["generics"],
         "difficulty": 7,
-        "topics": [
-          "lists",
-          "recursion"
-        ]
+        "topics": ["lists", "recursion"]
       },
       {
         "slug": "bowling",
@@ -972,34 +746,21 @@
         "practices": [],
         "prerequisites": [],
         "difficulty": 8,
-        "topics": [
-          "lists",
-          "recursion",
-          "result",
-          "pattern-matching"
-        ]
+        "topics": ["lists", "recursion", "result", "pattern-matching"]
       },
       {
         "slug": "complex-numbers",
         "name": "Complex Numbers",
         "uuid": "e982e16c-810c-477c-a478-7abf64e6132f",
-        "practices": [
-          "custom-types"
-        ],
-        "prerequisites": [
-          "basics-1",
-          "basics-2",
-          "custom-types"
-        ],
+        "practices": ["custom-types"],
+        "prerequisites": ["basics-1", "basics-2", "custom-types"],
         "difficulty": 4
       },
       {
         "slug": "sgf-parsing",
         "name": "SGF Parsing",
         "uuid": "86973113-b905-4582-9eac-46df97fab408",
-        "practices": [
-          "parsing"
-        ],
+        "practices": ["parsing"],
         "prerequisites": [
           "lists",
           "records",
@@ -1014,16 +775,15 @@
         "slug": "circular-buffer",
         "name": "Circular Buffer",
         "uuid": "759b1e1d-d4ea-4407-9da9-2da916cb45ef",
-        "practices": [
-          "custom-types"
-        ],
+        "practices": ["custom-types", "generics"],
         "prerequisites": [
           "booleans",
           "lists",
           "records",
           "pattern-matching",
           "custom-types",
-          "maybe"
+          "maybe",
+          "generics"
         ],
         "difficulty": 6
       },
@@ -1031,9 +791,7 @@
         "slug": "custom-set",
         "name": "Custom Set",
         "uuid": "b1d59ef6-b076-4399-b559-6a3195fd09d8",
-        "practices": [
-          "set"
-        ],
+        "practices": ["set"],
         "prerequisites": [
           "lists",
           "custom-types",
@@ -1048,9 +806,7 @@
         "slug": "two-bucket",
         "name": "Two Bucket",
         "uuid": "bc4aa6f0-4b16-45b6-b7f6-48f57b8ddf84",
-        "practices": [
-          "set"
-        ],
+        "practices": ["set"],
         "prerequisites": [
           "tuples",
           "booleans",

--- a/exercises/concept/treasure-chest/.docs/hints.md
+++ b/exercises/concept/treasure-chest/.docs/hints.md
@@ -1,0 +1,16 @@
+# General
+
+## 1. Define the TreasureChest generic custom type
+
+- The Elm guide has a section on [custom types][custom-types].
+- The TreasueChest custom type only has a single variant.
+- Idiomatically in Elm, when a custom type has a single variant, the variant and the type have the same name (in this case both would be called TreasureChest)
+
+## 2. Define the getTreasure function
+
+- There is a [shorthand for destructuring single member custom types][single-member-custom-destructuring].
+- The Elm guide has a sectoin on [Maybe][maybe] if you need a refresher.
+
+[custom-types][https://guide.elm-lang.org/types/custom_types.html]
+[single-member-custom-destructuring]: https://gist.github.com/yang-wei/4f563fbf81ff843e8b1e?permalink_comment_id=1701264#gistcomment-1701264
+[maybe][https://guide.elm-lang.org/error_handling/maybe.html]

--- a/exercises/concept/treasure-chest/.docs/instructions.md
+++ b/exercises/concept/treasure-chest/.docs/instructions.md
@@ -1,0 +1,26 @@
+# Instructions
+
+In this exercise you're going to write a generic (/ magical!) TreasureChest, to store some treasure.
+
+## 1. Define the TreasureChest generic custom type
+
+Define a `TreasureChest` custom type with a single variant.
+
+The variant should have an associated String value, which will be used to store the password of the treasure chest
+
+The variant should also have an associate generic value, which will be used to store the treasure. This value is generic so that the treasure can be anything.
+
+## 2. Define the getTreasure function
+
+This function should take two parameters
+
+- a String (for the passwordAttempt)
+- a TreasureChest generic custom type
+
+This function should check the provided passwordAttempt against the String in the TreasureChest.
+
+The function should return a `Maybe`
+
+If the passwords match then return `Just` with the generic value from the TreasureChest (the treasure!)
+
+If the passwords do not match then return `Nothing`.

--- a/exercises/concept/treasure-chest/.docs/introduction.md
+++ b/exercises/concept/treasure-chest/.docs/introduction.md
@@ -1,0 +1,1 @@
+# generate this before merging

--- a/exercises/concept/treasure-chest/.docs/introduction.md.tpl
+++ b/exercises/concept/treasure-chest/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: generics}

--- a/exercises/concept/treasure-chest/.meta/Exemplar.elm
+++ b/exercises/concept/treasure-chest/.meta/Exemplar.elm
@@ -1,0 +1,14 @@
+module TreasureChest exposing (..)
+
+
+type TreasureChest treasure
+    = TreasureChest String treasure
+
+
+getTreasure : String -> TreasureChest a -> Maybe a
+getTreasure passwordAttempt (TreasureChest password treasure) =
+    if passwordAttempt == password then
+        Just treasure
+
+    else
+        Nothing

--- a/exercises/concept/treasure-chest/.meta/config.json
+++ b/exercises/concept/treasure-chest/.meta/config.json
@@ -1,0 +1,10 @@
+{
+  "authors": ["ceddlyburge", "mpizenberg", "jiegillet"],
+  "files": {
+    "solution": ["src/TreasureChest.elm"],
+    "test": ["tests/Tests.elm"],
+    "exemplar": [".meta/Exemplar.elm"]
+  },
+  "icon": "tisbury-treasure-hunt",
+  "blurb": "Learn how to create and use Elm code that is generic by creating a Treasure Chest"
+}

--- a/exercises/concept/treasure-chest/.meta/design.md
+++ b/exercises/concept/treasure-chest/.meta/design.md
@@ -1,0 +1,26 @@
+# Design
+
+## Goal
+
+The goal of this exercise is to teach students how to consume and make generic code.
+
+## Learning objectives
+
+- Understand what a type variable is.
+- Know how to define generic types.
+- Know how to define generic functions.
+
+## Out of scope
+
+- Covariance and contravariance.
+- Higher order functions.
+
+## Concepts
+
+- `generics`: Learn how to create and use Elm code that is generic.
+
+## Prerequisites
+
+- `custom-types`: Learn how to use custom types in an Elm program.
+- `maybe`: Learn how to use optional values with the Maybe type.
+- `pattern-matching`: Pattern matching is a powerfull tool to identify and bind any kind of data.

--- a/exercises/concept/treasure-chest/elm.json
+++ b/exercises/concept/treasure-chest/elm.json
@@ -1,0 +1,28 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
+        },
+        "indirect": {}
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "1.2.2",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+        },
+        "indirect": {
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.2"
+        }
+    }
+}

--- a/exercises/concept/treasure-chest/src/TreasureChest.elm
+++ b/exercises/concept/treasure-chest/src/TreasureChest.elm
@@ -1,0 +1,13 @@
+module TreasureChest exposing (..)
+
+-- 1. define a single variant generic TreasureChest custom type with associated data:
+-- - a String (for a password)
+-- - a generic (for the treasure)
+-- 2. define a getTreasure function, with parameters:
+-- - a String (for the passwordAttempt)
+-- - a TreasureChest custom type
+--  and returns:
+-- - if the passwordAttempt does not match the String in the TreasureChest
+--   - Nothing
+-- - if the passwordAttempt matches the String in the TreasureChest
+--   - Just treasure (where treasure is the generic in the TreasureChest)

--- a/exercises/concept/treasure-chest/tests/Tests.elm
+++ b/exercises/concept/treasure-chest/tests/Tests.elm
@@ -1,0 +1,33 @@
+module Tests exposing (tests)
+
+import Expect
+import Test exposing (..)
+import TreasureChest exposing (..)
+
+
+tests : Test
+tests =
+    describe "TreasureChest"
+        [ describe "1"
+            [ test "Treasure can be a string" <|
+                \_ ->
+                    TreasureChest "password" "treasure"
+                        |> Expect.equal (TreasureChest "password" "treasure")
+            , test "Treasure can be an int" <|
+                \_ ->
+                    TreasureChest "password" 5
+                        |> Expect.equal (TreasureChest "password" 5)
+            ]
+        , describe "2"
+            [ test "The treasure is returned if the correct password is used" <|
+                \_ ->
+                    TreasureChest "password" "treasure"
+                        |> getTreasure "password"
+                        |> Expect.equal (Just "treasure")
+            , test "Nothing is returned if the correct password is used" <|
+                \_ ->
+                    TreasureChest "password" "treasure"
+                        |> getTreasure "wrong-password"
+                        |> Expect.equal Nothing
+            ]
+        ]


### PR DESCRIPTION
Fixes #422 

The exercise requires the use of a generic type parameter in a custom type and in a function type signature, but not in a record.

We could potentially ask the student to solve the exercise using a record first, and then using a custom type, similar to how we do it in the Monster Attack partial application exercise. And then in the opaque type concept / exercise we go one step further, making it impossible to get the treasure without the password. It might be a nice journey from simpler and easier to more complicated bit more robust. 

Or we could take the view that the way generics are used in records and custom types are similar enough that we don't need the student to explicitly code up both variants, and can see how it is done from the about / introduction.

@jiegillet @mpizenberg 