### PR TITLE
Fix Random.weighted bug in the concept doc: weight is the first element of the tuple

### DIFF
--- a/concepts/random/about.md
+++ b/concepts/random/about.md
@@ -84,7 +84,7 @@ generate 5 (Random.uniform Red [Green, Blue])
 We can also tweak the probabilities using `Random.weighted`:
 
 ```elm
-generate 5 (Random.weighted (Red, 80) [(Green, 15), (Blue, 5)])
+generate 5 (Random.weighted (80, Red) [(15, Green), (5, Blue)])
     --> [Red, Red, Green, Red, Red]
 ```
 

--- a/concepts/random/introduction.md
+++ b/concepts/random/introduction.md
@@ -57,7 +57,7 @@ generate 5 (Random.uniform Red [Green, Blue])
 We can also tweak the probabilities using `Random.weighted`:
 
 ```elm
-generate 5 (Random.weighted (Red, 80) [(Green, 15), (Blue, 5)])
+generate 5 (Random.weighted (80, Red) [(15, Green), (5, Blue)])
     --> [Red, Red, Green, Red, Red]
 ```
 


### PR DESCRIPTION
Forum thread: 
http://forum.exercism.org/t/random-concept-random-weighted-tuples-are-backwards/15566

Ref `weighted` doc: https://package.elm-lang.org/packages/elm/random/latest/Random#weighted