### PR TITLE
Update casing for partial-application-composition name

### DIFF
--- a/config.json
+++ b/config.json
@@ -1151,7 +1151,7 @@
     {
       "uuid": "3fde0ff5-d603-4f40-a7e3-a4ea2707af90",
       "slug": "partial-application-composition",
-      "name": "Partial application and function composition"
+      "name": "Partial Application and Function Composition"
     },
     {
       "uuid": "a5339d63-c63a-491b-996b-6666a2bdea99",


### PR DESCRIPTION
The other concepts with multiple words in the name are in Capitalized Case like "Pattern Matching", "Opaque Types", "Phantom Types", and so on. As a result, this concept sticks out weirdly when viewing the syllabus.