### PR TITLE
Update `elm-explorations/test`

### DIFF
--- a/elm-tooling.json
+++ b/elm-tooling.json
@@ -2,6 +2,6 @@
     "tools": {
         "elm": "0.19.1",
         "elm-format": "0.8.5",
-        "elm-test-rs": "2.0.0"
+        "elm-test-rs": "3.0.0"
     }
 }

--- a/exercises/concept/annalyns-infiltration/elm.json
+++ b/exercises/concept/annalyns-infiltration/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/bandwagoner/elm.json
+++ b/exercises/concept/bandwagoner/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/bettys-bike-shop/elm.json
+++ b/exercises/concept/bettys-bike-shop/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/blorkemon-cards/elm.json
+++ b/exercises/concept/blorkemon-cards/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/go/elm.json
+++ b/exercises/concept/go/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/gotta-snatch-em-all/elm.json
+++ b/exercises/concept/gotta-snatch-em-all/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/lucians-luscious-lasagna/elm.json
+++ b/exercises/concept/lucians-luscious-lasagna/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/marios-marvellous-lasagna/elm.json
+++ b/exercises/concept/marios-marvellous-lasagna/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/monster-attack/elm.json
+++ b/exercises/concept/monster-attack/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/paolas-prestigious-pizza/elm.json
+++ b/exercises/concept/paolas-prestigious-pizza/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/role-playing-game/elm.json
+++ b/exercises/concept/role-playing-game/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/secure-treasure-chest/elm.json
+++ b/exercises/concept/secure-treasure-chest/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/ticket-please/elm.json
+++ b/exercises/concept/ticket-please/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/ticket-please/tests/Tests.elm
+++ b/exercises/concept/ticket-please/tests/Tests.elm
@@ -22,11 +22,13 @@ tests =
             [ test "emptyComment should detect an empty comment" <|
                 \() ->
                     emptyComment ( User "Alice", "" )
-                        |> Expect.true "Expected the comment to be empty"
+                        |> Expect.equal True
+                        |> Expect.onFail "Expected the comment to be empty"
             , test "emptyComment should detect an non-empty comment" <|
                 \() ->
                     emptyComment ( User "Alice", "hello" )
-                        |> Expect.false "Expected the comment to contain something"
+                        |> Expect.equal False
+                        |> Expect.onFail "Expected the comment to contain something"
             , test "emptyComment can be used in a filter" <|
                 \() ->
                     [ ( User "Alice", "hello" )
@@ -85,27 +87,32 @@ tests =
                 \() ->
                     Ticket { newTicket | assignedTo = Nothing }
                         |> assignedToDevTeam
-                        |> Expect.false "Expected unassigned ticket"
+                        |> Expect.equal False
+                        |> Expect.onFail "Expected unassigned ticket"
             , test "assignedToDevTeam with ticket assigned to non-dev team" <|
                 \() ->
                     Ticket { newTicket | assignedTo = Just (User "Roy") }
                         |> assignedToDevTeam
-                        |> Expect.false "Expected ticket not assigned to dev team"
+                        |> Expect.equal False
+                        |> Expect.onFail "Expected ticket not assigned to dev team"
             , test "assignedToDevTeam with ticket assigned to Alice from dev team" <|
                 \() ->
                     Ticket { newTicket | assignedTo = Just (User "Alice") }
                         |> assignedToDevTeam
-                        |> Expect.true "Expected ticket assigned to Alice from dev team"
+                        |> Expect.equal True
+                        |> Expect.onFail "Expected ticket assigned to Alice from dev team"
             , test "assignedToDevTeam with ticket assigned to Bob from dev team" <|
                 \() ->
                     Ticket { newTicket | assignedTo = Just (User "Bob") }
                         |> assignedToDevTeam
-                        |> Expect.true "Expected ticket assigned to Bob from dev team"
+                        |> Expect.equal True
+                        |> Expect.onFail "Expected ticket assigned to Bob from dev team"
             , test "assignedToDevTeam with ticket assigned to Charlie from dev team" <|
                 \() ->
                     Ticket { newTicket | assignedTo = Just (User "Charlie") }
                         |> assignedToDevTeam
-                        |> Expect.true "Expected ticket assigned to Charlie from dev team"
+                        |> Expect.equal True
+                        |> Expect.onFail "Expected ticket assigned to Charlie from dev team"
             ]
         , describe "4"
             [ test "assign new, unassigned ticket to Roy" <|

--- a/exercises/concept/tisbury-treasure-hunt/elm.json
+++ b/exercises/concept/tisbury-treasure-hunt/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/top-scorers/elm.json
+++ b/exercises/concept/top-scorers/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/tracks-on-tracks-on-tracks/elm.json
+++ b/exercises/concept/tracks-on-tracks-on-tracks/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/treasure-chest/elm.json
+++ b/exercises/concept/treasure-chest/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/treasure-factory/elm.json
+++ b/exercises/concept/treasure-factory/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/concept/treasure-factory/tests/Tests.elm
+++ b/exercises/concept/treasure-factory/tests/Tests.elm
@@ -23,12 +23,14 @@ tests =
                 \() ->
                     TreasureFactory.makeChest "password" 1
                         /= TreasureFactory.makeChest "p4$$w0rd" 1
-                        |> Expect.true "Chests created with different passwords should not be the same"
+                        |> Expect.equal True
+                        |> Expect.onFail "Chests created with different passwords should not be the same"
             , test "makeChest doesn't internally use a fixed treasure" <|
                 \() ->
                     TreasureFactory.makeChest "password" 1
                         /= TreasureFactory.makeChest "password" 2
-                        |> Expect.true "Chests created with different treasures should not be the same"
+                        |> Expect.equal True
+                        |> Expect.onFail "Chests created with different treasures should not be the same"
             ]
         , describe "2"
             [ test "chest with passwords of less than 8 characters are insecure" <|
@@ -39,12 +41,14 @@ tests =
                 \() ->
                     TreasureFactory.secureChest (TreasureFactory.makeChest "12345678" 1)
                         /= Nothing
-                        |> Expect.true "Chests with 8 characters should be secure"
+                        |> Expect.equal True
+                        |> Expect.onFail "Chests with 8 characters should be secure"
             , test "chest with passwords of more than 8 characters are secure" <|
                 \() ->
                     TreasureFactory.secureChest (TreasureFactory.makeChest "123456789012345789" 1)
                         /= Nothing
-                        |> Expect.true "Chests with more than 8 characters should be secure"
+                        |> Expect.equal True
+                        |> Expect.onFail "Chests with more than 8 characters should be secure"
             ]
         , describe "3"
             [ test "chests with identical treasures are never unique" <|

--- a/exercises/concept/valentines-day/elm.json
+++ b/exercises/concept/valentines-day/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/accumulate/elm.json
+++ b/exercises/practice/accumulate/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/acronym/elm.json
+++ b/exercises/practice/acronym/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/all-your-base/elm.json
+++ b/exercises/practice/all-your-base/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/allergies/elm.json
+++ b/exercises/practice/allergies/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/anagram/elm.json
+++ b/exercises/practice/anagram/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/armstrong-numbers/elm.json
+++ b/exercises/practice/armstrong-numbers/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/atbash-cipher/elm.json
+++ b/exercises/practice/atbash-cipher/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/binary-search/elm.json
+++ b/exercises/practice/binary-search/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/bob/elm.json
+++ b/exercises/practice/bob/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/bowling/elm.json
+++ b/exercises/practice/bowling/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/circular-buffer/elm.json
+++ b/exercises/practice/circular-buffer/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/collatz-conjecture/elm.json
+++ b/exercises/practice/collatz-conjecture/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/complex-numbers/elm.json
+++ b/exercises/practice/complex-numbers/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/custom-set/elm.json
+++ b/exercises/practice/custom-set/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/custom-set/tests/Tests.elm
+++ b/exercises/practice/custom-set/tests/Tests.elm
@@ -36,66 +36,78 @@ tests =
                 test "empty set is empty" <|
                     \() ->
                         CustomSet.isEmpty CustomSet.empty
-                            |> Expect.true "isEmpty empty should be True"
+                            |> Expect.equal True
+                            |> Expect.onFail "isEmpty empty should be True"
             , skip <|
                 test "sets with no elements are empty" <|
                     \() ->
                         CustomSet.isEmpty (CustomSet.fromList [])
-                            |> Expect.true "isEmpty (fromList []) should be True"
+                            |> Expect.equal True
+                            |> Expect.onFail "isEmpty (fromList []) should be True"
             , skip <|
                 test "sets with elements are not empty" <|
                     \() ->
                         CustomSet.isEmpty (CustomSet.fromList [ 1 ])
-                            |> Expect.false "isEmpty (fromList [ 1 ]) should be False"
+                            |> Expect.equal False
+                            |> Expect.onFail "isEmpty (fromList [ 1 ]) should be False"
             ]
         , describe "Sets can report if they contain an element"
             [ skip <|
                 test "nothing is contained in an empty set" <|
                     \() ->
                         CustomSet.member 1 CustomSet.empty
-                            |> Expect.false "member 1 empty should be False"
+                            |> Expect.equal False
+                            |> Expect.onFail "member 1 empty should be False"
             , skip <|
                 test "when the element is in the set" <|
                     \() ->
                         CustomSet.member 1 (CustomSet.fromList [ 1, 2, 3 ])
-                            |> Expect.true "member 1 (fromList [ 1, 2, 3 ]) should be True"
+                            |> Expect.equal True
+                            |> Expect.onFail "member 1 (fromList [ 1, 2, 3 ]) should be True"
             , skip <|
                 test "when the element is not in the set" <|
                     \() ->
                         CustomSet.member 4 (CustomSet.fromList [ 1, 2, 3 ])
-                            |> Expect.false "member 4 (fromList [ 1, 2, 3 ]) should be False"
+                            |> Expect.equal False
+                            |> Expect.onFail "member 4 (fromList [ 1, 2, 3 ]) should be False"
             ]
         , describe "Sets with the same elements are equal"
             [ skip <|
                 test "empty sets are equal" <|
                     \() ->
                         CustomSet.equal CustomSet.empty CustomSet.empty
-                            |> Expect.true "equal empty empty should be True"
+                            |> Expect.equal True
+                            |> Expect.onFail "equal empty empty should be True"
             , skip <|
                 test "empty set is not equal to non-empty set" <|
                     \() ->
                         CustomSet.equal CustomSet.empty (CustomSet.fromList [ 1, 2, 3 ])
-                            |> Expect.false "equal empty (fromList [ 1, 2, 3 ]) should be False"
+                            |> Expect.equal False
+                            |> Expect.onFail "equal empty (fromList [ 1, 2, 3 ]) should be False"
             , skip <|
                 test "non-empty set is not equal to empty set" <|
                     \() ->
                         CustomSet.equal (CustomSet.fromList [ 1, 2, 3 ]) CustomSet.empty
-                            |> Expect.false "equal (fromList [ 1, 2, 3 ]) empty should be False"
+                            |> Expect.equal False
+                            |> Expect.onFail "equal (fromList [ 1, 2, 3 ]) empty should be False"
             , skip <|
                 test "sets with the same elements are equal" <|
                     \() ->
                         CustomSet.equal (CustomSet.fromList [ 1, 2 ]) (CustomSet.fromList [ 2, 1 ])
-                            |> Expect.true "equal (fromList [ 1, 2 ]) (fromList [ 2, 1 ]) should be True"
+                            |> Expect.equal True
+                            |> Expect.onFail "equal (fromList [ 1, 2 ]) (fromList [ 2, 1 ]) should be True"
             , skip <|
                 test "sets with different elements are not equal" <|
                     \() ->
                         CustomSet.equal (CustomSet.fromList [ 1, 2, 3 ]) (CustomSet.fromList [ 1, 2, 4 ])
-                            |> Expect.false "equal (fromList [ 1, 2, 3 ]) (fromList [ 1, 2, 4 ]) should be False"
+                            |> Expect.equal False
+                            |> Expect.onFail "equal (fromList [ 1, 2, 3 ]) (fromList [ 1, 2, 4 ]) should be False"
             , skip <|
                 test "set is not equal to larger set with same elements" <|
                     \() ->
                         CustomSet.equal (CustomSet.fromList [ 1, 2, 3 ]) (CustomSet.fromList [ 1, 2, 3, 4 ])
-                            |> Expect.false "equal (fromList [ 1, 2, 3 ]) (fromList [ 1, 2, 3, 4 ]) should be False"
+                            |> Expect.equal False
+                            |> Expect.onFail "equal (fromList [ 1, 2, 3 ]) (fromList [ 1, 2, 3, 4 ]) should be False"
             ]
         , describe "Union returns a set of all elements in either set"
             [ skip <|
@@ -199,58 +211,69 @@ tests =
                 test "empty set is a subset of another empty set" <|
                     \() ->
                         CustomSet.subset CustomSet.empty CustomSet.empty
-                            |> Expect.true "subset empty empty should be True"
+                            |> Expect.equal True
+                            |> Expect.onFail "subset empty empty should be True"
             , skip <|
                 test "empty set is a subset of non-empty set" <|
                     \() ->
                         CustomSet.subset CustomSet.empty (CustomSet.fromList [ 1 ])
-                            |> Expect.true "subset empty (fromList [ 1 ]) should be True"
+                            |> Expect.equal True
+                            |> Expect.onFail "subset empty (fromList [ 1 ]) should be True"
             , skip <|
                 test "non-empty set is not a subset of empty set" <|
                     \() ->
                         CustomSet.subset (CustomSet.fromList [ 1 ]) CustomSet.empty
-                            |> Expect.false "subset (fromList [ 1 ]) empty should be False"
+                            |> Expect.equal False
+                            |> Expect.onFail "subset (fromList [ 1 ]) empty should be False"
             , skip <|
                 test "set is a subset of set with exact same elements" <|
                     \() ->
                         CustomSet.subset (CustomSet.fromList [ 1, 2, 3 ]) (CustomSet.fromList [ 1, 2, 3 ])
-                            |> Expect.true "subset (fromList [ 1, 2, 3 ]) (fromList [ 1, 2, 3 ]) should be True"
+                            |> Expect.equal True
+                            |> Expect.onFail "subset (fromList [ 1, 2, 3 ]) (fromList [ 1, 2, 3 ]) should be True"
             , skip <|
                 test "set is a subset of larger set with same elements" <|
                     \() ->
                         CustomSet.subset (CustomSet.fromList [ 1, 2, 3 ]) (CustomSet.fromList [ 4, 1, 2, 3 ])
-                            |> Expect.true "subset (fromList [ 1, 2, 3 ]) (fromList [ 4, 1, 2, 3 ]) should be True"
+                            |> Expect.equal True
+                            |> Expect.onFail "subset (fromList [ 1, 2, 3 ]) (fromList [ 4, 1, 2, 3 ]) should be True"
             , skip <|
                 test "set is not a subset of set that does not contain its elements" <|
                     \() ->
                         CustomSet.subset (CustomSet.fromList [ 1, 2, 3 ]) (CustomSet.fromList [ 4, 1, 3 ])
-                            |> Expect.false "subset (fromList [ 1, 2, 3 ]) (fromList [ 4, 1, 3 ]) should be False"
+                            |> Expect.equal False
+                            |> Expect.onFail "subset (fromList [ 1, 2, 3 ]) (fromList [ 4, 1, 3 ]) should be False"
             ]
         , describe "Sets are disjoint if they share no elements"
             [ skip <|
                 test "the empty set is disjoint with itself" <|
                     \() ->
                         CustomSet.disjoint CustomSet.empty CustomSet.empty
-                            |> Expect.true "disjoint empty empty should be True"
+                            |> Expect.equal True
+                            |> Expect.onFail "disjoint empty empty should be True"
             , skip <|
                 test "empty set is disjoint with non-empty set" <|
                     \() ->
                         CustomSet.disjoint CustomSet.empty (CustomSet.fromList [ 1 ])
-                            |> Expect.true "disjoint empty (fromList [ 1 ]) should be True"
+                            |> Expect.equal True
+                            |> Expect.onFail "disjoint empty (fromList [ 1 ]) should be True"
             , skip <|
                 test "non-empty set is disjoint with empty set" <|
                     \() ->
                         CustomSet.disjoint (CustomSet.fromList [ 1 ]) CustomSet.empty
-                            |> Expect.true "disjoint (fromList [ 1 ]) empty should be True"
+                            |> Expect.equal True
+                            |> Expect.onFail "disjoint (fromList [ 1 ]) empty should be True"
             , skip <|
                 test "sets are not disjoint if they share an element" <|
                     \() ->
                         CustomSet.disjoint (CustomSet.fromList [ 1, 2 ]) (CustomSet.fromList [ 2, 3 ])
-                            |> Expect.false "disjoint (fromList [ 1, 2 ]) (fromList [ 2, 3 ]) should be False"
+                            |> Expect.equal False
+                            |> Expect.onFail "disjoint (fromList [ 1, 2 ]) (fromList [ 2, 3 ]) should be False"
             , skip <|
                 test "sets are disjoint if they share no elements" <|
                     \() ->
                         CustomSet.disjoint (CustomSet.fromList [ 1, 2 ]) (CustomSet.fromList [ 3, 4 ])
-                            |> Expect.true "disjoint (fromList [ 1, 2 ]) (fromList [ 3, 4 ]) should be True"
+                            |> Expect.equal True
+                            |> Expect.onFail "disjoint (fromList [ 1, 2 ]) (fromList [ 3, 4 ]) should be True"
             ]
         ]

--- a/exercises/practice/difference-of-squares/elm.json
+++ b/exercises/practice/difference-of-squares/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/etl/elm.json
+++ b/exercises/practice/etl/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/gigasecond/elm.json
+++ b/exercises/practice/gigasecond/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/grade-school/elm.json
+++ b/exercises/practice/grade-school/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/grains/elm.json
+++ b/exercises/practice/grains/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/hamming/elm.json
+++ b/exercises/practice/hamming/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/hello-world/elm.json
+++ b/exercises/practice/hello-world/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/isogram/elm.json
+++ b/exercises/practice/isogram/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/largest-series-product/elm.json
+++ b/exercises/practice/largest-series-product/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/leap/elm.json
+++ b/exercises/practice/leap/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/list-ops/elm.json
+++ b/exercises/practice/list-ops/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/luhn/elm.json
+++ b/exercises/practice/luhn/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/matching-brackets/elm.json
+++ b/exercises/practice/matching-brackets/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/nucleotide-count/elm.json
+++ b/exercises/practice/nucleotide-count/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/pangram/elm.json
+++ b/exercises/practice/pangram/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/pascals-triangle/elm.json
+++ b/exercises/practice/pascals-triangle/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/phone-number/elm.json
+++ b/exercises/practice/phone-number/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/pythagorean-triplet/elm.json
+++ b/exercises/practice/pythagorean-triplet/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/raindrops/elm.json
+++ b/exercises/practice/raindrops/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/rna-transcription/elm.json
+++ b/exercises/practice/rna-transcription/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/rna-transcription/tests/Tests.elm
+++ b/exercises/practice/rna-transcription/tests/Tests.elm
@@ -5,16 +5,6 @@ import RnaTranscription exposing (toRNA)
 import Test exposing (..)
 
 
-isErr : Result error value -> Bool
-isErr result =
-    case result of
-        Ok _ ->
-            False
-
-        Err _ ->
-            True
-
-
 tests : Test
 tests =
     describe "RNATranscription"
@@ -34,5 +24,8 @@ tests =
                 \() -> Expect.equal (Ok "UGCACCAGAAUU") (toRNA "ACGTGGTCTTAA")
         , skip <|
             test "input \"INVALID\" should produce an error" <|
-                \() -> Expect.true "expected an error message output. For example `Err \"Invalid input\"`" (toRNA "INVALID" |> isErr)
+                \() ->
+                    toRNA "INVALID"
+                        |> Expect.err
+                        |> Expect.onFail "expected an error message output. For example `Err \"Invalid input\"`"
         ]

--- a/exercises/practice/robot-simulator/elm.json
+++ b/exercises/practice/robot-simulator/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/roman-numerals/elm.json
+++ b/exercises/practice/roman-numerals/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/run-length-encoding/elm.json
+++ b/exercises/practice/run-length-encoding/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/say/elm.json
+++ b/exercises/practice/say/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/scrabble-score/elm.json
+++ b/exercises/practice/scrabble-score/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/series/elm.json
+++ b/exercises/practice/series/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/sgf-parsing/elm.json
+++ b/exercises/practice/sgf-parsing/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/space-age/elm.json
+++ b/exercises/practice/space-age/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/strain/elm.json
+++ b/exercises/practice/strain/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/sublist/elm.json
+++ b/exercises/practice/sublist/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/sum-of-multiples/elm.json
+++ b/exercises/practice/sum-of-multiples/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/transpose/elm.json
+++ b/exercises/practice/transpose/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/triangle/elm.json
+++ b/exercises/practice/triangle/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/twelve-days/elm.json
+++ b/exercises/practice/twelve-days/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/two-bucket/elm.json
+++ b/exercises/practice/two-bucket/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/two-fer/elm.json
+++ b/exercises/practice/two-fer/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/word-count/elm.json
+++ b/exercises/practice/word-count/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/wordy/elm.json
+++ b/exercises/practice/wordy/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/exercises/practice/zebra-puzzle/elm.json
+++ b/exercises/practice/zebra-puzzle/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }

--- a/template/elm.json
+++ b/template/elm.json
@@ -17,12 +17,13 @@
     },
     "test-dependencies": {
         "direct": {
-            "elm-explorations/test": "1.2.2",
-            "rtfeldman/elm-iso8601-date-strings": "1.1.3"
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
         },
         "indirect": {
+            "elm/bytes": "1.0.8",
             "elm/html": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
+            "elm/virtual-dom": "1.0.3"
         }
     }
 }


### PR DESCRIPTION
Part of https://github.com/exercism/elm-test-runner/issues/42.

I had to make changes to the tests of 4 exercises: `concept/ticket-please/tests`, `concept/treasure-factory`, `practice/custom-set/tests` and `practice/rna-transcription`. The reason is that `Expect.true "reason"` disappeared, and had to be replaced with `Expect.equal True |> Expect.onFail "reason"`.

The test runner download and uses the template file of this repo (on the master branch) when rebuilding, so what needs to be done now is:
1. Prepare a PR in elm-test-runner upgrading elm-test-rs and the smoke test examples
3. Test locally that the test runner will be fine with this branch
4. Take a leap of faith and merge this PR
5. Merge the PR from elm-test-runner, that should trigger a re-build of the docker container with the correct template

I'm a bit worried of things going wrong, especially since we cannot merge things directly in elm-test-runner. 

Maybe building elm-test-runner with a local copy of the elm.json instad of downloading this one could help?