### PR TITLE
Add practice exercise `rest-api`

### DIFF
--- a/config.json
+++ b/config.json
@@ -1111,6 +1111,21 @@
           "random"
         ],
         "difficulty": 4
+      },
+      {
+        "slug": "rest-api",
+        "name": "REST API",
+        "uuid": "98b75220-b8bb-488b-9339-a3972f040c21",
+        "practices": [],
+        "prerequisites": [
+          "lists",
+          "comparison",
+          "dict",
+          "records",
+          "maybe",
+          "result"
+        ],
+        "difficulty": 8
       }
     ]
   },

--- a/exercises/practice/rest-api/.docs/instructions.md
+++ b/exercises/practice/rest-api/.docs/instructions.md
@@ -1,0 +1,48 @@
+# Instructions
+
+Implement a RESTful API for tracking IOUs.
+
+Four roommates have a habit of borrowing money from each other frequently, and have trouble remembering who owes whom, and how much.
+
+Your task is to implement a simple [RESTful API][restful-wikipedia] that receives [IOU][iou]s as POST requests, and can deliver specified summary information via GET requests.
+
+## API Specification
+
+### User object
+
+```json
+{
+  "name": "Adam",
+  "owes": {
+    "Bob": 12.0,
+    "Chuck": 4.0,
+    "Dan": 9.5
+  },
+  "owed_by": {
+    "Bob": 6.5,
+    "Dan": 2.75
+  },
+  "balance": "<(total owed by other users) - (total owed to other users)>"
+}
+```
+
+### Methods
+
+| Description              | HTTP Method | URL    | Payload Format                                                            | Response w/o Payload                   | Response w/ Payload                                                             |
+| ------------------------ | ----------- | ------ | ------------------------------------------------------------------------- | -------------------------------------- | ------------------------------------------------------------------------------- |
+| List of user information | GET         | /users | `{"users":["Adam","Bob"]}`                                                | `{"users":<List of all User objects>}` | `{"users":<List of User objects for <users> (sorted by name)}`                  |
+| Create user              | POST        | /add   | `{"user":<name of new user (unique)>}`                                    | N/A                                    | `<User object for new user>`                                                    |
+| Create IOU               | POST        | /iou   | `{"lender":<name of lender>,"borrower":<name of borrower>,"amount":5.25}` | N/A                                    | `{"users":<updated User objects for <lender> and <borrower> (sorted by name)>}` |
+
+## Other Resources
+
+- [REST API Tutorial][restfulapi]
+- Example RESTful APIs
+  - [GitHub][github-rest]
+  - [Reddit][reddit-rest]
+
+[restful-wikipedia]: https://en.wikipedia.org/wiki/Representational_state_transfer
+[iou]: https://en.wikipedia.org/wiki/IOU
+[github-rest]: https://developer.github.com/v3/
+[reddit-rest]: https://www.reddit.com/dev/api/
+[restfulapi]: https://restfulapi.net/

--- a/exercises/practice/rest-api/.meta/config.json
+++ b/exercises/practice/rest-api/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [
+    "jiegillet"
+  ],
+  "files": {
+    "solution": [
+      "src/RestApi.elm"
+    ],
+    "test": [
+      "tests/Tests.elm"
+    ],
+    "example": [
+      ".meta/src/RestApi.example.elm"
+    ]
+  },
+  "blurb": "Implement a RESTful API for tracking IOUs."
+}

--- a/exercises/practice/rest-api/.meta/src/RestApi.example.elm
+++ b/exercises/practice/rest-api/.meta/src/RestApi.example.elm
@@ -1,0 +1,187 @@
+module RestApi exposing (buildDatabase, get, post)
+
+import Dict exposing (Dict)
+import Json.Decode as Decode exposing (Decoder, Error)
+import Json.Encode as Encode exposing (Value)
+
+
+type alias Name =
+    String
+
+
+type alias User =
+    { name : Name
+    , owes : Dict Name Int
+    , owedBy : Dict Name Int
+    , balance : Int
+    }
+
+
+type alias IOU =
+    { lender : Name, borrower : Name, amount : Int }
+
+
+type alias Database =
+    Dict Name User
+
+
+type PostPayload
+    = NewUser User
+    | NewIOU IOU
+
+
+buildDatabase : String -> Result Error Database
+buildDatabase =
+    Decode.decodeString databaseD
+
+
+get : Database -> String -> Maybe String -> String
+get database url maybePayload =
+    case ( url, Maybe.map (Decode.decodeString getPayloadD) maybePayload ) of
+        ( "/users", Nothing ) ->
+            Encode.encode 0 (encodeDatabase database)
+
+        ( "/users", Just (Ok names) ) ->
+            database
+                |> Dict.filter (\name _ -> List.member name names)
+                |> encodeDatabase
+                |> Encode.encode 0
+
+        _ ->
+            "error"
+
+
+post : Database -> String -> String -> String
+post database url payload =
+    case ( url, Decode.decodeString postPayloadD payload ) of
+        ( "/add", Ok (NewUser user) ) ->
+            Encode.encode 0 (encodeUser user)
+
+        ( "/iou", Ok (NewIOU ({ lender, borrower } as iou)) ) ->
+            database
+                |> addIOU iou
+                |> Dict.filter (\name _ -> List.member name [ lender, borrower ])
+                |> encodeDatabase
+                |> Encode.encode 0
+
+        _ ->
+            "error"
+
+
+newUser : Name -> User
+newUser name =
+    User name Dict.empty Dict.empty 0
+
+
+addIOU : IOU -> Database -> Database
+addIOU { lender, borrower, amount } database =
+    let
+        addCredit user =
+            { user
+                | owedBy = Dict.update borrower increaseAmount user.owedBy
+                , balance = user.balance + amount
+            }
+
+        addDebt user =
+            { user
+                | owes = Dict.update lender increaseAmount user.owes
+                , balance = user.balance - amount
+            }
+
+        increaseAmount =
+            Maybe.withDefault 0 >> (+) amount >> Just
+
+        normalize user =
+            let
+                ignore _ _ =
+                    identity
+
+                keepDifference name a b =
+                    case compare a b of
+                        GT ->
+                            Dict.insert name (a - b)
+
+                        _ ->
+                            identity
+
+                owes =
+                    Dict.merge Dict.insert keepDifference ignore user.owes user.owedBy Dict.empty
+
+                owedBy =
+                    Dict.merge Dict.insert keepDifference ignore user.owedBy user.owes Dict.empty
+            in
+            { user | owes = owes, owedBy = owedBy }
+    in
+    database
+        |> Dict.update lender (Maybe.withDefault (newUser lender) >> addCredit >> normalize >> Just)
+        |> Dict.update borrower (Maybe.withDefault (newUser borrower) >> addDebt >> normalize >> Just)
+
+
+
+-- DECODERS
+
+
+databaseD : Decoder Database
+databaseD =
+    userD
+        |> Decode.list
+        |> Decode.field "users"
+        |> Decode.map
+            (List.map (\user -> ( user.name, user ))
+                >> Dict.fromList
+            )
+
+
+userD : Decoder User
+userD =
+    Decode.map4 User
+        (Decode.field "name" Decode.string)
+        (Decode.field "owes" (Decode.dict Decode.int))
+        (Decode.field "owed_by" (Decode.dict Decode.int))
+        (Decode.field "balance" Decode.int)
+
+
+getPayloadD : Decoder (List Name)
+getPayloadD =
+    Decode.list Decode.string |> Decode.field "users"
+
+
+postPayloadD : Decoder PostPayload
+postPayloadD =
+    Decode.oneOf [ newUserD, newIOUD ]
+
+
+newUserD : Decoder PostPayload
+newUserD =
+    Decode.field "user" Decode.string
+        |> Decode.map (\name -> NewUser (newUser name))
+
+
+newIOUD : Decoder PostPayload
+newIOUD =
+    Decode.map3 IOU
+        (Decode.field "lender" Decode.string)
+        (Decode.field "borrower" Decode.string)
+        (Decode.field "amount" Decode.int)
+        |> Decode.map NewIOU
+
+
+
+-- ENCODERS
+
+
+encodeDatabase : Database -> Value
+encodeDatabase database =
+    Encode.object
+        [ ( "users", database |> Dict.toList |> Encode.list (Tuple.second >> encodeUser) )
+        ]
+
+
+encodeUser : User -> Value
+encodeUser { name, owes, owedBy, balance } =
+    Encode.object
+        [ ( "name", Encode.string name )
+        , ( "owes", Encode.dict identity Encode.int owes )
+        , ( "owed_by", Encode.dict identity Encode.int owedBy )
+        , ( "balance", Encode.int balance )
+        ]

--- a/exercises/practice/rest-api/.meta/src/RestApi.example.elm
+++ b/exercises/practice/rest-api/.meta/src/RestApi.example.elm
@@ -1,8 +1,12 @@
-module RestApi exposing (buildDatabase, get, post)
+module RestApi exposing (databaseFromJsonString, get, post)
 
 import Dict exposing (Dict)
 import Json.Decode as Decode exposing (Decoder, Error)
 import Json.Encode as Encode exposing (Value)
+
+
+type alias JsonString =
+    String
 
 
 type alias Name =
@@ -30,12 +34,12 @@ type PostPayload
     | NewIOU IOU
 
 
-buildDatabase : String -> Result Error Database
-buildDatabase =
+databaseFromJsonString : JsonString -> Result Error Database
+databaseFromJsonString =
     Decode.decodeString databaseDecoder
 
 
-get : Database -> String -> Maybe String -> String
+get : Database -> String -> Maybe JsonString -> JsonString
 get database url maybePayload =
     case ( url, Maybe.map (Decode.decodeString getPayloadDecoder) maybePayload ) of
         ( "/users", Nothing ) ->
@@ -51,7 +55,7 @@ get database url maybePayload =
             "error"
 
 
-post : Database -> String -> String -> String
+post : Database -> String -> JsonString -> JsonString
 post database url payload =
     case ( url, Decode.decodeString postPayloadDecoder payload ) of
         ( "/add", Ok (NewUser user) ) ->

--- a/exercises/practice/rest-api/.meta/tests.toml
+++ b/exercises/practice/rest-api/.meta/tests.toml
@@ -1,0 +1,37 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[5be01ffb-a814-47a8-a19f-490a5622ba07]
+description = "user management -> no users"
+
+[382b70cc-9f6c-486d-9bee-fda2df81c803]
+description = "user management -> add user"
+
+[d624e5e5-1abb-4f18-95b3-45d55c818dc3]
+description = "user management -> get single user"
+
+[7a81b82c-7276-433e-8fce-29ce983a7c56]
+description = "iou -> both users have 0 balance"
+
+[1c61f957-cf8c-48ba-9e77-b221ab068803]
+description = "iou -> borrower has negative balance"
+
+[8a8567b3-c097-468a-9541-6bb17d5afc85]
+description = "iou -> lender has negative balance"
+
+[29fb7c12-7099-4a85-a7c4-9c290d2dc01a]
+description = "iou -> lender owes borrower"
+
+[ce969e70-163c-4135-a4a6-2c3a5da286f5]
+description = "iou -> lender owes borrower less than new loan"
+
+[7f4aafd9-ae9b-4e15-a406-87a87bdf47a4]
+description = "iou -> lender owes borrower same as new loan"

--- a/exercises/practice/rest-api/elm.json
+++ b/exercises/practice/rest-api/elm.json
@@ -1,0 +1,29 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0"
+        },
+        "indirect": {}
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/html": "1.0.0",
+            "elm/virtual-dom": "1.0.3"
+        }
+    }
+}

--- a/exercises/practice/rest-api/src/RestApi.elm
+++ b/exercises/practice/rest-api/src/RestApi.elm
@@ -1,8 +1,12 @@
-module RestApi exposing (buildDatabase, get, post)
+module RestApi exposing (databaseFromJsonString, get, post)
 
 import Dict exposing (Dict)
 import Json.Decode exposing (Error)
 import Json.Encode
+
+
+type alias JsonString =
+    String
 
 
 type alias Name =
@@ -21,16 +25,16 @@ type alias Database =
     Dict Name User
 
 
-buildDatabase : String -> Result Error Database
-buildDatabase payload =
-    Debug.todo "Please implement buildDatabase"
+databaseFromJsonString : JsonString -> Result Error Database
+databaseFromJsonString payload =
+    Debug.todo "Please implement databaseFromJsonString"
 
 
-get : Database -> String -> Maybe String -> String
+get : Database -> String -> Maybe JsonString -> JsonString
 get database url maybePayload =
     Debug.todo "Please implement get"
 
 
-post : Database -> String -> String -> String
+post : Database -> String -> JsonString -> JsonString
 post database url payload =
     Debug.todo "Please implement post"

--- a/exercises/practice/rest-api/src/RestApi.elm
+++ b/exercises/practice/rest-api/src/RestApi.elm
@@ -1,0 +1,36 @@
+module RestApi exposing (buildDatabase, get, post)
+
+import Dict exposing (Dict)
+import Json.Decode exposing (Error)
+import Json.Encode
+
+
+type alias Name =
+    String
+
+
+type alias User =
+    { name : Name
+    , owes : Dict Name Int
+    , owedBy : Dict Name Int
+    , balance : Int
+    }
+
+
+type alias Database =
+    Dict Name User
+
+
+buildDatabase : String -> Result Error Database
+buildDatabase payload =
+    Debug.todo "Please implement buildDatabase"
+
+
+get : Database -> String -> Maybe String -> String
+get database url maybePayload =
+    Debug.todo "Please implement get"
+
+
+post : Database -> String -> String -> String
+post database url payload =
+    Debug.todo "Please implement post"

--- a/exercises/practice/rest-api/tests/Tests.elm
+++ b/exercises/practice/rest-api/tests/Tests.elm
@@ -13,7 +13,7 @@ tests =
             [ -- skip <|
               test "no users" <|
                 \() ->
-                    case RestApi.buildDatabase "{\"users\":[]}" of
+                    case RestApi.databaseFromJsonString "{\"users\":[]}" of
                         Err error ->
                             Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
 
@@ -23,7 +23,7 @@ tests =
             , skip <|
                 test "add user" <|
                     \() ->
-                        case RestApi.buildDatabase "{\"users\":[]}" of
+                        case RestApi.databaseFromJsonString "{\"users\":[]}" of
                             Err error ->
                                 Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
 
@@ -33,7 +33,7 @@ tests =
             , skip <|
                 test "get single user" <|
                     \() ->
-                        case RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0}]}" of
+                        case RestApi.databaseFromJsonString "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0}]}" of
                             Err error ->
                                 Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
 
@@ -45,7 +45,7 @@ tests =
             [ skip <|
                 test "both users have 0 balance" <|
                     \() ->
-                        case RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0}]}" of
+                        case RestApi.databaseFromJsonString "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0}]}" of
                             Err error ->
                                 Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
 
@@ -56,7 +56,7 @@ tests =
                 test "borrower has negative balance" <|
                     \() ->
                         case
-                            RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Chuck\",\"owes\":{},\"owed_by\":{\"Bob\":3},\"balance\":3}]}"
+                            RestApi.databaseFromJsonString "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Chuck\",\"owes\":{},\"owed_by\":{\"Bob\":3},\"balance\":3}]}"
                         of
                             Err error ->
                                 Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
@@ -67,7 +67,7 @@ tests =
             , skip <|
                 test "lender has negative balance" <|
                     \() ->
-                        case RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Chuck\",\"owes\":{},\"owed_by\":{\"Bob\":3},\"balance\":3}]}" of
+                        case RestApi.databaseFromJsonString "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Chuck\",\"owes\":{},\"owed_by\":{\"Bob\":3},\"balance\":3}]}" of
                             Err error ->
                                 Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
 
@@ -77,7 +77,7 @@ tests =
             , skip <|
                 test "lender owes borrower" <|
                     \() ->
-                        case RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3},\"balance\":3}]}" of
+                        case RestApi.databaseFromJsonString "{\"users\":[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3},\"balance\":3}]}" of
                             Err error ->
                                 Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
 
@@ -87,7 +87,7 @@ tests =
             , skip <|
                 test "lender owes borrower less than new loan" <|
                     \() ->
-                        case RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3},\"balance\":3}]}" of
+                        case RestApi.databaseFromJsonString "{\"users\":[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3},\"balance\":3}]}" of
                             Err error ->
                                 Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
 
@@ -97,7 +97,7 @@ tests =
             , skip <|
                 test "lender owes borrower same as new loan" <|
                     \() ->
-                        case RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3},\"balance\":3}]}" of
+                        case RestApi.databaseFromJsonString "{\"users\":[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3},\"balance\":3}]}" of
                             Err error ->
                                 Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
 

--- a/exercises/practice/rest-api/tests/Tests.elm
+++ b/exercises/practice/rest-api/tests/Tests.elm
@@ -1,0 +1,108 @@
+module Tests exposing (tests)
+
+import Expect
+import Json.Decode as Decode
+import RestApi
+import Test exposing (Test, describe, skip, test)
+
+
+tests : Test
+tests =
+    describe "RestApi"
+        [ describe "user management"
+            [ -- skip <|
+              test "no users" <|
+                \() ->
+                    case RestApi.buildDatabase "{\"users\":[]}" of
+                        Err error ->
+                            Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
+
+                        Ok database ->
+                            RestApi.get database "/users" Nothing
+                                |> Expect.equal "{\"users\":[]}"
+            , skip <|
+                test "add user" <|
+                    \() ->
+                        case RestApi.buildDatabase "{\"users\":[]}" of
+                            Err error ->
+                                Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
+
+                            Ok database ->
+                                RestApi.post database "/add" "{\"user\":\"Adam\"}"
+                                    |> Expect.equal "{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0}"
+            , skip <|
+                test "get single user" <|
+                    \() ->
+                        case RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0}]}" of
+                            Err error ->
+                                Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
+
+                            Ok database ->
+                                RestApi.get database "/users" (Just "{\"users\":[\"Bob\"]}")
+                                    |> Expect.equal "{\"users\":[{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0}]}"
+            ]
+        , describe "iou"
+            [ skip <|
+                test "both users have 0 balance" <|
+                    \() ->
+                        case RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0}]}" of
+                            Err error ->
+                                Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
+
+                            Ok database ->
+                                RestApi.post database "/iou" "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":3}"
+                                    |> Expect.equal "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{\"Bob\":3},\"balance\":3},{\"name\":\"Bob\",\"owes\":{\"Adam\":3},\"owed_by\":{},\"balance\":-3}]}"
+            , skip <|
+                test "borrower has negative balance" <|
+                    \() ->
+                        case
+                            RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Chuck\",\"owes\":{},\"owed_by\":{\"Bob\":3},\"balance\":3}]}"
+                        of
+                            Err error ->
+                                Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
+
+                            Ok database ->
+                                RestApi.post database "/iou" "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":3}"
+                                    |> Expect.equal "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{\"Bob\":3},\"balance\":3},{\"name\":\"Bob\",\"owes\":{\"Adam\":3,\"Chuck\":3},\"owed_by\":{},\"balance\":-6}]}"
+            , skip <|
+                test "lender has negative balance" <|
+                    \() ->
+                        case RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Chuck\",\"owes\":{},\"owed_by\":{\"Bob\":3},\"balance\":3}]}" of
+                            Err error ->
+                                Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
+
+                            Ok database ->
+                                RestApi.post database "/iou" "{\"lender\":\"Bob\",\"borrower\":\"Adam\",\"amount\":3}"
+                                    |> Expect.equal "{\"users\":[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{\"Chuck\":3},\"owed_by\":{\"Adam\":3},\"balance\":0}]}"
+            , skip <|
+                test "lender owes borrower" <|
+                    \() ->
+                        case RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3},\"balance\":3}]}" of
+                            Err error ->
+                                Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
+
+                            Ok database ->
+                                RestApi.post database "/iou" "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":2}"
+                                    |> Expect.equal "{\"users\":[{\"name\":\"Adam\",\"owes\":{\"Bob\":1},\"owed_by\":{},\"balance\":-1},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":1},\"balance\":1}]}"
+            , skip <|
+                test "lender owes borrower less than new loan" <|
+                    \() ->
+                        case RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3},\"balance\":3}]}" of
+                            Err error ->
+                                Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
+
+                            Ok database ->
+                                RestApi.post database "/iou" "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":4}"
+                                    |> Expect.equal "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{\"Bob\":1},\"balance\":1},{\"name\":\"Bob\",\"owes\":{\"Adam\":1},\"owed_by\":{},\"balance\":-1}]}"
+            , skip <|
+                test "lender owes borrower same as new loan" <|
+                    \() ->
+                        case RestApi.buildDatabase "{\"users\":[{\"name\":\"Adam\",\"owes\":{\"Bob\":3},\"owed_by\":{},\"balance\":-3},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{\"Adam\":3},\"balance\":3}]}" of
+                            Err error ->
+                                Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)
+
+                            Ok database ->
+                                RestApi.post database "/iou" "{\"lender\":\"Adam\",\"borrower\":\"Bob\",\"amount\":3}"
+                                    |> Expect.equal "{\"users\":[{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0},{\"name\":\"Bob\",\"owes\":{},\"owed_by\":{},\"balance\":0}]}"
+            ]
+        ]


### PR DESCRIPTION
I'm now thinking about the `json` concept, and this is the most suitable practice exercise for it, maybe even the suitable one? I'm sure we could engineer some other to use JSON as raw data, I don't know.

I quite like my solution, it's pretty clean, but I don't really know about the general API. The description in problem-specs itself is pretty vague about it. Right now what I have is
```elm
  case RestApi.buildDatabase "{\"users\":[]}" of
      Err error ->
          Expect.fail ("== Database payload could not be parsed ==\n" ++ Decode.errorToString error)

      Ok database ->
          RestApi.post database "/add" "{\"user\":\"Adam\"}"
              |> Expect.equal "{\"name\":\"Adam\",\"owes\":{},\"owed_by\":{},\"balance\":0}"
```
I'm feeding the raw JSON into `buildDatabase` in one step, check if that worked, and then use `post`. I did this so that the parsing for the database could be done separately. 
Ideally the "server" would keep the database in an internal state, but it can't work in Elm.
Anyway, I'm happy for some feedback on that API.

This will require an analyzer check to encourage students to use `Json.Decode` and `Json.Encode`, because technically they could do it without.