### PR TITLE
Prevent some stubs from making the tests crash

### DIFF
--- a/exercises/practice/binary-search-tree/src/BinarySearchTree.elm
+++ b/exercises/practice/binary-search-tree/src/BinarySearchTree.elm
@@ -7,10 +7,10 @@ type BinaryTree
 
 
 makeTree : List Int -> BinaryTree
-makeTree =
+makeTree data =
     Debug.todo "Please implement makeTree"
 
 
 sort : List Int -> List Int
-sort =
+sort data =
     Debug.todo "Please implement sort"

--- a/exercises/practice/complex-numbers/src/ComplexNumbers.elm
+++ b/exercises/practice/complex-numbers/src/ComplexNumbers.elm
@@ -24,7 +24,7 @@ fromPair pair =
 
 
 fromReal : Float -> Complex
-fromReal real =
+fromReal float =
     Debug.todo "Please implement fromReal."
 
 

--- a/exercises/practice/dnd-character/src/DndCharacter.elm
+++ b/exercises/practice/dnd-character/src/DndCharacter.elm
@@ -21,9 +21,9 @@ modifier score =
 
 ability : Generator Int
 ability =
-    Debug.todo "Please implement ability"
+    Random.lazy (\_ -> Debug.todo "Please implement ability")
 
 
 character : Generator Character
 character =
-    Debug.todo "Please implement character"
+    Random.lazy (\_ -> Debug.todo "Please implement character")


### PR DESCRIPTION
Usually test runner handles the `Debug.todo` of the stub files well, the tests fail but nothing else.
In `dnd-character`, the test runner crashes, because of the generators. 

I'm pretty sure it's not because of fuzz tests, because it also crashes without them as long as you're trying to use the generators (with `Random.step` for example).

After playing around, I found that wrapping the `Debug.todo` in a `Random.lazy` fixes the issue. It makes it slightly more messy for the students, but it's much better than crashing, because as of now they have to complete all of the functions before running any test.

@mpizenberg do you think I should open an issue about this? What would the right place be? `elm-explorations/test`? `rtfeldman/node-test-runner`?  `elm-test-rs`? (edit: I've found that the tests are really finicky with what crashes and what doesn't, maybe it's not worth it).

After playing around more, I found more exercises with a stub that makes the test runner crash, it's kind of finicky. In one case, it was a variable name shadowing, in another the functions needed to have the arguments, I fixed those.

There are still 3 exercises that make the test runner crash: `custom-set`, `grade-school` and `zebra-puzzle`. I've decided not to address these:
- for `custom-set` and `grade-school` the problem is the first function: `empty` (for some reason). But since this is the very first function the student would create, it's not much of an issue.
- for zebra-puzzle`, the problem may be that `drinksWater` and `ownsZebra` are constants? I don't know. But there are no real tests in that exercise anyway, so it doesn't matter

Also lots of concept exercises don't compile, but that's on purpose because the types need to be defined.