### PR TITLE
Disable representer

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,7 +5,7 @@
   "status": {
     "concept_exercises": true,
     "test_runner": true,
-    "representer": true,
+    "representer": false,
     "analyzer": true
   },
   "blurb": "Elm is a friendly functional language for the Web",


### PR DESCRIPTION
The elm representer is 500ing. This is now critical as it stops community solutions from showing. I'm disabling this and rolling back to the general default representer for this track.