### PR TITLE
corrected wrong test case

### DIFF
--- a/exercises/concept/role-playing-game/tests/Tests.elm
+++ b/exercises/concept/role-playing-game/tests/Tests.elm
@@ -33,7 +33,7 @@ tests =
             [ test "Casting a spell causes damage of double the mana" <|
                 \() ->
                     Expect.equal (castSpell 9 { name = Nothing, level = 10, health = 69, mana = Just 20 })
-                        ( { name = Nothing, level = 10, health = 69, mana = Just 2 }, 18 )
+                        ( { name = Nothing, level = 10, health = 69, mana = Just 11 }, 18 )
             , test "Attempting to cast a spell with insufficient mana does nothing" <|
                 \() ->
                     Expect.equal (castSpell 39 { name = Nothing, level = 10, health = 69, mana = Just 20 })

--- a/exercises/concept/role-playing-game/tests/Tests.elm
+++ b/exercises/concept/role-playing-game/tests/Tests.elm
@@ -33,7 +33,7 @@ tests =
             [ test "Casting a spell spends double the mana" <|
                 \() ->
                     Expect.equal (castSpell 9 { name = Nothing, level = 10, health = 69, mana = Just 20 })
-                        ( { name = Nothing, level = 10, health = 69, mana = Just 11 }, 18 )
+                        ( { name = Nothing, level = 10, health = 69, mana = Just 2 }, 18 )
             , test "Attempting to cast a spell with insufficient mana does nothing" <|
                 \() ->
                     Expect.equal (castSpell 39 { name = Nothing, level = 10, health = 69, mana = Just 20 })

--- a/exercises/concept/role-playing-game/tests/Tests.elm
+++ b/exercises/concept/role-playing-game/tests/Tests.elm
@@ -30,7 +30,7 @@ tests =
                         (Just { name = Nothing, level = 10, health = 100, mana = Just 100 })
             ]
         , describe "3"
-            [ test "Casting a spell spends double the mana" <|
+            [ test "Casting a spell causes damage of double the mana" <|
                 \() ->
                     Expect.equal (castSpell 9 { name = Nothing, level = 10, health = 69, mana = Just 20 })
                         ( { name = Nothing, level = 10, health = 69, mana = Just 2 }, 18 )


### PR DESCRIPTION
 "Casting a spell spends double the mana" 
mana = 20 and manaCost = 9
updated mana should be 20 - 2*9 = 20 - 18 = 2
test case given : 11(wrong)