### PR TITLE
fix tests of concept exercise 'monster-attack'

### DIFF
--- a/exercises/concept/monster-attack/tests/Tests.elm
+++ b/exercises/concept/monster-attack/tests/Tests.elm
@@ -11,50 +11,50 @@ tests =
         [ describe "1"
             [ test "attackWithSword1 should update Monster with desired description" <|
                 \_ ->
-                    attackWithSword1 "A monster approaches Annalyn and her pet dog Kazak." 2
+                    attackWithSword1 "A monster approaches Annalyn and her pet dog Kazak. " 2
                         |> Expect.equal
-                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with sword of strength 2."
+                            "A monster approaches Annalyn and her pet dog Kazak. Attacked with sword of strength 2."
             ]
         , describe "2"
             [ test "attackWithClaw1 should update Monster with desired description" <|
                 \_ ->
-                    attackWithClaw1 "A monster approaches Annalyn and her pet dog Kazak." 3
+                    attackWithClaw1 "A monster approaches Annalyn and her pet dog Kazak. " 3
                         |> Expect.equal
-                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with claw of strength 3."
+                            "A monster approaches Annalyn and her pet dog Kazak. Attacked with claw of strength 3."
             ]
         , describe "3"
             [ test "attack1 should attack with sword twice and claw twice" <|
                 \_ ->
-                    attack1 "A monster approaches Annalyn and her pet dog Kazak."
+                    attack1 "A monster approaches Annalyn and her pet dog Kazak. "
                         |> Expect.equal
-                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
+                            "A monster approaches Annalyn and her pet dog Kazak. Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
             ]
         , describe "4"
             [ test "attackWithSword2 should update Monster with desired description" <|
                 \_ ->
-                    attackWithSword2 2 "A monster approaches Annalyn and her pet dog Kazak."
+                    attackWithSword2 2 "A monster approaches Annalyn and her pet dog Kazak. "
                         |> Expect.equal
-                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with sword of strength 2."
+                            "A monster approaches Annalyn and her pet dog Kazak. Attacked with sword of strength 2."
             ]
         , describe "5"
             [ test "attackWithClaw2 should update Monster with desired description" <|
                 \_ ->
-                    attackWithClaw2 3 "A monster approaches Annalyn and her pet dog Kazak."
+                    attackWithClaw2 3 "A monster approaches Annalyn and her pet dog Kazak. "
                         |> Expect.equal
-                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with claw of strength 3."
+                            "A monster approaches Annalyn and her pet dog Kazak. Attacked with claw of strength 3."
             ]
         , describe "6"
             [ test "attack2 should attack with sword twice and claw twice" <|
                 \_ ->
-                    attack2 "A monster approaches Annalyn and her pet dog Kazak."
+                    attack2 "A monster approaches Annalyn and her pet dog Kazak. "
                         |> Expect.equal
-                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
+                            "A monster approaches Annalyn and her pet dog Kazak. Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
             ]
         , describe "7"
             [ test "attack3 should attack with sword twice and claw twice" <|
                 \_ ->
-                    attack3 "A monster approaches Annalyn and her pet dog Kazak."
+                    attack3 "A monster approaches Annalyn and her pet dog Kazak. "
                         |> Expect.equal
-                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
+                            "A monster approaches Annalyn and her pet dog Kazak. Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
             ]
         ]

--- a/exercises/concept/monster-attack/tests/Tests.elm
+++ b/exercises/concept/monster-attack/tests/Tests.elm
@@ -11,50 +11,50 @@ tests =
         [ describe "1"
             [ test "attackWithSword1 should update Monster with desired description" <|
                 \_ ->
-                    attackWithSword1 "" 2
+                    attackWithSword1 "A monster approaches Annalyn and her pet dog Kazak." 2
                         |> Expect.equal
-                            "Attacked with sword of strength 2."
+                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with sword of strength 2."
             ]
         , describe "2"
             [ test "attackWithClaw1 should update Monster with desired description" <|
                 \_ ->
-                    attackWithClaw1 "" 3
+                    attackWithClaw1 "A monster approaches Annalyn and her pet dog Kazak." 3
                         |> Expect.equal
-                            "Attacked with claw of strength 3."
+                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with claw of strength 3."
             ]
         , describe "3"
             [ test "attack1 should attack with sword twice and claw twice" <|
                 \_ ->
-                    attack1 ""
+                    attack1 "A monster approaches Annalyn and her pet dog Kazak."
                         |> Expect.equal
-                            "Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
+                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
             ]
         , describe "4"
             [ test "attackWithSword2 should update Monster with desired description" <|
                 \_ ->
-                    attackWithSword2 2 ""
+                    attackWithSword2 2 "A monster approaches Annalyn and her pet dog Kazak."
                         |> Expect.equal
-                            "Attacked with sword of strength 2."
+                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with sword of strength 2."
             ]
         , describe "5"
             [ test "attackWithClaw2 should update Monster with desired description" <|
                 \_ ->
-                    attackWithClaw2 3 ""
+                    attackWithClaw2 3 "A monster approaches Annalyn and her pet dog Kazak."
                         |> Expect.equal
-                            "Attacked with claw of strength 3."
+                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with claw of strength 3."
             ]
         , describe "6"
             [ test "attack2 should attack with sword twice and claw twice" <|
                 \_ ->
-                    attack2 ""
+                    attack2 "A monster approaches Annalyn and her pet dog Kazak."
                         |> Expect.equal
-                            "Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
+                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
             ]
         , describe "7"
             [ test "attack3 should attack with sword twice and claw twice" <|
                 \_ ->
-                    attack3 ""
+                    attack3 "A monster approaches Annalyn and her pet dog Kazak."
                         |> Expect.equal
-                            "Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
+                            "A monster approaches Annalyn and her pet dog Kazak.Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
             ]
         ]


### PR DESCRIPTION
Until now the tests passed even if the exercise functions didn't concatenate their content to the input string, because the tests always provided an empty input string.