### PR TITLE
Give task sections more explicit names

### DIFF
--- a/exercises/concept/annalyns-infiltration/tests/Tests.elm
+++ b/exercises/concept/annalyns-infiltration/tests/Tests.elm
@@ -8,7 +8,7 @@ import Test exposing (..)
 tests : Test
 tests =
     describe "AnnalynsInfiltration"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "Cannot execute fast attack if knight is awake" <|
                 \_ ->
                     let
@@ -26,7 +26,7 @@ tests =
                     canFastAttack knightIsAwake
                         |> Expect.equal True
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "Cannot spy if everyone is sleeping" <|
                 \_ ->
                     let
@@ -140,7 +140,7 @@ tests =
                     canSpy knightIsAwake archerIsAwake prisonerIsAwake
                         |> Expect.equal True
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "Can signal prisoner if archer is sleeping and prisoner is awake" <|
                 \_ ->
                     let
@@ -186,7 +186,7 @@ tests =
                     canSignalPrisoner archerIsAwake prisonerIsAwake
                         |> Expect.equal False
             ]
-        , describe "4"
+        , describe "Task 4"
             [ test "Cannot release prisoner if everyone is awake and pet dog is present" <|
                 \_ ->
                     let
@@ -460,7 +460,7 @@ tests =
                     canFreePrisoner knightIsAwake archerIsAwake prisonerIsAwake petDogIsPresent
                         |> Expect.equal False
             ]
-        , describe "5"
+        , describe "Task 5"
             [ test "Annalyn does 12 damage if undetected" <|
                 \_ ->
                     let

--- a/exercises/concept/bandwagoner/tests/Tests.elm
+++ b/exercises/concept/bandwagoner/tests/Tests.elm
@@ -8,7 +8,7 @@ import Test exposing (..)
 tests : Test
 tests =
     describe "Bandwagoner"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "has Coach type alias with correct fields in correct order" <|
                 \_ ->
                     Coach "Steve Kerr" True
@@ -31,7 +31,7 @@ tests =
                     in
                     Expect.equal team (Team "Boston Celtics" coach stats)
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "createTeam creates a Team structural type" <|
                 \_ ->
                     let
@@ -46,7 +46,7 @@ tests =
                     in
                     Expect.equal team (Team "Boston Celtics" coach stats)
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "can replace coach for a team" <|
                 \_ ->
                     let
@@ -67,7 +67,7 @@ tests =
                     in
                     Expect.equal newTeam (Team "New York Knicks" newCoach stats)
             ]
-        , describe "4"
+        , describe "Task 4"
             [ test "should root for teams that have more wins than losses" <|
                 \_ ->
                     Team "" (Coach "" True) (Stats 1 0)

--- a/exercises/concept/bettys-bike-shop/tests/Tests.elm
+++ b/exercises/concept/bettys-bike-shop/tests/Tests.elm
@@ -8,12 +8,12 @@ import Test exposing (..)
 tests : Test
 tests =
     describe "BettysBikeShop"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "penceToPounds has been imported" <|
                 \_ ->
                     Expect.pass
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "599 pence should be 5.99 pounds" <|
                 \_ ->
                     penceToPounds (truncate 599)
@@ -23,7 +23,7 @@ tests =
                     penceToPounds (truncate 33)
                         |> Expect.within (Absolute 0.001) 0.33
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "5.99 pounds should be formatted as £5.99" <|
                 \_ ->
                     poundsToString 5.99

--- a/exercises/concept/blorkemon-cards/tests/Tests.elm
+++ b/exercises/concept/blorkemon-cards/tests/Tests.elm
@@ -8,7 +8,7 @@ import Test exposing (Test, describe, test)
 tests : Test
 tests =
     describe "BlorkemonCards"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "First is more powerful" <|
                 \() ->
                     isMorePowerful (Card "Bleakachu" 60 False) (Card "Veevee" 40 True)
@@ -22,7 +22,7 @@ tests =
                     isMorePowerful (Card "Bleakachu" 55 False) (Card "Veevee" 55 False)
                         |> Expect.equal False
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "First is more powerful" <|
                 \() ->
                     maxPower (Card "Charilord" 60 True) (Card "Gyros" 40 True)
@@ -36,7 +36,7 @@ tests =
                     maxPower (Card "Charilord" 55 False) (Card "Gyros" 55 False)
                         |> Expect.equal 55
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "A bunch of monsters" <|
                 \() ->
                     sortByMonsterName
@@ -56,7 +56,7 @@ tests =
                             , Card "Wigglycream" 44 True
                             ]
             ]
-        , describe "4"
+        , describe "Task 4"
             [ test "A bunch of monsters" <|
                 \() ->
                     sortByCoolness
@@ -74,7 +74,7 @@ tests =
                             , Card "Mayofried" 25 False
                             ]
             ]
-        , describe "5"
+        , describe "Task 5"
             [ test "First is more powerful" <|
                 \() ->
                     compareShinyPower (Card "Blasturtle" 60 True) (Card "Hitmonchuck" 40 True)
@@ -116,7 +116,7 @@ tests =
                             , Card "Mayofried" 55 False
                             ]
             ]
-        , describe "6"
+        , describe "Task 6"
             [ test "First is more powerful" <|
                 \() ->
                     expectedWinner (Card "Phiswan" 60 True) (Card "Zumbat" 40 True)

--- a/exercises/concept/go/tests/Tests.elm
+++ b/exercises/concept/go/tests/Tests.elm
@@ -44,7 +44,7 @@ addWhiteCapturedStone game =
 tests : Test
 tests =
     describe "Go"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "should change the player if all rules pass" <|
                 \() ->
                     applyRules vanillaGame identityRule identity identityRule identityRule

--- a/exercises/concept/gotta-snatch-em-all/tests/Tests.elm
+++ b/exercises/concept/gotta-snatch-em-all/tests/Tests.elm
@@ -9,7 +9,7 @@ import Test exposing (Test, describe, test)
 tests : Test
 tests =
     describe "GottaSnatchEmAll"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "newCollection creates a singleton" <|
                 \() ->
                     GottaSnatchEmAll.newCollection "Bleakachu"
@@ -19,7 +19,7 @@ tests =
                     GottaSnatchEmAll.newCollection "Shiny Bleakachu"
                         |> Expect.equalSets (Set.singleton "Shiny Bleakachu")
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "addCard to an empty collection" <|
                 \() ->
                     GottaSnatchEmAll.addCard "Veevee" Set.empty
@@ -37,7 +37,7 @@ tests =
                     GottaSnatchEmAll.addCard "Veevee" (Set.fromList [ "Bleakachu", "Veevee" ])
                         |> Expect.equal ( True, Set.fromList [ "Bleakachu", "Veevee" ] )
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "tradeCard to an empty collection" <|
                 \() ->
                     GottaSnatchEmAll.tradeCard "Charilord" "Gyros" Set.empty
@@ -63,7 +63,7 @@ tests =
                     GottaSnatchEmAll.tradeCard "Charilord" "Gyros" (Set.fromList [ "Charilord", "Bleakachu", "Veevee" ])
                         |> Expect.equal ( True, Set.fromList [ "Gyros", "Bleakachu", "Veevee" ] )
             ]
-        , describe "4"
+        , describe "Task 4"
             [ test "removeDuplicates of an empty list" <|
                 \() ->
                     GottaSnatchEmAll.removeDuplicates []
@@ -81,7 +81,7 @@ tests =
                     GottaSnatchEmAll.removeDuplicates [ "Quarterpie", "Wigglycream", "Cooltentbrov", "Mayofried", "Wigglycream", "Cooltentbrov", "Cooltentbrov" ]
                         |> Expect.equalLists [ "Cooltentbrov", "Mayofried", "Quarterpie", "Wigglycream" ]
             ]
-        , describe "5"
+        , describe "Task 5"
             [ test "extraCards of empty collections" <|
                 \() ->
                     GottaSnatchEmAll.extraCards Set.empty Set.empty
@@ -113,7 +113,7 @@ tests =
                         (Set.fromList [ "Shazam", "Cooltentbro", "Wigglycream" ])
                         |> Expect.equal 1
             ]
-        , describe "6"
+        , describe "Task 6"
             [ test "boringCards of no collection" <|
                 \() ->
                     GottaSnatchEmAll.boringCards []
@@ -150,7 +150,7 @@ tests =
                         ]
                         |> Expect.equalLists [ "Gyros", "Veevee" ]
             ]
-        , describe "7"
+        , describe "Task 7"
             [ test "totalCards of no collection" <|
                 \() ->
                     GottaSnatchEmAll.totalCards []
@@ -189,7 +189,7 @@ tests =
                         ]
                         |> Expect.equal 6
             ]
-        , describe "8"
+        , describe "Task 8"
             [ test "splitShinyCards of empty collection" <|
                 \() ->
                     GottaSnatchEmAll.splitShinyCards Set.empty

--- a/exercises/concept/lucians-luscious-lasagna/tests/Tests.elm
+++ b/exercises/concept/lucians-luscious-lasagna/tests/Tests.elm
@@ -8,13 +8,13 @@ import Test exposing (..)
 tests : Test
 tests =
     describe "LuciansLusciousLasagna"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "The expected amount of time in the oven is 40 minutes" <|
                 \_ ->
                     expectedMinutesInOven
                         |> Expect.equal 40
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "For 2 layers, the preparation time is 4 minutes" <|
                 \_ ->
                     preparationTimeInMinutes 2
@@ -24,7 +24,7 @@ tests =
                     preparationTimeInMinutes 5
                         |> Expect.equal 10
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "For a 3-layers lasagna already in the oven for 10 minutes, you've spent 16 minutes cooking" <|
                 \_ ->
                     elapsedTimeInMinutes 3 10

--- a/exercises/concept/magician-in-training/tests/Tests.elm
+++ b/exercises/concept/magician-in-training/tests/Tests.elm
@@ -9,14 +9,14 @@ import Test exposing (..)
 tests : Test
 tests =
     describe "MagicianInTraining"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "getCard should return the card at index" <|
                 \_ ->
                     getCard 2 (Array.fromList [ 1, 2, 4 ])
                         |> Expect.equal
                             (Just 4)
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "setCard should change the card at index" <|
                 \_ ->
                     setCard 2 6 (Array.fromList [ 1, 2, 4 ])
@@ -28,14 +28,14 @@ tests =
                         |> Expect.equal
                             (Array.fromList [ 1, 2, 4 ])
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "addCard should add a card" <|
                 \_ ->
                     addCard 8 (Array.fromList [ 5, 9, 7, 1 ])
                         |> Expect.equal
                             (Array.fromList [ 5, 9, 7, 1, 8 ])
             ]
-        , describe "4"
+        , describe "Task 4"
             [ test "removeCard should remove the card at index" <|
                 \_ ->
                     removeCard 2 (Array.fromList [ 3, 2, 6, 4, 8 ])
@@ -47,7 +47,7 @@ tests =
                         |> Expect.equal
                             (Array.fromList [ 3, 2 ])
             ]
-        , describe "5"
+        , describe "Task 5"
             [ test "evenCardCount returns the number of even cards in the deck" <|
                 \_ ->
                     evenCardCount (Array.fromList [ 3, 8, 4, 5, 1, 6, 10 ])

--- a/exercises/concept/marios-marvellous-lasagna/tests/Tests.elm
+++ b/exercises/concept/marios-marvellous-lasagna/tests/Tests.elm
@@ -8,7 +8,7 @@ import Test exposing (..)
 tests : Test
 tests =
     describe "MariosMarvellousLasagna"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "For a 3-layers lasagna started 10 minutes ago, there are 36 minutes remaining" <|
                 \_ ->
                     remainingTimeInMinutes 3 10

--- a/exercises/concept/maze-maker/tests/Tests.elm
+++ b/exercises/concept/maze-maker/tests/Tests.elm
@@ -13,13 +13,13 @@ import Test.Distribution
 tests : Test
 tests =
     describe "MazeMaker"
-        [ describe "1"
+        [ describe "Task 1"
             [ fuzz (Fuzz.fromGenerator MazeMaker.deadend)
                 "deadend always generates a Deadend"
               <|
                 \deadend -> deadend |> Expect.equal DeadEnd
             ]
-        , describe "2"
+        , describe "Task 2"
             [ fuzzWith
                 { runs = 100
                 , distribution =
@@ -47,7 +47,7 @@ tests =
               <|
                 \_ -> Expect.pass
             ]
-        , describe "3"
+        , describe "Task 3"
             [ fuzz
                 (Fuzz.fromGenerator (MazeMaker.branch MazeMaker.deadend))
                 "branch generates a Branch variant"
@@ -99,7 +99,7 @@ tests =
               <|
                 \_ -> Expect.pass
             ]
-        , describe "4"
+        , describe "Task 4"
             [ fuzzWith
                 { runs = 100
                 , distribution =
@@ -128,7 +128,7 @@ tests =
               <|
                 \_ -> Expect.pass
             ]
-        , describe "5"
+        , describe "Task 5"
             [ fuzz (Fuzz.fromGenerator (MazeMaker.mazeOfDepth 0))
                 "mazeOfDepth 0 generates a maze of depth 0"
               <|

--- a/exercises/concept/monster-attack/tests/Tests.elm
+++ b/exercises/concept/monster-attack/tests/Tests.elm
@@ -8,49 +8,49 @@ import Test exposing (..)
 tests : Test
 tests =
     describe "MonsterAttack"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "attackWithSword1 should update Monster with desired description" <|
                 \_ ->
                     attackWithSword1 "A monster approaches Annalyn and her pet dog Kazak. " 2
                         |> Expect.equal
                             "A monster approaches Annalyn and her pet dog Kazak. Attacked with sword of strength 2."
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "attackWithClaw1 should update Monster with desired description" <|
                 \_ ->
                     attackWithClaw1 "A monster approaches Annalyn and her pet dog Kazak. " 3
                         |> Expect.equal
                             "A monster approaches Annalyn and her pet dog Kazak. Attacked with claw of strength 3."
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "attack1 should attack with sword twice and claw twice" <|
                 \_ ->
                     attack1 "A monster approaches Annalyn and her pet dog Kazak. "
                         |> Expect.equal
                             "A monster approaches Annalyn and her pet dog Kazak. Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
             ]
-        , describe "4"
+        , describe "Task 4"
             [ test "attackWithSword2 should update Monster with desired description" <|
                 \_ ->
                     attackWithSword2 2 "A monster approaches Annalyn and her pet dog Kazak. "
                         |> Expect.equal
                             "A monster approaches Annalyn and her pet dog Kazak. Attacked with sword of strength 2."
             ]
-        , describe "5"
+        , describe "Task 5"
             [ test "attackWithClaw2 should update Monster with desired description" <|
                 \_ ->
                     attackWithClaw2 3 "A monster approaches Annalyn and her pet dog Kazak. "
                         |> Expect.equal
                             "A monster approaches Annalyn and her pet dog Kazak. Attacked with claw of strength 3."
             ]
-        , describe "6"
+        , describe "Task 6"
             [ test "attack2 should attack with sword twice and claw twice" <|
                 \_ ->
                     attack2 "A monster approaches Annalyn and her pet dog Kazak. "
                         |> Expect.equal
                             "A monster approaches Annalyn and her pet dog Kazak. Attacked with sword of strength 5.Attacked with claw of strength 1.Attacked with claw of strength 1.Attacked with sword of strength 5."
             ]
-        , describe "7"
+        , describe "Task 7"
             [ test "attack3 should attack with sword twice and claw twice" <|
                 \_ ->
                     attack3 "A monster approaches Annalyn and her pet dog Kazak. "

--- a/exercises/concept/paolas-prestigious-pizza/tests/Tests.elm
+++ b/exercises/concept/paolas-prestigious-pizza/tests/Tests.elm
@@ -9,7 +9,7 @@ import Test exposing (Test, describe, test)
 tests : Test
 tests =
     describe "PaolasPrestigiousPizza"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "parse small price" <|
                 \() ->
                     Parser.run priceParser "5€"
@@ -23,7 +23,7 @@ tests =
                     Parser.run priceParser "5"
                         |> Expect.err
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "parse vegetarian indicator" <|
                 \() ->
                     Parser.run vegetarianParser "(v)"
@@ -37,7 +37,7 @@ tests =
                     Parser.run vegetarianParser "( v )"
                         |> Expect.equal (Ok False)
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "parse pizza name" <|
                 \() ->
                     Parser.run wordParser "CAPRESE"
@@ -55,7 +55,7 @@ tests =
                     Parser.run wordParser ""
                         |> Expect.equal (Ok "")
             ]
-        , describe "4"
+        , describe "Task 4"
             [ test "parse one ingredient" <|
                 \() ->
                     Parser.run ingredientsParser "spinach"
@@ -77,7 +77,7 @@ tests =
                     Parser.run ingredientsParser "spinach(fresh from the garden)"
                         |> Expect.equal (Ok [ "spinach" ])
             ]
-        , describe "5"
+        , describe "Task 5"
             [ test "parse a vegetarian pizza" <|
                 \() ->
                     Parser.run pizzaParser "Formaggio (v): tomato, emmental - 8€"
@@ -103,7 +103,7 @@ tests =
                     Parser.run pizzaParser "Regina: tomato, ham, mushrooms, cantal -"
                         |> Expect.err
             ]
-        , describe "6"
+        , describe "Task 6"
             [ test "parse one pizza" <|
                 \() ->
                     Parser.run menuParser "Formaggio (v): tomato, emmental - 8€"
@@ -155,7 +155,7 @@ Hawaii: tomato, pineapple, ham - 9€
                     Parser.run menuParser "Formaggio (v): tomato, emmental - 8€\n[END]"
                         |> Expect.equal (Err [ { problem = Parser.ExpectingEnd, col = 1, row = 2 } ])
             ]
-        , describe "7"
+        , describe "Task 7"
             [ test "parse multi-word ingredient" <|
                 \() ->
                     Parser.run oneIngredientParser "fresh fish"

--- a/exercises/concept/role-playing-game/tests/Tests.elm
+++ b/exercises/concept/role-playing-game/tests/Tests.elm
@@ -8,7 +8,7 @@ import Test exposing (..)
 tests : Test
 tests =
     describe "RolePlayingGame"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "Introducing someone with their name" <|
                 \() ->
                     Expect.equal (introduce { name = Just "Gandalf", level = 1, health = 42, mana = Nothing }) "Gandalf"
@@ -16,7 +16,7 @@ tests =
                 \() ->
                     Expect.equal (introduce { name = Nothing, level = 1, health = 42, mana = Nothing }) "Mighty Magician"
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "Attempting to revive a player that is alive should return Nothing" <|
                 \() ->
                     Expect.equal (revive { name = Nothing, level = 12, health = 42, mana = Just 7 }) Nothing
@@ -29,7 +29,7 @@ tests =
                     Expect.equal (revive { name = Nothing, level = 10, health = 0, mana = Just 14 })
                         (Just { name = Nothing, level = 10, health = 100, mana = Just 100 })
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "Casting a spell causes damage of double the mana" <|
                 \() ->
                     Expect.equal (castSpell 9 { name = Nothing, level = 10, health = 69, mana = Just 20 })

--- a/exercises/concept/secure-treasure-chest/tests/Tests.elm
+++ b/exercises/concept/secure-treasure-chest/tests/Tests.elm
@@ -8,7 +8,7 @@ import Test exposing (..)
 tests : Test
 tests =
     describe "SecureTreasureChest"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "Password is exposed" <|
                 \_ ->
                     let
@@ -29,7 +29,7 @@ tests =
                     createPassword "1234567"
                         |> Expect.equal Nothing
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "SecureTreasureChest is exposed" <|
                 \_ ->
                     let
@@ -39,7 +39,7 @@ tests =
                     in
                     Expect.pass
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "Treasure can be a string" <|
                 \_ ->
                     createPassword "12345678"
@@ -57,7 +57,7 @@ tests =
                             , Expect.equal (createPassword "12345678" |> Maybe.map (createTreasure 5))
                             ]
             ]
-        , describe "4"
+        , describe "Task 4"
             [ test "The treasure is returned if the correct password is used" <|
                 \_ ->
                     createPassword "12345678"

--- a/exercises/concept/squeaky-clean/tests/Tests.elm
+++ b/exercises/concept/squeaky-clean/tests/Tests.elm
@@ -8,7 +8,7 @@ import Test exposing (Test, describe, test)
 tests : Test
 tests =
     describe "Squeaky Clean"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "Empty String" <|
                 \_ ->
                     clean1 ""
@@ -26,7 +26,7 @@ tests =
                     clean1 "my   Id"
                         |> Expect.equal "my___Id"
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "Empty String" <|
                 \_ ->
                     clean2 ""
@@ -52,7 +52,7 @@ tests =
                     clean2 "Line one.\u{000D}Line two.\u{000D}"
                         |> Expect.equal "Line_one.[CTRL]Line_two.[CTRL]"
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "Empty String" <|
                 \_ ->
                     clean3 ""
@@ -82,7 +82,7 @@ tests =
                     clean3 "à-ḃç"
                         |> Expect.equal "àḂç"
             ]
-        , describe "4"
+        , describe "Task 4"
             [ test "Empty String" <|
                 \_ ->
                     clean4 ""
@@ -116,7 +116,7 @@ tests =
                     clean4 "1My2Finder3"
                         |> Expect.equal "MyFinder"
             ]
-        , describe "5"
+        , describe "Task 5"
             [ test "Empty String" <|
                 \_ ->
                     clean ""

--- a/exercises/concept/ticket-please/tests/Tests.elm
+++ b/exercises/concept/ticket-please/tests/Tests.elm
@@ -18,7 +18,7 @@ newTicket =
 tests : Test
 tests =
     describe "TicketPlease "
-        [ describe "1"
+        [ describe "Task 1"
             [ test "emptyComment should detect an empty comment" <|
                 \() ->
                     emptyComment ( User "Alice", "" )
@@ -43,7 +43,7 @@ tests =
                             , ( User "Bob", "hi!" )
                             ]
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "numberOfCreatorComments with no comment" <|
                 \() ->
                     Ticket { newTicket | createdBy = ( User "John", 1 ), comments = [] }
@@ -82,7 +82,7 @@ tests =
                         |> numberOfCreatorComments
                         |> Expect.equal 2
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "assignedToDevTeam with no one assigned" <|
                 \() ->
                     Ticket { newTicket | assignedTo = Nothing }
@@ -114,7 +114,7 @@ tests =
                         |> Expect.equal True
                         |> Expect.onFail "Expected ticket assigned to Charlie from dev team"
             ]
-        , describe "4"
+        , describe "Task 4"
             [ test "assign new, unassigned ticket to Roy" <|
                 \() ->
                     Ticket { newTicket | status = New, assignedTo = Nothing }

--- a/exercises/concept/tisbury-treasure-hunt/tests/Tests.elm
+++ b/exercises/concept/tisbury-treasure-hunt/tests/Tests.elm
@@ -8,13 +8,13 @@ import TisburyTreasureHunt exposing (..)
 tests : Test
 tests =
     describe "TisburyTreasureHunt"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "placeLocationToTreasureLocation should convert PlaceLocation to TreasureLocation" <|
                 \_ ->
                     placeLocationToTreasureLocation ( 'C', 1 )
                         |> Expect.equal ( 1, 'C' )
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "1,F is not at Seaside Cottages" <|
                 \_ ->
                     treasureLocationMatchesPlaceLocation ( 'C', 1 ) ( 1, 'F' )
@@ -24,7 +24,7 @@ tests =
                     treasureLocationMatchesPlaceLocation ( 'F', 1 ) ( 1, 'F' )
                         |> Expect.equal True
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "places should know how many treasures are available" <|
                 \_ ->
                     countPlaceTreasures
@@ -34,7 +34,7 @@ tests =
                         ]
                         |> Expect.equal 2
             ]
-        , describe "4"
+        , describe "Task 4"
             [ test "can swap Amethyst Octopus for Crystal Crab at Stormy Breakwater" <|
                 \_ ->
                     specialCaseSwapPossible

--- a/exercises/concept/top-scorers/tests/Tests.elm
+++ b/exercises/concept/top-scorers/tests/Tests.elm
@@ -10,8 +10,7 @@ import TopScorersSupport exposing (..)
 tests : Test
 tests =
     describe "Top Scorers"
-        [ describe
-            "1"
+        [ describe "Task 1"
             [ test "aggregateScores should count the number of occurences of a player name" <|
                 \() ->
                     aggregateScorers [ "Betty", "Cedd", "Betty" ]
@@ -20,8 +19,7 @@ tests =
                                 [ ( "Betty", 2 ), ( "Cedd", 1 ) ]
                             )
             ]
-        , describe
-            "2"
+        , describe "Task 2"
             [ test "removeInsignificantPlayers should remove players that have scored less goals than the threshold" <|
                 \() ->
                     removeInsignificantPlayers 2
@@ -33,8 +31,7 @@ tests =
                                 [ ( "Betty", 2 ) ]
                             )
             ]
-        , describe
-            "3"
+        , describe "Task 3"
             [ test "resetPlayerGoalCount should set the goalCount to zero for the player" <|
                 \() ->
                     resetPlayerGoalCount "Betty"
@@ -46,8 +43,7 @@ tests =
                                 [ ( "Betty", 0 ), ( "Cedd", 1 ) ]
                             )
             ]
-        , describe
-            "4"
+        , describe "Task 4"
             [ test "formatPlayer should return the player name and the goal count" <|
                 \() ->
                     formatPlayer "Betty" (Dict.singleton "Betty" 3)
@@ -59,7 +55,7 @@ tests =
                         |> Expect.equal
                             "Betty: 0"
             ]
-        , describe "5"
+        , describe "Task 5"
             [ test "formatPlayers should return the player name and the goal count, ordered by player name" <|
                 \() ->
                     formatPlayers
@@ -69,7 +65,7 @@ tests =
                         |> Expect.equal
                             "Betty: 2, Cedd: 1"
             ]
-        , describe "6"
+        , describe "Task 6"
             [ test "combineGames should count goals in both games" <|
                 \() ->
                     combineGames

--- a/exercises/concept/tracks-on-tracks-on-tracks/tests/Tests.elm
+++ b/exercises/concept/tracks-on-tracks-on-tracks/tests/Tests.elm
@@ -9,13 +9,13 @@ import TracksOnTracksOnTracks exposing (..)
 tests : Test
 tests =
     describe "TracksOnTracksOnTracks"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "newList should return an empty list" <|
                 \_ ->
                     newList
                         |> Expect.equal []
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "existingList should return Elm, Clojure and Haskell" <|
                 \_ ->
                     existingList
@@ -31,13 +31,13 @@ tests =
                         |> addLanguage "Common Lisp"
                         |> Expect.equal [ "Common Lisp", "Elm", "Clojure", "Haskell" ]
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "addLanguage adds language to custom list" <|
                 \_ ->
                     addLanguage "Racket" [ "Scheme" ]
                         |> Expect.equal [ "Racket", "Scheme" ]
             ]
-        , describe "4"
+        , describe "Task 4"
             [ test "Count languages on new list" <|
                 \_ ->
                     newList
@@ -53,7 +53,7 @@ tests =
                     countLanguages [ "Python", "JavaScript" ]
                         |> Expect.equal 2
             ]
-        , describe "5"
+        , describe "Task 5"
             [ test "Reverse order of new list" <|
                 \_ ->
                     newList
@@ -69,7 +69,7 @@ tests =
                     reverseList [ "Kotlin", "Java", "Scala", "Clojure" ]
                         |> Expect.equal [ "Clojure", "Scala", "Java", "Kotlin" ]
             ]
-        , describe "6"
+        , describe "Task 6"
             [ test "Empty list is not exciting" <|
                 \_ ->
                     excitingList []

--- a/exercises/concept/treasure-chest/tests/Tests.elm
+++ b/exercises/concept/treasure-chest/tests/Tests.elm
@@ -8,7 +8,7 @@ import TreasureChest exposing (..)
 tests : Test
 tests =
     describe "TreasureChest"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "Treasure can be a string" <|
                 \_ ->
                     TreasureChest "password" "treasure"
@@ -18,7 +18,7 @@ tests =
                     TreasureChest "password" 5
                         |> Expect.equal (TreasureChest "password" 5)
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "The treasure is returned if the correct password is used" <|
                 \_ ->
                     TreasureChest "password" "treasure"
@@ -30,7 +30,7 @@ tests =
                         |> getTreasure "wrong-password"
                         |> Expect.equal Nothing
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "The multiplied treasure is returned" <|
                 \_ ->
                     TreasureChest "password" "treasure"

--- a/exercises/concept/treasure-factory/tests/Tests.elm
+++ b/exercises/concept/treasure-factory/tests/Tests.elm
@@ -8,7 +8,7 @@ import TreasureFactory
 tests : Test
 tests =
     describe "TreasureFactory"
-        [ describe "1"
+        [ describe "Task 1"
             [ test "module compiles" <|
                 \() -> Expect.pass
             , test "makeChest returns a value" <|
@@ -32,7 +32,7 @@ tests =
                         |> Expect.equal True
                         |> Expect.onFail "Chests created with different treasures should not be the same"
             ]
-        , describe "2"
+        , describe "Task 2"
             [ test "chest with passwords of less than 8 characters are insecure" <|
                 \() ->
                     TreasureFactory.secureChest (TreasureFactory.makeChest "12345" 1)
@@ -50,7 +50,7 @@ tests =
                         |> Expect.equal True
                         |> Expect.onFail "Chests with more than 8 characters should be secure"
             ]
-        , describe "3"
+        , describe "Task 3"
             [ test "chests with identical treasures are never unique" <|
                 \() ->
                     [ ( "short", 1 )
@@ -84,7 +84,7 @@ tests =
                         |> List.length
                         |> Expect.equal 4
             ]
-        , describe "4"
+        , describe "Task 4"
             [ test "treasures have the correct secure passwords" <|
                 \() ->
                     [ ( "short", 1 )

--- a/exercises/concept/valentines-day/tests/Tests.elm
+++ b/exercises/concept/valentines-day/tests/Tests.elm
@@ -8,7 +8,7 @@ import ValentinesDay exposing (..)
 tests : Test
 tests =
     describe "ValentinesDay"
-        [ describe "5"
+        [ describe "Task 5"
             [ test "board game rated no" <|
                 \_ ->
                     rateActivity BoardGame


### PR DESCRIPTION
Intended effect in the output of `elm-test`:

```diff
 > Tests
 > Squeaky Clean
-> 5
+> Task 5
 > Omit digits
 
     "1My2Finder3"
     ╷
     │ Expect.equal
     ╵
     "MyFinder"
```

Beware: if this is merged the test runner might need some adjustment as well.

I used to ignore the digits with unclear origin; the aim of this change is to make their meaning very clear.

Contributor to previous confusion: e.g. `squeaky-clean` has several tests named `"Omit digits"`, in `elm-test`'s output only distinguished by section number.

[no important files changed]