### PR TITLE
Fix links (the reference style markdown format was wrong)

### DIFF
--- a/concepts/opaque-types/about.md
+++ b/concepts/opaque-types/about.md
@@ -78,7 +78,7 @@ isValidEmailAddress: String -> bool
 -- ... 
 ```
 
-[custom-types][https://guide.elm-lang.org/types/custom_types.html]
-[parse-dont-validate][https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/] 
-[uphold-invariants][https://ckoster22.medium.com/advanced-types-in-elm-opaque-types-ec5ec3b84ed2]
+[custom-types]: https://guide.elm-lang.org/types/custom_types.html
+[parse-dont-validate]: https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/
+[uphold-invariants]: https://ckoster22.medium.com/advanced-types-in-elm-opaque-types-ec5ec3b84ed2
 

--- a/concepts/opaque-types/introduction.md
+++ b/concepts/opaque-types/introduction.md
@@ -58,7 +58,7 @@ isValidEmailAddress: String -> bool
 -- ... 
 ```
 
-[custom-types][https://guide.elm-lang.org/types/custom_types.html]
-[parse-dont-validate][https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/] 
-[uphold-invariants][https://ckoster22.medium.com/advanced-types-in-elm-opaque-types-ec5ec3b84ed2]
+[custom-types]: https://guide.elm-lang.org/types/custom_types.html
+[parse-dont-validate]: https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/
+[uphold-invariants]: https://ckoster22.medium.com/advanced-types-in-elm-opaque-types-ec5ec3b84ed2
 

--- a/exercises/concept/secure-treasure-chest/.docs/hints.md
+++ b/exercises/concept/secure-treasure-chest/.docs/hints.md
@@ -24,6 +24,6 @@
 - This is most easily done with an `if` expression
 - The Elm guide has a section on [Maybe][maybe] if you need a refresher.
 
-[custom-types][https://guide.elm-lang.org/types/custom_types.html]
-[single-member-custom-destructuring][https://gist.github.com/yang-wei/4f563fbf81ff843e8b1e?permalink_comment_id=1701264#gistcomment-1701264]
-[maybe][https://guide.elm-lang.org/error_handling/maybe.html]
+[custom-types]: https://guide.elm-lang.org/types/custom_types.html
+[single-member-custom-destructuring]: https://gist.github.com/yang-wei/4f563fbf81ff843e8b1e?permalink_comment_id=1701264#gistcomment-1701264
+[maybe]: https://guide.elm-lang.org/error_handling/maybe.html

--- a/exercises/concept/secure-treasure-chest/.docs/instructions.md
+++ b/exercises/concept/secure-treasure-chest/.docs/instructions.md
@@ -56,5 +56,5 @@ If the passwords do not match then return `Nothing`.
 Expose this function, so that other modules are able to get the treasure from a `SecureTreasureChest`, as long as they supply the correct password.
 
 
-[owasp-password-length][https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls]
-[elm-review][https://package.elm-lang.org/packages/jfmengels/elm-review/latest/]
+[owasp-password-length]: https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls
+[elm-review]: https://package.elm-lang.org/packages/jfmengels/elm-review/latest/

--- a/exercises/concept/secure-treasure-chest/.docs/introduction.md
+++ b/exercises/concept/secure-treasure-chest/.docs/introduction.md
@@ -58,6 +58,6 @@ isValidEmailAddress: String -> bool
 -- ... 
 ```
 
-[custom-types][https://guide.elm-lang.org/types/custom_types.html]
-[parse-dont-validate][https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/] 
-[uphold-invariants][https://ckoster22.medium.com/advanced-types-in-elm-opaque-types-ec5ec3b84ed2]
+[custom-types]: https://guide.elm-lang.org/types/custom_types.html
+[parse-dont-validate]: https://lexi-lambda.github.io/blog/2019/11/05/parse-don-t-validate/
+[uphold-invariants]: https://ckoster22.medium.com/advanced-types-in-elm-opaque-types-ec5ec3b84ed2


### PR DESCRIPTION
I've just done the Opaque Types concept exercise on the website, and the markdown links are wrong, so this fixes them up.

@jiegillet @mpizenberg 