### PR TITLE
Fix broken link

### DIFF
--- a/concepts/lists/about.md
+++ b/concepts/lists/about.md
@@ -47,7 +47,7 @@ List.length [ 7, 8 ] --> 2
 Any function/operator that appear to modify a list (such as adding an element), will actually return a new list.
 Performance is usually not an issue though, as the implementation of lists prevents unnecessary allocations/copies.
 
-Lists can also be processed using [pattern matching](list-destructuring).
+Lists can also be processed using [pattern matching][list-destructuring].
 
 ```elm
 describe : List String -> String

--- a/concepts/lists/introduction.md
+++ b/concepts/lists/introduction.md
@@ -17,7 +17,7 @@ twoToFour = [ 2, 3, 4 ]
 oneToFour = 1 :: twoToFour --> [ 1, 2, 3, 4 ]
 ```
 
-Lists are manipulated by functions and operators defined in the [`List` module][list-module] or by [pattern matching](list-destructuring)
+Lists are manipulated by functions and operators defined in the [`List` module][list-module] or by [pattern matching][list-destructuring]
 
 ```elm
 describe : List String -> String


### PR DESCRIPTION
Fixes a `[…](…)` vs. `[…][…]` typo.

I came across this one only by chance; you might want to check for others.