### PR TITLE
Fix magician in training introduction

### DIFF
--- a/concepts/array/about.md
+++ b/concepts/array/about.md
@@ -18,7 +18,7 @@ Array Int --> an array of Int
 Arrays can be defined as follows:
 
 ```elm
-import Array exposing Array
+import Array exposing (Array)
 
 empty : Array Char
 empty = Array.empty

--- a/concepts/array/about.md
+++ b/concepts/array/about.md
@@ -6,7 +6,7 @@ There is no literal syntax for arrays (like there is for list), so instead the A
 For example, an `Array` with "a", "b" and "c" in it is usually shown as `Array.fromList ["a", "b", "c"]`.
 You will see this on console output, in the debugger, and other places like that.
 
-Unlike `List` which is a [default-import][default import], the `Array` module must be explicity imported, using `import Array` or similar.
+Unlike `List` which is a [default-import][default-imports], the `Array` module must be explicity imported, using `import Array` or similar.
 
 Type annotations for lists can be defined as follows
 

--- a/concepts/array/introduction.md
+++ b/concepts/array/introduction.md
@@ -2,7 +2,7 @@
 
 An [`Array`][array] in Elm is a fast immutable collection of zero or more values of the same type.
 
-Unlike `List` which is a [default-import][default import], the `Array` module must be explicity imported, using `import Array` or similar.
+Unlike `List` which is a [default-import][default-imports], the `Array` module must be explicity imported, using `import Array` or similar.
 
 Arrays can be defined as follows:
 

--- a/concepts/array/introduction.md
+++ b/concepts/array/introduction.md
@@ -7,7 +7,7 @@ Unlike `List` which is a [default-import][default import], the `Array` module mu
 Arrays can be defined as follows:
 
 ```elm
-import Array exposing Array
+import Array exposing (Array)
 
 empty : Array Char
 empty = Array.empty

--- a/exercises/concept/magician-in-training/.docs/introduction.md
+++ b/exercises/concept/magician-in-training/.docs/introduction.md
@@ -4,7 +4,7 @@
 
 An [`Array`][array] in Elm is a fast immutable collection of zero or more values of the same type.
 
-Unlike `List` which is a [default-import][default import], the `Array` module must be explicity imported, using `import Array` or similar.
+Unlike `List` which is a [default-import][default-imports], the `Array` module must be explicity imported, using `import Array` or similar.
 
 Arrays can be defined as follows:
 

--- a/exercises/concept/magician-in-training/.docs/introduction.md
+++ b/exercises/concept/magician-in-training/.docs/introduction.md
@@ -9,7 +9,7 @@ Unlike `List` which is a [default-import][default import], the `Array` module mu
 Arrays can be defined as follows:
 
 ```elm
-import Array exposing Array
+import Array exposing (Array)
 
 empty : Array Char
 empty = Array.empty
@@ -33,7 +33,7 @@ oneToFour = Array.push 1 twoToFour --> Array.fromList [ 1, 2, 3, 4 ]
 An element in an Array is retrieved using `Array.get`:
 
 ```elm
-sixSeven = Array.fromList [ 6, 7 ]    
+sixSeven = Array.fromList [ 6, 7 ]
 Array.get 0 sixSeven --> Just 6
 ```
 


### PR DESCRIPTION
* Fixed the import example that requires parentheses
* Fixed link to default imports