### PR TITLE
doc fix: missing link target in pipers-pie introduction

### DIFF
--- a/concepts/tail-call-recursion/introduction.md
+++ b/concepts/tail-call-recursion/introduction.md
@@ -45,3 +45,4 @@ This would not be possible for a function with the type signature `Int -> Int`, 
 
 [recursion-tc]: https://en.wikipedia.org/wiki/Tail_call
 [call-stack]: https://en.wikipedia.org/wiki/Call_stack
+[tail-call-optimization]: https://jfmengels.net/tail-call-optimization/

--- a/exercises/concept/pipers-pie/.docs/introduction.md
+++ b/exercises/concept/pipers-pie/.docs/introduction.md
@@ -47,3 +47,4 @@ This would not be possible for a function with the type signature `Int -> Int`, 
 
 [recursion-tc]: https://en.wikipedia.org/wiki/Tail_call
 [call-stack]: https://en.wikipedia.org/wiki/Call_stack
+[tail-call-optimization]: https://jfmengels.net/tail-call-optimization/


### PR DESCRIPTION
[Current text](https://exercism.org/tracks/elm/concepts/tail-call-recursion):

```none
Tail-recursive functions allow for [tail call optimization][tail-call-optimization] (or tail call elimination).
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```