### PR TITLE
Add forked concept `recursion` and concept exercise `bird-count`

### DIFF
--- a/concepts/recursion/.meta/config.json
+++ b/concepts/recursion/.meta/config.json
@@ -1,5 +1,5 @@
 {
-  "blurb": "Recursive functions are functions that call themselves, learn how to use recursion in Elm",
+  "blurb": "Recursive functions are functions that call themselves. Learn how to use recursion in Elm",
   "authors": [
     "jiegillet"
   ],

--- a/concepts/recursion/.meta/config.json
+++ b/concepts/recursion/.meta/config.json
@@ -1,0 +1,7 @@
+{
+  "blurb": "Recursive functions are functions that call themselves, learn how to use recursion in Elm",
+  "authors": [
+    "jiegillet"
+  ],
+  "contributors": []
+}

--- a/concepts/recursion/.meta/config.json
+++ b/concepts/recursion/.meta/config.json
@@ -3,5 +3,7 @@
   "authors": [
     "jiegillet"
   ],
-  "contributors": []
+  "contributors": [
+    "ceddlyburge"
+  ]
 }

--- a/concepts/recursion/about.md
+++ b/concepts/recursion/about.md
@@ -37,6 +37,8 @@ fibonacci n =
             fibonacci (n - 1) + fibonacci (n - 2)
 ```
 
+Note that this particular implementation is exponentially slow, since related Fibonacci numbers are being calculated from scratch in two independent recursive calls.
+
 Counting the number of occurrences of some given value `x` in a list has two recursive cases:
 
 ```elm

--- a/concepts/recursion/about.md
+++ b/concepts/recursion/about.md
@@ -85,9 +85,9 @@ Under the hood, these functions are implemented using recursion.
 
 ## Infinite execution
 
-Recursive functions, if implemented incorrectly, might never return their result.
+Recursive functions, if implemented incorrectly or for a number of recursion calls too large, might never return their result.
 This can be problematic because each time a function is called, a reference is stored in memory where the runtime should return the result (on the [call stack][wiki-call-stack]).
-If a recursive function calls itself infinitely, it is possible to run out of memory causing the runtime to crash (a [stack overflow error][wiki-stack-overflow]).
+If a recursive function calls itself too much or even infinitely, it is possible to run out of memory causing the runtime to crash (a [stack overflow error][wiki-stack-overflow]).
 Elm's runtime is optimized for recursion and reliability, but infinite recursion can still cause issues.
 
 This problem of infinite execution can be caused by:

--- a/concepts/recursion/about.md
+++ b/concepts/recursion/about.md
@@ -58,7 +58,7 @@ countOccurrences list x =
 Due to immutability, loops in Elm are written differently from imperative languages.
 For example, loops commonly look like:
 
-```
+```c
 for(i = 0; i < array.length; i++) {
   // do something with array[i]
 }

--- a/concepts/recursion/about.md
+++ b/concepts/recursion/about.md
@@ -1,0 +1,102 @@
+# About
+
+Recursive functions are functions that call themselves.
+
+A recursive function needs to have at least one _base case_ and at least one _recursive case_.
+
+A _base case_ returns a value without calling the function again.
+A _recursive case_ calls the function again, modifying the input so that it will at some point match the base case.
+
+In Elm, recursive functions are typically defined using pattern matching with `case` expressions.
+
+```elm
+count : List a -> Int
+count list =
+    case list of
+        [] ->
+            0  -- base case
+
+        _ :: tail ->
+            1 + count tail  -- recursive case
+```
+
+A recursive function can have many base cases and/or many recursive cases.
+For example [the Fibonacci sequence][fibonacci] is a recursive sequence with two base cases:
+
+```elm
+fibonacci : Int -> Int
+fibonacci n =
+    case n of
+        0 ->
+            0
+
+        1 ->
+            1
+
+        _ ->
+            fibonacci (n - 1) + fibonacci (n - 2)
+```
+
+Counting the number of occurrences of some given value `x` in a list has two recursive cases:
+
+```elm
+countOccurrences : List a -> a -> Int
+countOccurrences list x =
+    case list of
+        [] ->
+            0
+
+        head :: tail ->
+            if head == x then
+                1 + countOccurrences tail x
+            else
+                countOccurrences tail x
+```
+
+## Loops through recursion
+
+Due to immutability, loops in Elm are written differently from imperative languages.
+For example, loops commonly look like:
+
+```
+for(i = 0; i < array.length; i++) {
+  // do something with array[i]
+}
+```
+
+In a functional language like Elm, mutating variables is not possible.
+Thus, loops have to be implemented with recursion.
+
+The equivalent of a `for` loop in Elm would look like this:
+
+```elm
+loop : List a -> (a -> b) -> List b
+loop list f =
+    case list of
+        [] ->
+            []
+
+        head :: tail ->
+            f head :: loop tail f
+```
+
+In practice, iterating over lists and other data structures in Elm is most often done using functions from the [`List`][module-list] module, such as `List.map`, `List.filter`, and `List.foldl`.
+Under the hood, these functions are implemented using recursion.
+
+## Infinite execution
+
+Recursive functions, if implemented incorrectly, might never return their result.
+This can be problematic because each time a function is called, a reference is stored in memory where the runtime should return the result (on the [call stack][wiki-call-stack]).
+If a recursive function calls itself infinitely, it is possible to run out of memory causing the runtime to crash (a [stack overflow error][wiki-stack-overflow]).
+Elm's runtime is optimized for recursion and reliability, but infinite recursion can still cause issues.
+
+This problem of infinite execution can be caused by:
+
+- Forgetting to implement a base case.
+- Not handling all possible cases in pattern matching.
+- Not modifying the argument properly when doing the recursive call, and thus never reaching the base case.
+
+[fibonacci]: https://en.wikipedia.org/wiki/Fibonacci_number
+[module-list]: https://package.elm-lang.org/packages/elm/core/latest/List
+[wiki-call-stack]: https://en.wikipedia.org/wiki/Call_stack
+[wiki-stack-overflow]: https://en.wikipedia.org/wiki/Stack_overflow

--- a/concepts/recursion/introduction.md
+++ b/concepts/recursion/introduction.md
@@ -25,7 +25,7 @@ count list =
 Due to immutability, loops in Elm are written differently from imperative languages.
 For example, loops commonly look like:
 
-```
+```c
 for(i = 0; i < array.length; i++) {
   // do something with array[i]
 }

--- a/concepts/recursion/introduction.md
+++ b/concepts/recursion/introduction.md
@@ -1,0 +1,51 @@
+# Introduction
+
+Recursive functions are functions that call themselves.
+
+A recursive function needs to have at least one _base case_ and at least one _recursive case_.
+
+A _base case_ returns a value without calling the function again.
+A _recursive case_ calls the function again, modifying the input so that it will at some point match the base case.
+
+In Elm, recursive functions are typically defined using pattern matching with `case` expressions or multiple function clauses.
+
+```elm
+count : List a -> Int
+count list =
+    case list of
+        [] ->
+            0  -- base case
+
+        _ :: tail ->
+            1 + count tail  -- recursive case
+```
+
+## Loops through recursion
+
+Due to immutability, loops in Elm are written differently from imperative languages.
+For example, loops commonly look like:
+
+```
+for(i = 0; i < array.length; i++) {
+  // do something with array[i]
+}
+```
+
+In a functional language like Elm, mutating variables is not possible.
+Thus, loops have to be implemented with recursion.
+
+The equivalent of a `for` loop in Elm would look like this:
+
+```elm
+loop : List a -> (a -> b) -> List b
+loop list f =
+    case list of
+        [] ->
+            []
+
+        head :: tail ->
+            f head :: loop tail f
+```
+
+In practice, iterating over lists and other data structures in Elm is most often done using functions from the `List` module, such as `List.map`, `List.filter`, and `List.foldl`.
+Under the hood, these functions are implemented using recursion.

--- a/concepts/recursion/links.json
+++ b/concepts/recursion/links.json
@@ -1,0 +1,10 @@
+[
+  {
+    "url": "https://functional-programming-in-elm.netlify.app/recursion/",
+    "description": "Recursion described by Evan Czaplicki, creator of Elm"
+  },
+  {
+    "url": "https://learnyouanelm.github.io/pages/05-recursion.html",
+    "description": "Recursion chapter from Learn You an Elm"
+  }
+]

--- a/config.json
+++ b/config.json
@@ -402,6 +402,20 @@
           "pattern-matching"
         ],
         "status": "beta"
+      },
+      {
+        "slug": "bird-count",
+        "name": "Bird Count",
+        "uuid": "8200e967-8183-4468-a0fc-5f58a38c25cb",
+        "concepts": [
+          "recursion"
+        ],
+        "prerequisites": [
+          "maybe",
+          "lists",
+          "pattern-matching"
+        ],
+        "status": "beta"
       }
     ],
     "practice": [
@@ -1713,6 +1727,11 @@
       "uuid": "9dbfbc83-7e02-4ab4-867a-52ecd2276566",
       "slug": "time",
       "name": "Time"
+    },
+    {
+      "uuid": "651a2eba-41d2-4b80-a861-7291536cad5c",
+      "slug": "recursion",
+      "name": "Recursion"
     }
   ],
   "key_features": [

--- a/config.json
+++ b/config.json
@@ -707,10 +707,11 @@
         "name": "Square Root",
         "uuid": "8960514f-17af-4009-b334-d6bfc4722c80",
         "practices": [
-          "pattern-matching"
+          "recursion"
         ],
         "prerequisites": [
           "basics-2",
+          "recursion",
           "pattern-matching"
         ],
         "difficulty": 2
@@ -720,9 +721,10 @@
         "name": "Twelve Days",
         "uuid": "50770287-c734-46ba-b3a1-c36d31b6cc3c",
         "practices": [
-          "strings"
+          "recursion"
         ],
         "prerequisites": [
+          "recursion",
           "booleans",
           "strings",
           "lists",
@@ -831,10 +833,11 @@
         "name": "Largest Series Product",
         "uuid": "1902d726-5a62-475b-b7d3-7188a50e717f",
         "practices": [
-          "strings",
+          "recursion",
           "lists"
         ],
         "prerequisites": [
+          "recursion",
           "strings",
           "lists"
         ],
@@ -1016,8 +1019,7 @@
         "name": "Say",
         "uuid": "ea41b90d-3ff5-43c0-94e5-6b436feb99e5",
         "practices": [
-          "array",
-          "strings"
+          "array"
         ],
         "prerequisites": [
           "array",
@@ -1090,20 +1092,13 @@
         "name": "Armstrong Numbers",
         "uuid": "2a71bafa-87ac-4f36-ba45-a1b24dcca67a",
         "practices": [
-          "strings",
-          "lists"
+          "recursion"
         ],
         "prerequisites": [
-          "strings",
+          "recursion",
           "lists"
         ],
-        "difficulty": 3,
-        "topics": [
-          "integers",
-          "lists",
-          "algorithms",
-          "math"
-        ]
+        "difficulty": 3
       },
       {
         "slug": "scrabble-score",
@@ -1287,9 +1282,7 @@
         "slug": "zebra-puzzle",
         "name": "Zebra Puzzle",
         "uuid": "b4734ab6-cedc-46eb-9648-d59b90f2596e",
-        "practices": [
-          "lists"
-        ],
+        "practices": [],
         "prerequisites": [
           "lists",
           "tuples",
@@ -1489,8 +1482,11 @@
         "slug": "spiral-matrix",
         "name": "Spiral Matrix",
         "uuid": "e44952ec-185a-4c8e-9404-fb7b365e3961",
-        "practices": [],
+        "practices": [
+          "recursion"
+        ],
         "prerequisites": [
+          "recursion",
           "lists",
           "comparison",
           "dict",
@@ -1505,8 +1501,11 @@
         "slug": "food-chain",
         "name": "Food Chain",
         "uuid": "40e735ba-0bc7-436e-9c5f-5a8abdf8c436",
-        "practices": [],
+        "practices": [
+          "recursion"
+        ],
         "prerequisites": [
+          "recursion",
           "strings",
           "lists",
           "tuples",
@@ -1520,12 +1519,14 @@
         "name": "Knapsack",
         "uuid": "9bf186d3-e904-42f2-a705-dffbe98adb08",
         "practices": [
-          "records"
+          "records",
+          "recursion"
         ],
         "prerequisites": [
           "comparison",
           "lists",
-          "records"
+          "records",
+          "recursion"
         ],
         "difficulty": 7
       },

--- a/exercises/concept/bird-count/.docs/hints.md
+++ b/exercises/concept/bird-count/.docs/hints.md
@@ -1,0 +1,41 @@
+# Hints
+
+## General
+
+- Read about recursion [here][recursion].
+- Use pattern matching with `case` expressions.
+- Try to split a problem into a base case and a recursive case. For example, let's say you want to count how many cookies are there in the cookie jar with a recursive approach. A base case is an empty jar - it has zero cookies. If the jar is not empty, then the number of cookies in the jar is equal to one cookie plus the number of cookies in the jar after removing one cookie.
+
+## 1. Check how many birds visited today
+
+- This task doesn't need recursion.
+- Accessing the first element in a list can be done by pattern matching with a `case` expression.
+- Remember to wrap the result in `Just` when returning a value.
+
+## 2. Increment today's count
+
+- This task doesn't need recursion.
+- Accessing the first element in a list can be done by pattern matching with a `case` expression.
+- Use the [`::` operator][list-cons] to deconstruct and reconstruct the new list.
+
+## 3. Check if there was a day with no visiting birds
+
+- Use recursion to iterate over elements in the list until a day with no visiting birds is found.
+- The base cases are an empty list or a day without bird.
+- Use pattern matching to check for `0` in the list.
+
+## 4. Calculate the total number of visiting birds
+
+- Use recursion to iterate over every element in the list.
+- The base case is an empty list.
+- Use the `+` operator to add the current element to the total of the rest.
+
+## 5. Calculate the number of busy days
+
+- Use recursion to iterate over every element in the list.
+- The base case is an empty list.
+- Use an `if` expression to check if the current day is busy (5 or more birds).
+- Add 1 to the count of busy days in the rest of the list when a busy day is found.
+
+[list-cons]: https://package.elm-lang.org/packages/elm/core/latest/List#(::)
+[recursion]: https://functional-programming-in-elm.netlify.app/recursion/

--- a/exercises/concept/bird-count/.docs/hints.md
+++ b/exercises/concept/bird-count/.docs/hints.md
@@ -2,7 +2,7 @@
 
 ## General
 
-- Read about recursion [here][recursion].
+- Read about [recursion from the creator of Elm][recursion].
 - Use pattern matching with `case` expressions.
 - Try to split a problem into a base case and a recursive case. For example, let's say you want to count how many cookies are there in the cookie jar with a recursive approach. A base case is an empty jar - it has zero cookies. If the jar is not empty, then the number of cookies in the jar is equal to one cookie plus the number of cookies in the jar after removing one cookie.
 

--- a/exercises/concept/bird-count/.docs/instructions.md
+++ b/exercises/concept/bird-count/.docs/instructions.md
@@ -7,6 +7,10 @@ You decided to bring your bird watching to a new level and implement a few tools
 You have chosen to store the data as a list of integers.
 The first number in the list is the number of birds that visited your garden today, the second yesterday, and so on.
 
+```exercism/note
+For the purpose of learning about recursion, do not use any of the `List` functions in this exercise.
+```
+
 ## 1. Check how many birds visited today
 
 Implement the `today` function.

--- a/exercises/concept/bird-count/.docs/instructions.md
+++ b/exercises/concept/bird-count/.docs/instructions.md
@@ -1,0 +1,67 @@
+# Instructions
+
+You're an avid bird watcher that keeps track of how many birds have visited your garden on any given day.
+
+You decided to bring your bird watching to a new level and implement a few tools that will help you track and process the data.
+
+You have chosen to store the data as a list of integers.
+The first number in the list is the number of birds that visited your garden today, the second yesterday, and so on.
+
+## 1. Check how many birds visited today
+
+Implement the `today` function.
+It should take a list of daily bird counts and return today's count.
+If the list is empty, it should return `Nothing`, otherwise the count will be wrapped in a `Just`.
+
+```elm
+BirdCount.today [2, 5, 1]
+    -- Just 2
+```
+
+## 2. Increment today's count
+
+Implement the `incrementDayCount` function.
+It should take a list of daily bird counts and increment today's count by 1.
+If the list is empty, return `[1]`.
+
+```elm
+BirdCount.incrementDayCount [4, 0, 2]
+    -- [5, 0, 2]
+```
+
+## 3. Check if there was a day with no visiting birds
+
+Implement the `hasDayWithoutBirds` function.
+It should take a list of daily bird counts.
+It should return `True` if there was at least one day when no birds visited the garden, and `False` otherwise.
+
+```elm
+BirdCount.hasDayWithoutBirds [2, 0, 4]
+    -- True
+
+BirdCount.hasDayWithoutBirds [3, 8, 1, 5]
+    -- False
+```
+
+## 4. Calculate the total number of visiting birds
+
+Implement the `total` function.
+It should take a list of daily bird counts and return the total number that visited your garden since you started collecting the data.
+
+```elm
+BirdCount.total [4, 0, 9, 0, 5]
+    -- 18
+```
+
+## 5. Calculate the number of busy days
+
+Some days are busier than others.
+A busy day is one where five or more birds have visited your garden.
+
+Implement the `busyDays` function.
+It should take a list of daily bird counts and return the number of busy days.
+
+```elm
+BirdCount.busyDays [4, 5, 0, 0, 6]
+    -- 2
+```

--- a/exercises/concept/bird-count/.docs/instructions.md
+++ b/exercises/concept/bird-count/.docs/instructions.md
@@ -8,7 +8,7 @@ You have chosen to store the data as a list of integers.
 The first number in the list is the number of birds that visited your garden today, the second yesterday, and so on.
 
 ```exercism/note
-For the purpose of learning about recursion, do not use any of the `List` functions in this exercise.
+In real-world applications, you should always use core modules whenever applicable, however for the purpose of learning about recursion, do not use any of the `List` functions in this exercise.
 ```
 
 ## 1. Check how many birds visited today

--- a/exercises/concept/bird-count/.docs/introduction.md
+++ b/exercises/concept/bird-count/.docs/introduction.md
@@ -1,0 +1,53 @@
+# Introduction
+
+## Recursion
+
+Recursive functions are functions that call themselves.
+
+A recursive function needs to have at least one _base case_ and at least one _recursive case_.
+
+A _base case_ returns a value without calling the function again.
+A _recursive case_ calls the function again, modifying the input so that it will at some point match the base case.
+
+In Elm, recursive functions are typically defined using pattern matching with `case` expressions or multiple function clauses.
+
+```elm
+count : List a -> Int
+count list =
+    case list of
+        [] ->
+            0  -- base case
+
+        _ :: tail ->
+            1 + count tail  -- recursive case
+```
+
+### Loops through recursion
+
+Due to immutability, loops in Elm are written differently from imperative languages.
+For example, loops commonly look like:
+
+```c
+for(i = 0; i < array.length; i++) {
+  // do something with array[i]
+}
+```
+
+In a functional language like Elm, mutating variables is not possible.
+Thus, loops have to be implemented with recursion.
+
+The equivalent of a `for` loop in Elm would look like this:
+
+```elm
+loop : List a -> (a -> b) -> List b
+loop list f =
+    case list of
+        [] ->
+            []
+
+        head :: tail ->
+            f head :: loop tail f
+```
+
+In practice, iterating over lists and other data structures in Elm is most often done using functions from the `List` module, such as `List.map`, `List.filter`, and `List.foldl`.
+Under the hood, these functions are implemented using recursion.

--- a/exercises/concept/bird-count/.docs/introduction.md.tpl
+++ b/exercises/concept/bird-count/.docs/introduction.md.tpl
@@ -1,0 +1,3 @@
+# Introduction
+
+%{concept: recursion}

--- a/exercises/concept/bird-count/.meta/Exemplar.elm
+++ b/exercises/concept/bird-count/.meta/Exemplar.elm
@@ -1,0 +1,58 @@
+module BirdCount exposing (busyDays, hasDayWithoutBirds, incrementDayCount, today, total)
+
+
+today : List Int -> Maybe Int
+today counts =
+    case counts of
+        [] ->
+            Nothing
+
+        head :: _ ->
+            Just head
+
+
+incrementDayCount : List Int -> List Int
+incrementDayCount counts =
+    case counts of
+        [] ->
+            [ 1 ]
+
+        head :: tail ->
+            (head + 1) :: tail
+
+
+hasDayWithoutBirds : List Int -> Bool
+hasDayWithoutBirds counts =
+    case counts of
+        [] ->
+            False
+
+        0 :: _ ->
+            True
+
+        _ :: tail ->
+            hasDayWithoutBirds tail
+
+
+total : List Int -> Int
+total counts =
+    case counts of
+        [] ->
+            0
+
+        head :: tail ->
+            head + total tail
+
+
+busyDays : List Int -> Int
+busyDays counts =
+    case counts of
+        [] ->
+            0
+
+        head :: tail ->
+            if head >= 5 then
+                1 + busyDays tail
+
+            else
+                busyDays tail

--- a/exercises/concept/bird-count/.meta/config.json
+++ b/exercises/concept/bird-count/.meta/config.json
@@ -1,0 +1,22 @@
+{
+  "authors": [
+    "jiegillet"
+  ],
+  "contributors": [],
+  "files": {
+    "solution": [
+      "src/BirdCount.elm"
+    ],
+    "test": [
+      "tests/Tests.elm"
+    ],
+    "exemplar": [
+      ".meta/Exemplar.elm"
+    ]
+  },
+  "forked_from": [
+    "csharp/bird-watcher"
+  ],
+  "icon": "bird-watcher",
+  "blurb": "Learn about recursion by keeping track of how many birds visit your garden each day."
+}

--- a/exercises/concept/bird-count/.meta/config.json
+++ b/exercises/concept/bird-count/.meta/config.json
@@ -2,7 +2,6 @@
   "authors": [
     "jiegillet"
   ],
-  "contributors": [],
   "files": {
     "solution": [
       "src/BirdCount.elm"

--- a/exercises/concept/bird-count/.meta/design.md
+++ b/exercises/concept/bird-count/.meta/design.md
@@ -1,0 +1,34 @@
+# Design
+
+## Goal
+
+The Goal is to learn to use recursion
+
+## Learning objectives
+
+Students should be able to
+
+- understand that it's a fundamental pattern in FP
+- understand that many core functions are built with recursion
+- use recursive functions
+- write a recursive function
+
+## Out of scope
+
+Tail call recursion.
+
+## Concepts
+
+The concept this exercise unlocks is:
+
+- `recursion`
+
+## Prerequisites
+
+- maybe
+- lists
+- pattern matching
+
+## Analyzer
+
+- [essential] functions from the `List` module are not used anywhere

--- a/exercises/concept/bird-count/elm.json
+++ b/exercises/concept/bird-count/elm.json
@@ -1,0 +1,29 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
+        },
+        "indirect": {}
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/virtual-dom": "1.0.3"
+        }
+    }
+}

--- a/exercises/concept/bird-count/src/BirdCount.elm
+++ b/exercises/concept/bird-count/src/BirdCount.elm
@@ -1,0 +1,26 @@
+module BirdCount exposing (busyDays, hasDayWithoutBirds, incrementDayCount, today, total)
+
+
+today : List Int -> Maybe Int
+today counts =
+    Debug.todo "Please implement today"
+
+
+incrementDayCount : List Int -> List Int
+incrementDayCount counts =
+    Debug.todo "Please implement incrementDayCount"
+
+
+hasDayWithoutBirds : List Int -> Bool
+hasDayWithoutBirds counts =
+    Debug.todo "Please implement hasDayWithoutBirds"
+
+
+total : List Int -> Int
+total counts =
+    Debug.todo "Please implement total"
+
+
+busyDays : List Int -> Int
+busyDays counts =
+    Debug.todo "Please implement busyDays"

--- a/exercises/concept/bird-count/tests/Tests.elm
+++ b/exercises/concept/bird-count/tests/Tests.elm
@@ -1,0 +1,97 @@
+module Tests exposing (tests)
+
+import BirdCount
+import Expect
+import Test exposing (Test, describe, test)
+
+
+tests : Test
+tests =
+    describe "BirdCount"
+        [ describe "1"
+            [ test "returns Nothing if no bird watching data recorded" <|
+                \_ ->
+                    BirdCount.today []
+                        |> Expect.equal Nothing
+            , test "with one day of data" <|
+                \_ ->
+                    BirdCount.today [ 5 ]
+                        |> Expect.equal (Just 5)
+            , test "with multiple days of data" <|
+                \_ ->
+                    BirdCount.today [ 2, 4, 11, 10, 6, 8 ]
+                        |> Expect.equal (Just 2)
+            ]
+        , describe "2"
+            [ test "creates entry for today if no bird watching data recorded" <|
+                \_ ->
+                    BirdCount.incrementDayCount []
+                        |> Expect.equal [ 1 ]
+            , test "with one day of data" <|
+                \_ ->
+                    BirdCount.incrementDayCount [ 5 ]
+                        |> Expect.equal [ 6 ]
+            , test "with multiple days of data" <|
+                \_ ->
+                    BirdCount.incrementDayCount [ 4, 2, 1, 0, 10 ]
+                        |> Expect.equal [ 5, 2, 1, 0, 10 ]
+            ]
+        , describe "3"
+            [ test "False if no bird watching data recorded" <|
+                \_ ->
+                    BirdCount.hasDayWithoutBirds []
+                        |> Expect.equal False
+            , test "False if there is a single non-zero entry" <|
+                \_ ->
+                    BirdCount.hasDayWithoutBirds [ 1 ]
+                        |> Expect.equal False
+            , test "False if there are only non-zero entries" <|
+                \_ ->
+                    BirdCount.hasDayWithoutBirds [ 6, 7, 10, 2, 5 ]
+                        |> Expect.equal False
+            , test "True if the data is a single zero" <|
+                \_ ->
+                    BirdCount.hasDayWithoutBirds [ 0 ]
+                        |> Expect.equal True
+            , test "True if the data has one zero" <|
+                \_ ->
+                    BirdCount.hasDayWithoutBirds [ 4, 4, 0, 1 ]
+                        |> Expect.equal True
+            , test "True if the data has multiple zeros" <|
+                \_ ->
+                    BirdCount.hasDayWithoutBirds [ 0, 0, 3, 0, 5, 6, 0 ]
+                        |> Expect.equal True
+            ]
+        , describe "4"
+            [ test "zero if no bird watching data recorded" <|
+                \_ ->
+                    BirdCount.total []
+                        |> Expect.equal 0
+            , test "with one day of data" <|
+                \_ ->
+                    BirdCount.total [ 5 ]
+                        |> Expect.equal 5
+            , test "with multiple days of data" <|
+                \_ ->
+                    BirdCount.total [ 3, 0, 0, 4, 4, 0, 0, 10 ]
+                        |> Expect.equal 21
+            ]
+        , describe "5"
+            [ test "zero if no bird watching data recorded" <|
+                \_ ->
+                    BirdCount.busyDays []
+                        |> Expect.equal 0
+            , test "with a single non-busy day" <|
+                \_ ->
+                    BirdCount.busyDays [ 1 ]
+                        |> Expect.equal 0
+            , test "with several days including one busy day" <|
+                \_ ->
+                    BirdCount.busyDays [ 0, 5 ]
+                        |> Expect.equal 1
+            , test "with several busy days" <|
+                \_ ->
+                    BirdCount.busyDays [ 0, 6, 10, 4, 4, 5, 0 ]
+                        |> Expect.equal 3
+            ]
+        ]


### PR DESCRIPTION
Part of #692

I took this concept and exercise combo pretty much straight out of the Elixir track, which itself forked it from the C# track.

Some notes:
- The original issue include teaching about tail call recursion, but since Elixir was separating the two, I thought it would be easier to do the same, so this PR does not talk about tail call recursion.
- I usually leave the `introduction.md` as TODO, but this time, I followed the lead of Elixir that includes more details in the `about.md` and less in the intro. (it's still missing in the exercise though, so the CI will fail)
- I again used AI to help me translate from Elixir to Elm, very useful
- I added a bunch of exercises to practice the concept. There are definitely more that do, but I didn't go through all of them
- I removed the fields `strings` and `lists` from some exercises that practiced those, because we had to many, (`bin/configlet lint` warns that we should have at most 10, now we are OK)