### PR TITLE
Update about.md

### DIFF
--- a/concepts/dict/about.md
+++ b/concepts/dict/about.md
@@ -87,7 +87,7 @@ Items can be transformed using `map`.
 
 ```elm
 alice = Dict.fromList [ ( "Alice", 0 ) ]
-empty = Dict.map (\player count -> count + 1) --> Dict.fromList [ ( "Alice", 1 ) ]
+newAlice = Dict.map (\player count -> count + 1) alice --> Dict.fromList [ ( "Alice", 1 ) ]
 ```
 
 Dicts can be combined / transformed using `merge`.


### PR DESCRIPTION
The Dict.map function does not return Dict.empty, change the function name from "empty".

The Dict.map annotation is (k -> a -> b) -> Dict k a -> Dict k b, but Dict k a (alice) is missing from the function.