### PR TITLE
CI: pin GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,12 +18,12 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
         with:
           node-version: ${{ matrix.node-version }}
 
       - name: Install elm + tools and cache the ELM_HOME directory
-        uses: mpizenberg/elm-tooling-action@v1.5
+        uses: mpizenberg/elm-tooling-action@913c4c779e2dbf757453839a6df89917f71d7cf9
         with:
           cache-key: elm-${{ matrix.node-version }}-${{ hashFiles('elm-tooling.json', 'template/elm.json') }}
           cache-restore-key: elm-${{ matrix.node-version }}


### PR DESCRIPTION
This PR updates GitHub Actions workflows to a specific version.
This ensures that the workflow will always run the same code, which makes your build _stable_.
It will also prevent a potential security issue where a tag could be replaced by a malicious commit without consumers being aware of it.

The PR updates each non-SHA based workflow reference with the SHA of the referenced version/tag, so the current behavior should not change.

See https://exercism.org/docs/building/github/gha-best-practices#h-pin-actions-to-shas for more information.