### PR TITLE
Hopefully fix formatting in maze maker

### DIFF
--- a/exercises/concept/maze-maker/.docs/instructions.md
+++ b/exercises/concept/maze-maker/.docs/instructions.md
@@ -49,5 +49,5 @@ Your `maze` is nice, but it has some issues:
 3. While deep mazes can be generated, they are not very likely: a maze of depth of 3 has an approximate 3% chance of being generated, a maze of depth 10 a 0.2% chance (the depth of a maze is calculated with `MazeMakerSupport.mazeDepth`)
 
 Define the `mazeOfDepth n` generator so that it generates a maze of depth `n`.
-Only the deepest level `0` should contain dead ends or treasure rooms (with equal probability), all other levels should be a branch containing mazes of depth `n - 1` generated recursively with `mazeOfDepth`.
+Only the deepest level `0` should contain dead ends or treasure rooms (with equal probability), all other levels should be a branch containing mazes of depth `n-1` generated recursively with `mazeOfDepth`.
 Make sure to use `deadend`, `room` and `branch` in the generator.


### PR DESCRIPTION
Remove whitespace in `n - 1`

The previous version was valid markdown, but this will hopefully work around a rendering bug

We will only know if this works when we deploy it and have a look sadly

This will hopefully fix #717 