### PR TITLE
Move elm/html to direct dependencies in all elm.json

### DIFF
--- a/exercises/concept/annalyns-infiltration/elm.json
+++ b/exercises/concept/annalyns-infiltration/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/bandwagoner/elm.json
+++ b/exercises/concept/bandwagoner/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/bettys-bike-shop/elm.json
+++ b/exercises/concept/bettys-bike-shop/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/blorkemon-cards/elm.json
+++ b/exercises/concept/blorkemon-cards/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/githup-api/elm.json
+++ b/exercises/concept/githup-api/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/go/elm.json
+++ b/exercises/concept/go/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/gotta-snatch-em-all/elm.json
+++ b/exercises/concept/gotta-snatch-em-all/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/lucians-luscious-lasagna/elm.json
+++ b/exercises/concept/lucians-luscious-lasagna/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/magician-in-training/elm.json
+++ b/exercises/concept/magician-in-training/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/marios-marvellous-lasagna/elm.json
+++ b/exercises/concept/marios-marvellous-lasagna/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/maze-maker/elm.json
+++ b/exercises/concept/maze-maker/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/monster-attack/elm.json
+++ b/exercises/concept/monster-attack/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/paolas-prestigious-pizza/elm.json
+++ b/exercises/concept/paolas-prestigious-pizza/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/role-playing-game/elm.json
+++ b/exercises/concept/role-playing-game/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/secure-treasure-chest/elm.json
+++ b/exercises/concept/secure-treasure-chest/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/squeaky-clean/elm.json
+++ b/exercises/concept/squeaky-clean/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/ticket-please/elm.json
+++ b/exercises/concept/ticket-please/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/tisbury-treasure-hunt/elm.json
+++ b/exercises/concept/tisbury-treasure-hunt/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/top-scorers/elm.json
+++ b/exercises/concept/top-scorers/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/tracks-on-tracks-on-tracks/elm.json
+++ b/exercises/concept/tracks-on-tracks-on-tracks/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/treasure-chest/elm.json
+++ b/exercises/concept/treasure-chest/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/treasure-factory/elm.json
+++ b/exercises/concept/treasure-factory/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/concept/valentines-day/elm.json
+++ b/exercises/concept/valentines-day/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/accumulate/elm.json
+++ b/exercises/practice/accumulate/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/acronym/elm.json
+++ b/exercises/practice/acronym/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/all-your-base/elm.json
+++ b/exercises/practice/all-your-base/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/allergies/elm.json
+++ b/exercises/practice/allergies/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/anagram/elm.json
+++ b/exercises/practice/anagram/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/armstrong-numbers/elm.json
+++ b/exercises/practice/armstrong-numbers/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/atbash-cipher/elm.json
+++ b/exercises/practice/atbash-cipher/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/binary-search-tree/elm.json
+++ b/exercises/practice/binary-search-tree/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/binary-search/elm.json
+++ b/exercises/practice/binary-search/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/bob/elm.json
+++ b/exercises/practice/bob/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/bowling/elm.json
+++ b/exercises/practice/bowling/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/circular-buffer/elm.json
+++ b/exercises/practice/circular-buffer/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/collatz-conjecture/elm.json
+++ b/exercises/practice/collatz-conjecture/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/complex-numbers/elm.json
+++ b/exercises/practice/complex-numbers/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/custom-set/elm.json
+++ b/exercises/practice/custom-set/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/diamond/elm.json
+++ b/exercises/practice/diamond/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/difference-of-squares/elm.json
+++ b/exercises/practice/difference-of-squares/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/dnd-character/elm.json
+++ b/exercises/practice/dnd-character/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/eliuds-eggs/elm.json
+++ b/exercises/practice/eliuds-eggs/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/etl/elm.json
+++ b/exercises/practice/etl/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/food-chain/elm.json
+++ b/exercises/practice/food-chain/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/gigasecond/elm.json
+++ b/exercises/practice/gigasecond/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/grade-school/elm.json
+++ b/exercises/practice/grade-school/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/grains/elm.json
+++ b/exercises/practice/grains/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/hamming/elm.json
+++ b/exercises/practice/hamming/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/hello-world/elm.json
+++ b/exercises/practice/hello-world/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/isogram/elm.json
+++ b/exercises/practice/isogram/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/kindergarten-garden/elm.json
+++ b/exercises/practice/kindergarten-garden/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/knapsack/elm.json
+++ b/exercises/practice/knapsack/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/largest-series-product/elm.json
+++ b/exercises/practice/largest-series-product/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/leap/elm.json
+++ b/exercises/practice/leap/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/list-ops/elm.json
+++ b/exercises/practice/list-ops/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/luhn/elm.json
+++ b/exercises/practice/luhn/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/matching-brackets/elm.json
+++ b/exercises/practice/matching-brackets/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/meetup/elm.json
+++ b/exercises/practice/meetup/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/minesweeper/elm.json
+++ b/exercises/practice/minesweeper/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/nucleotide-count/elm.json
+++ b/exercises/practice/nucleotide-count/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/pangram/elm.json
+++ b/exercises/practice/pangram/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/pascals-triangle/elm.json
+++ b/exercises/practice/pascals-triangle/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/phone-number/elm.json
+++ b/exercises/practice/phone-number/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/pig-latin/elm.json
+++ b/exercises/practice/pig-latin/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/protein-translation/elm.json
+++ b/exercises/practice/protein-translation/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/pythagorean-triplet/elm.json
+++ b/exercises/practice/pythagorean-triplet/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/raindrops/elm.json
+++ b/exercises/practice/raindrops/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/rest-api/elm.json
+++ b/exercises/practice/rest-api/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/reverse-string/elm.json
+++ b/exercises/practice/reverse-string/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/rna-transcription/elm.json
+++ b/exercises/practice/rna-transcription/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/robot-simulator/elm.json
+++ b/exercises/practice/robot-simulator/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/roman-numerals/elm.json
+++ b/exercises/practice/roman-numerals/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/rotational-cipher/elm.json
+++ b/exercises/practice/rotational-cipher/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/run-length-encoding/elm.json
+++ b/exercises/practice/run-length-encoding/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/say/elm.json
+++ b/exercises/practice/say/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/scrabble-score/elm.json
+++ b/exercises/practice/scrabble-score/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/secret-handshake/elm.json
+++ b/exercises/practice/secret-handshake/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/series/elm.json
+++ b/exercises/practice/series/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/sgf-parsing/elm.json
+++ b/exercises/practice/sgf-parsing/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/sieve/elm.json
+++ b/exercises/practice/sieve/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/simple-cipher/elm.json
+++ b/exercises/practice/simple-cipher/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/space-age/elm.json
+++ b/exercises/practice/space-age/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/spiral-matrix/elm.json
+++ b/exercises/practice/spiral-matrix/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/strain/elm.json
+++ b/exercises/practice/strain/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/sublist/elm.json
+++ b/exercises/practice/sublist/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/sum-of-multiples/elm.json
+++ b/exercises/practice/sum-of-multiples/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/transpose/elm.json
+++ b/exercises/practice/transpose/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/triangle/elm.json
+++ b/exercises/practice/triangle/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/twelve-days/elm.json
+++ b/exercises/practice/twelve-days/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/two-bucket/elm.json
+++ b/exercises/practice/two-bucket/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/two-fer/elm.json
+++ b/exercises/practice/two-fer/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/word-count/elm.json
+++ b/exercises/practice/word-count/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/wordy/elm.json
+++ b/exercises/practice/wordy/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/yacht/elm.json
+++ b/exercises/practice/yacht/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/exercises/practice/zebra-puzzle/elm.json
+++ b/exercises/practice/zebra-puzzle/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }

--- a/generate_practice_exercise/elm.json
+++ b/generate_practice_exercise/elm.json
@@ -6,19 +6,24 @@
     "elm-version": "0.19.1",
     "dependencies": {
         "direct": {
-            "elm/browser": "1.0.2",
             "elm/core": "1.0.5",
-            "elm/html": "1.0.0",
-            "elm/json": "1.1.3"
-        },
-        "indirect": {
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
             "elm/time": "1.0.0",
-            "elm/url": "1.0.0",
-            "elm/virtual-dom": "1.0.2"
-        }
+            "elm/html": "1.0.0"
+        },
+        "indirect": {}
     },
     "test-dependencies": {
-        "direct": {},
-        "indirect": {}
+        "direct": {
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/virtual-dom": "1.0.3"
+        }
     }
 }

--- a/template/elm.json
+++ b/template/elm.json
@@ -11,7 +11,8 @@
             "elm/parser": "1.1.0",
             "elm/random": "1.0.0",
             "elm/regex": "1.0.0",
-            "elm/time": "1.0.0"
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
         },
         "indirect": {}
     },
@@ -22,7 +23,6 @@
         },
         "indirect": {
             "elm/bytes": "1.0.8",
-            "elm/html": "1.0.0",
             "elm/virtual-dom": "1.0.3"
         }
     }


### PR DESCRIPTION
This is related to #730. 

Hopefully it will allow me to release a new version of the test runner, that will then allow the #730 github actions to pass