### PR TITLE
Updates prerequisites for exercises

### DIFF
--- a/config.json
+++ b/config.json
@@ -346,7 +346,9 @@
         "slug": "hello-world",
         "name": "Hello World",
         "uuid": "2c3902df-93e1-48d1-829d-4daa93a1f06f",
-        "practices": ["strings"],
+        "practices": [
+          "strings"
+        ],
         "prerequisites": [],
         "difficulty": 1,
         "topics": [
@@ -357,8 +359,12 @@
         "slug": "two-fer",
         "name": "Two Fer",
         "uuid": "0118175a-761f-4d05-8857-fe93745f490f",
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 1,
         "topics": [
           "strings"
@@ -368,8 +374,12 @@
         "slug": "bob",
         "name": "Bob",
         "uuid": "11ce2a73-3f43-4b14-b755-6c52dc71bdda",
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 1,
         "topics": [
           "conditionals",
@@ -461,8 +471,12 @@
         "slug": "raindrops",
         "name": "Raindrops",
         "uuid": "e3e73171-c3d1-49f7-9511-d1f4a08e7a69",
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 2,
         "topics": [
           "filtering",
@@ -474,8 +488,12 @@
         "slug": "robot-simulator",
         "name": "Robot Simulator",
         "uuid": "6b8f952e-94ea-4264-accf-cdb28b3b4529",
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 3,
         "topics": [
           "records",
@@ -500,8 +518,12 @@
         "slug": "hamming",
         "name": "Hamming",
         "uuid": "472c2e13-6608-4862-b884-a7e458e0bcdd",
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 2,
         "topics": [
           "filtering",
@@ -512,8 +534,12 @@
         "slug": "pangram",
         "name": "Pangram",
         "uuid": "a70503ba-f1f3-4583-9226-c3ada98e9500",
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 2,
         "topics": [
           "booleans",
@@ -554,8 +580,12 @@
         "slug": "twelve-days",
         "name": "Twelve Days",
         "uuid": "50770287-c734-46ba-b3a1-c36d31b6cc3c",
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 4,
         "topics": [
           "conditionals",
@@ -567,8 +597,12 @@
         "slug": "acronym",
         "name": "Acronym",
         "uuid": "851ddd78-13a0-4d8f-adda-41abde670687",
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 4,
         "topics": [
           "strings",
@@ -800,8 +834,12 @@
         "slug": "nucleotide-count",
         "name": "Nucleotide Count",
         "uuid": "c9e00708-3d18-4a0b-a3de-cae4d979a981",
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 2,
         "topics": [
           "maps",
@@ -812,8 +850,12 @@
         "slug": "word-count",
         "name": "Word Count",
         "uuid": "9c9507a6-8187-4ce6-b0bc-b4765effb74c",
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 4,
         "topics": [
           "maps",
@@ -942,8 +984,12 @@
         "slug": "run-length-encoding",
         "name": "Run-Length Encoding",
         "uuid": "0b2ac079-f7ed-4e90-a566-00c9fe0d5c88",
-        "practices": ["strings"],
-        "prerequisites": ["strings"],
+        "practices": [
+          "strings"
+        ],
+        "prerequisites": [
+          "strings"
+        ],
         "difficulty": 5,
         "topics": [
           "algorithms",

--- a/config.json
+++ b/config.json
@@ -350,10 +350,7 @@
           "strings"
         ],
         "prerequisites": [],
-        "difficulty": 1,
-        "topics": [
-          "strings"
-        ]
+        "difficulty": 1
       },
       {
         "slug": "two-fer",
@@ -365,10 +362,7 @@
         "prerequisites": [
           "strings"
         ],
-        "difficulty": 1,
-        "topics": [
-          "strings"
-        ]
+        "difficulty": 1
       },
       {
         "slug": "bob",
@@ -383,7 +377,6 @@
         "difficulty": 1,
         "topics": [
           "conditionals",
-          "strings",
           "text_formatting"
         ]
       },
@@ -480,8 +473,7 @@
         "difficulty": 2,
         "topics": [
           "filtering",
-          "text_formatting",
-          "strings"
+          "text_formatting"
         ]
       },
       {
@@ -497,8 +489,7 @@
         "difficulty": 3,
         "topics": [
           "records",
-          "tuples",
-          "strings"
+          "tuples"
         ]
       },
       {
@@ -526,8 +517,7 @@
         ],
         "difficulty": 2,
         "topics": [
-          "filtering",
-          "strings"
+          "filtering"
         ]
       },
       {
@@ -542,8 +532,7 @@
         ],
         "difficulty": 2,
         "topics": [
-          "booleans",
-          "strings"
+          "booleans"
         ]
       },
       {
@@ -560,8 +549,7 @@
         ],
         "difficulty": 3,
         "topics": [
-          "filtering",
-          "strings"
+          "filtering"
         ]
       },
       {
@@ -589,7 +577,6 @@
         "difficulty": 4,
         "topics": [
           "conditionals",
-          "strings",
           "text_formatting"
         ]
       },
@@ -605,7 +592,6 @@
         ],
         "difficulty": 4,
         "topics": [
-          "strings",
           "transforming"
         ]
       },
@@ -623,8 +609,7 @@
         ],
         "difficulty": 4,
         "topics": [
-          "filtering",
-          "strings"
+          "filtering"
         ]
       },
       {
@@ -636,7 +621,6 @@
         "difficulty": 4,
         "topics": [
           "lists",
-          "strings",
           "transforming"
         ]
       },
@@ -657,7 +641,6 @@
         "difficulty": 5,
         "topics": [
           "algorithms",
-          "strings",
           "transforming"
         ]
       },
@@ -670,7 +653,6 @@
         "difficulty": 5,
         "topics": [
           "algorithms",
-          "strings",
           "transforming"
         ]
       },
@@ -714,7 +696,6 @@
         "topics": [
           "integers",
           "math",
-          "strings",
           "transforming"
         ]
       },
@@ -842,8 +823,7 @@
         ],
         "difficulty": 2,
         "topics": [
-          "maps",
-          "strings"
+          "maps"
         ]
       },
       {
@@ -859,7 +839,6 @@
         "difficulty": 4,
         "topics": [
           "maps",
-          "strings",
           "transforming"
         ]
       },
@@ -889,7 +868,6 @@
         ],
         "difficulty": 8,
         "topics": [
-          "strings",
           "text_formatting",
           "transforming"
         ]
@@ -944,7 +922,6 @@
         ],
         "difficulty": 1,
         "topics": [
-          "strings",
           "transforming"
         ]
       },
@@ -962,7 +939,6 @@
         ],
         "difficulty": 3,
         "topics": [
-          "strings",
           "integers",
           "lists",
           "algorithms",
@@ -993,8 +969,7 @@
         "difficulty": 5,
         "topics": [
           "algorithms",
-          "transforming",
-          "strings"
+          "transforming"
         ]
       },
       {
@@ -1025,8 +1000,7 @@
         "difficulty": 7,
         "topics": [
           "parsing",
-          "stacks",
-          "strings"
+          "stacks"
         ]
       },
       {

--- a/config.json
+++ b/config.json
@@ -346,9 +346,7 @@
         "slug": "hello-world",
         "name": "Hello World",
         "uuid": "2c3902df-93e1-48d1-829d-4daa93a1f06f",
-        "practices": [
-          "strings"
-        ],
+        "practices": [],
         "prerequisites": [],
         "difficulty": 1
       },

--- a/config.json
+++ b/config.json
@@ -186,6 +186,7 @@
           "booleans",
           "maybe",
           "lists",
+          "strings",
           "partial-application-composition"
         ],
         "status": "beta"
@@ -204,6 +205,7 @@
           "lists",
           "records",
           "result",
+          "strings",
           "partial-application-composition"
         ],
         "status": "beta"
@@ -218,7 +220,8 @@
         "prerequisites": [
           "basics-1",
           "basics-2",
-          "let"
+          "let",
+          "strings"
         ]
       },
       {
@@ -343,7 +346,7 @@
         "slug": "hello-world",
         "name": "Hello World",
         "uuid": "2c3902df-93e1-48d1-829d-4daa93a1f06f",
-        "practices": [],
+        "practices": ["strings"],
         "prerequisites": [],
         "difficulty": 1,
         "topics": [
@@ -354,8 +357,8 @@
         "slug": "two-fer",
         "name": "Two Fer",
         "uuid": "0118175a-761f-4d05-8857-fe93745f490f",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["strings"],
+        "prerequisites": ["strings"],
         "difficulty": 1,
         "topics": [
           "strings"
@@ -365,8 +368,8 @@
         "slug": "bob",
         "name": "Bob",
         "uuid": "11ce2a73-3f43-4b14-b755-6c52dc71bdda",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["strings"],
+        "prerequisites": ["strings"],
         "difficulty": 1,
         "topics": [
           "conditionals",
@@ -458,24 +461,26 @@
         "slug": "raindrops",
         "name": "Raindrops",
         "uuid": "e3e73171-c3d1-49f7-9511-d1f4a08e7a69",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["strings"],
+        "prerequisites": ["strings"],
         "difficulty": 2,
         "topics": [
           "filtering",
-          "text_formatting"
+          "text_formatting",
+          "strings"
         ]
       },
       {
         "slug": "robot-simulator",
         "name": "Robot Simulator",
         "uuid": "6b8f952e-94ea-4264-accf-cdb28b3b4529",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["strings"],
+        "prerequisites": ["strings"],
         "difficulty": 3,
         "topics": [
           "records",
-          "tuples"
+          "tuples",
+          "strings"
         ]
       },
       {
@@ -495,8 +500,8 @@
         "slug": "hamming",
         "name": "Hamming",
         "uuid": "472c2e13-6608-4862-b884-a7e458e0bcdd",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["strings"],
+        "prerequisites": ["strings"],
         "difficulty": 2,
         "topics": [
           "filtering",
@@ -507,8 +512,8 @@
         "slug": "pangram",
         "name": "Pangram",
         "uuid": "a70503ba-f1f3-4583-9226-c3ada98e9500",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["strings"],
+        "prerequisites": ["strings"],
         "difficulty": 2,
         "topics": [
           "booleans",
@@ -520,10 +525,12 @@
         "name": "Isogram",
         "uuid": "61ef49ef-1086-445b-aa0a-b99de263b728",
         "practices": [
-          "comparison"
+          "comparison",
+          "strings"
         ],
         "prerequisites": [
-          "booleans"
+          "booleans",
+          "strings"
         ],
         "difficulty": 3,
         "topics": [
@@ -547,8 +554,8 @@
         "slug": "twelve-days",
         "name": "Twelve Days",
         "uuid": "50770287-c734-46ba-b3a1-c36d31b6cc3c",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["strings"],
+        "prerequisites": ["strings"],
         "difficulty": 4,
         "topics": [
           "conditionals",
@@ -560,8 +567,8 @@
         "slug": "acronym",
         "name": "Acronym",
         "uuid": "851ddd78-13a0-4d8f-adda-41abde670687",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["strings"],
+        "prerequisites": ["strings"],
         "difficulty": 4,
         "topics": [
           "strings",
@@ -573,10 +580,12 @@
         "name": "Anagram",
         "uuid": "5845a108-d8b2-41dd-b371-cf9eff7a2230",
         "practices": [
-          "comparison"
+          "comparison",
+          "strings"
         ],
         "prerequisites": [
-          "lists"
+          "lists",
+          "strings"
         ],
         "difficulty": 4,
         "topics": [
@@ -601,8 +610,16 @@
         "slug": "atbash-cipher",
         "name": "Atbash Cipher",
         "uuid": "8322872b-e020-4a9e-9206-015c0fdacb62",
-        "practices": [],
-        "prerequisites": [],
+        "practices": [
+          "dict",
+          "tuples",
+          "strings"
+        ],
+        "prerequisites": [
+          "dict",
+          "tuples",
+          "strings"
+        ],
         "difficulty": 5,
         "topics": [
           "algorithms",
@@ -651,8 +668,14 @@
         "slug": "largest-series-product",
         "name": "Largest Series Product",
         "uuid": "1902d726-5a62-475b-b7d3-7188a50e717f",
-        "practices": [],
-        "prerequisites": [],
+        "practices": [
+          "strings",
+          "lists"
+        ],
+        "prerequisites": [
+          "strings",
+          "lists"
+        ],
         "difficulty": 4,
         "topics": [
           "integers",
@@ -777,8 +800,8 @@
         "slug": "nucleotide-count",
         "name": "Nucleotide Count",
         "uuid": "c9e00708-3d18-4a0b-a3de-cae4d979a981",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["strings"],
+        "prerequisites": ["strings"],
         "difficulty": 2,
         "topics": [
           "maps",
@@ -789,8 +812,8 @@
         "slug": "word-count",
         "name": "Word Count",
         "uuid": "9c9507a6-8187-4ce6-b0bc-b4765effb74c",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["strings"],
+        "prerequisites": ["strings"],
         "difficulty": 4,
         "topics": [
           "maps",
@@ -815,9 +838,13 @@
         "name": "Say",
         "uuid": "ea41b90d-3ff5-43c0-94e5-6b436feb99e5",
         "practices": [
-          "array"
+          "array",
+          "strings"
         ],
-        "prerequisites": [],
+        "prerequisites": [
+          "array",
+          "strings"
+        ],
         "difficulty": 8,
         "topics": [
           "strings",
@@ -865,8 +892,14 @@
         "slug": "rna-transcription",
         "name": "RNA Transcription",
         "uuid": "3af96d19-87d7-4d8b-aecb-f63122815501",
-        "practices": [],
-        "prerequisites": [],
+        "practices": [
+          "strings",
+          "result"
+        ],
+        "prerequisites": [
+          "strings",
+          "result"
+        ],
         "difficulty": 1,
         "topics": [
           "strings",
@@ -877,8 +910,14 @@
         "slug": "armstrong-numbers",
         "name": "Armstrong Numbers",
         "uuid": "2a71bafa-87ac-4f36-ba45-a1b24dcca67a",
-        "practices": [],
-        "prerequisites": [],
+        "practices": [
+          "strings",
+          "lists"
+        ],
+        "prerequisites": [
+          "strings",
+          "lists"
+        ],
         "difficulty": 3,
         "topics": [
           "strings",
@@ -903,12 +942,13 @@
         "slug": "run-length-encoding",
         "name": "Run-Length Encoding",
         "uuid": "0b2ac079-f7ed-4e90-a566-00c9fe0d5c88",
-        "practices": [],
-        "prerequisites": [],
+        "practices": ["strings"],
+        "prerequisites": ["strings"],
         "difficulty": 5,
         "topics": [
           "algorithms",
-          "transforming"
+          "transforming",
+          "strings"
         ]
       },
       {
@@ -926,12 +966,21 @@
         "slug": "matching-brackets",
         "name": "Matching Brackets",
         "uuid": "5b2f0983-6feb-4329-aff2-d822274a9882",
-        "practices": [],
-        "prerequisites": [],
+        "practices": [
+          "dict",
+          "lists",
+          "strings"
+        ],
+        "prerequisites": [
+          "dict",
+          "lists",
+          "strings"
+        ],
         "difficulty": 7,
         "topics": [
           "parsing",
-          "stacks"
+          "stacks",
+          "strings"
         ]
       },
       {
@@ -1103,7 +1152,8 @@
         "name": "Simple Cipher",
         "uuid": "49a3d9b1-38bd-464b-9d8b-4c603d351f55",
         "practices": [
-          "random"
+          "random",
+          "strings"
         ],
         "prerequisites": [
           "lists",

--- a/exercises/concept/bettys-bike-shop/.docs/instructions.md
+++ b/exercises/concept/bettys-bike-shop/.docs/instructions.md
@@ -26,6 +26,7 @@ penceToPounds 106
 
 Since Betty's bikes are sold in pounds, prices should be displayed with the symbol "£".
 Your second task is thus to implement the `poundsToString` function, taking an amount of pounds as a `Float` and returning its price displayed as a `String` with the pound symbol prepended.
+The `String` module contains the `String.fromFloat` function that will be helpful for this.
 You should import the `String` module before using it.
 You should also define the type annotation for `poundsToString`.
 


### PR DESCRIPTION
Answers last requirement for #606 

I pulled all the exercises that mentioned "string" in the instructions and checked whether the exemplar required the use of `String`. All the exercises that required `string` as a prerequisite are marked "y" below. Additional changes to the exercise prerequisites under Notes.

| Required         | Exercise       | Notes |
|------------------|--------------------|----------|
| n   | concept/bandwagoner    | |
| n  |         bettys-bike-shop    | Uses String.fromFloat but the concept comes two levels before Strings in the concepts graph. I did not add the strings prerequisites, instead I added an explicit mention of `String.fromFloat` to the exercise instructions. |
| n   |         go                           | |
| y  |         monster-attack         | Already had "strings" in prerequisites. No change. |
| y   |         paolas-prestigious-pizza  | |
| n   |         role-playing-game        | |
| n   |         secure-treasure-chest  | |
| n/a |         squeaky-clean            | N/A. String concept exercise |
| y   |         top-scorers                  | |
| n   |         treasure-chest            | |
| y   | practice/acronym                | |
| y   |          anagram                    | |
| y  |          armstrong-numbers  | Also added `Lists` to prerequisites/practices.   |
| y  |          atbash-cipher           | Also added `Dict` and `tuples` to prerequisites/practices. |
| y   |          bob                            | |
| y   |          hamming                   | |
| n   |          hello-world                | |
| y  |          largest-series-product  | Also added `Lists` to prerequisites/practices. |
| y   |          luhn                          | |
| y  |          matching-brackets    | Also added `Dict` and `Lists` to prerequisites/practices. |
| y   |          nucleotide-count     | |
| y   |          isogram                   | |
| y   |          pangram                 | |
| y   |          raindrops                | |
| y   |          robot-simulator       | |
| y  |          rna-transcription      | Also added `Result` to prerequisites/practices. |
| y   |          run-length-encoding  | |
| y  |           say                         | Also added `Array` to prerequisites/practices. |
| y   |          series                     | |
| y   |          simple-cipher         | |
| n   |          sgf-parsing             | |
| y   |          simple-cipher          | |
| y   |          twelve-days            | |
| y   |          two-fer                    | |
| y   |          word-count              | |