### PR TITLE
Use Parser.problem instead of Debug.todo

### DIFF
--- a/exercises/concept/paolas-prestigious-pizza/src/PaolasPrestigiousPizza.elm
+++ b/exercises/concept/paolas-prestigious-pizza/src/PaolasPrestigiousPizza.elm
@@ -22,34 +22,34 @@ type alias Pizza =
 
 priceParser : Parser Int
 priceParser =
-    Debug.todo "Please implement this parser"
+    Parser.problem "Please implement this parser"
 
 
 vegetarianParser : Parser Bool
 vegetarianParser =
-    Debug.todo "Please implement this parser"
+    Parser.problem "Please implement this parser"
 
 
 wordParser : Parser String
 wordParser =
-    Debug.todo "Please implement this parser"
+    Parser.problem "Please implement this parser"
 
 
 ingredientsParser : Parser (List String)
 ingredientsParser =
-    Debug.todo "Please implement this parser"
+    Parser.problem "Please implement this parser"
 
 
 pizzaParser : Parser Pizza
 pizzaParser =
-    Debug.todo "Please implement this parser"
+    Parser.problem "Please implement this parser"
 
 
 menuParser : Parser (List Pizza)
 menuParser =
-    Debug.todo "Please implement this parser"
+    Parser.problem "Please implement this parser"
 
 
 oneIngredientParser : Parser String
 oneIngredientParser =
-    Debug.todo "Please implement this parser"
+    Parser.problem "Please implement this parser"


### PR DESCRIPTION
As per https://forum.exercism.org/t/debug-todo-in-paolas-prestigious-pizza/10596

I ran the existing code locally and it did reproduce the problem reported by Glenn.

I then used Parser.problem instead as suggested, and the test failure messages respond with something useful:

```
Tests
↓ PaolasPrestigiousPizza
↓ 7
✗ parse a pizza with no ingredients

    Err [{ col = 1, problem = Problem "Please implement this parser", row = 1 }]
    ╷
    │ Expect.equal
    ╵
    Ok { ingredients = [], name = "triste", price = 1, vegetarian = True }
```

