### PR TITLE
Add new practice exercise `hangman`

### DIFF
--- a/config.json
+++ b/config.json
@@ -1682,6 +1682,27 @@
           "tuples"
         ],
         "difficulty": 7
+      },
+      {
+        "slug": "hangman",
+        "name": "Hangman",
+        "uuid": "aeb89f0f-d924-4dd4-8ec8-5a74368875f0",
+        "practices": [
+          "web-applications-sandbox"
+        ],
+        "prerequisites": [
+          "web-applications-sandbox",
+          "strings",
+          "lists",
+          "records",
+          "custom-types",
+          "pattern-matching",
+          "let",
+          "booleans",
+          "maybe",
+          "tuples"
+        ],
+        "difficulty": 5
       }
     ],
     "foregone": [

--- a/exercises/practice/hangman/.docs/instructions.append.md
+++ b/exercises/practice/hangman/.docs/instructions.append.md
@@ -1,0 +1,29 @@
+# Instructions Append
+
+Historically, Elm was using functional reactive programming until it specialized to using the Elm Architecture.
+
+Solve this exercise as if you were writing a web app using the Elm Architecture.
+The output of the program should be HTML with the following structure
+
+```html
+<div>
+  <dl>
+    <dt>State</dt>
+    <dd>Ongoing</dd>
+    <dt>Word</dt>
+    <dd>______</dd>
+    <dt>Remaining failures</dt>
+    <dd>5</dd>
+  </dl>
+</div>
+```
+
+where `<dl>` is the description list element, `<dt>` the description term element and `<dd>` the description details element, all standard HTML elements.
+
+If there is an error, the output should have the following structure
+
+```html
+<div>
+  <p>error message</p>
+</div>
+```

--- a/exercises/practice/hangman/.docs/instructions.md
+++ b/exercises/practice/hangman/.docs/instructions.md
@@ -1,0 +1,14 @@
+# Instructions
+
+Implement the logic of the hangman game using functional reactive programming.
+
+[Hangman][hangman] is a simple word guessing game.
+
+[Functional Reactive Programming][frp] is a way to write interactive programs.
+It differs from the usual perspective in that instead of saying "when the button is pressed increment the counter", you write "the value of the counter is the sum of the number of times the button is pressed."
+
+Implement the basic logic behind hangman using functional reactive programming.
+You'll need to install an FRP library for this, this will be described in the language/track specific files of the exercise.
+
+[hangman]: https://en.wikipedia.org/wiki/Hangman_%28game%29
+[frp]: https://en.wikipedia.org/wiki/Functional_reactive_programming

--- a/exercises/practice/hangman/.meta/config.json
+++ b/exercises/practice/hangman/.meta/config.json
@@ -13,5 +13,5 @@
       ".meta/src/Hangman.example.elm"
     ]
   },
-  "blurb": "Implement the logic of the hangman game using functional reactive programming."
+  "blurb": "Implement the logic of the hangman game using the Elm Architecture."
 }

--- a/exercises/practice/hangman/.meta/config.json
+++ b/exercises/practice/hangman/.meta/config.json
@@ -1,0 +1,17 @@
+{
+  "authors": [
+    "jiegillet"
+  ],
+  "files": {
+    "solution": [
+      "src/Hangman.elm"
+    ],
+    "test": [
+      "tests/Tests.elm"
+    ],
+    "example": [
+      ".meta/src/Hangman.example.elm"
+    ]
+  },
+  "blurb": "Implement the logic of the hangman game using functional reactive programming."
+}

--- a/exercises/practice/hangman/.meta/src/Hangman.example.elm
+++ b/exercises/practice/hangman/.meta/src/Hangman.example.elm
@@ -1,7 +1,6 @@
 module Hangman exposing (Msg(..), init, update, view)
 
 import Html exposing (Html)
-import Html.Attributes
 
 
 type State
@@ -57,7 +56,7 @@ update msg model =
 
 
 guess : Char -> Model -> Model
-guess letter ({ state, word, maskedWord, remainingFailures } as model) =
+guess letter ({ word, maskedWord, remainingFailures } as model) =
     if List.member letter word then
         let
             revealLetter wordChar maskedChar =
@@ -91,7 +90,7 @@ guess letter ({ state, word, maskedWord, remainingFailures } as model) =
 
 
 view : Model -> Html Msg
-view { state, word, maskedWord, remainingFailures, error } =
+view { state, maskedWord, remainingFailures, error } =
     case error of
         Just errorMessage ->
             Html.div [] [ Html.p [] [ Html.text errorMessage ] ]

--- a/exercises/practice/hangman/.meta/src/Hangman.example.elm
+++ b/exercises/practice/hangman/.meta/src/Hangman.example.elm
@@ -1,0 +1,122 @@
+module Hangman exposing (Msg(..), init, update, view)
+
+import Html exposing (Html)
+import Html.Attributes
+
+
+type State
+    = Ongoing
+    | Win
+    | Lose
+
+
+
+-- MODEL
+
+
+type alias Model =
+    { state : State
+    , word : List Char
+    , maskedWord : List Char
+    , remainingFailures : Int
+    , error : Maybe String
+    }
+
+
+init : String -> Model
+init word =
+    { state = Ongoing
+    , word = String.toList word
+    , maskedWord = List.repeat (String.length word) '_'
+    , remainingFailures = 9
+    , error = Nothing
+    }
+
+
+
+-- UPDATE
+
+
+type Msg
+    = Guess Char
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        Guess letter ->
+            case model.state of
+                Win ->
+                    { model | error = Just "cannot guess after the game is won" }
+
+                Lose ->
+                    { model | error = Just "cannot guess after the game is lost" }
+
+                Ongoing ->
+                    guess letter model
+
+
+guess : Char -> Model -> Model
+guess letter ({ state, word, maskedWord, remainingFailures } as model) =
+    if List.member letter word then
+        let
+            revealLetter wordChar maskedChar =
+                if wordChar == letter then
+                    ( '_', letter )
+
+                else
+                    ( wordChar, maskedChar )
+
+            ( newWord, newMaskedWord ) =
+                List.map2 revealLetter word maskedWord |> List.unzip
+
+            newState =
+                if List.all (\c -> c == '_') newWord then
+                    Win
+
+                else
+                    Ongoing
+        in
+        { model | maskedWord = newMaskedWord, word = newWord, state = newState }
+
+    else if remainingFailures == 0 then
+        { model | state = Lose }
+
+    else
+        { model | remainingFailures = remainingFailures - 1 }
+
+
+
+-- VIEW
+
+
+view : Model -> Html Msg
+view { state, word, maskedWord, remainingFailures, error } =
+    case error of
+        Just errorMessage ->
+            Html.div [] [ Html.p [] [ Html.text errorMessage ] ]
+
+        Nothing ->
+            Html.div []
+                [ Html.dl []
+                    [ Html.dt [] [ Html.text "State" ]
+                    , Html.dd [] [ Html.text (viewState state) ]
+                    , Html.dt [] [ Html.text "Word" ]
+                    , Html.dd [] [ Html.text (String.fromList maskedWord) ]
+                    , Html.dt [] [ Html.text "Remaining failures" ]
+                    , Html.dd [] [ Html.text (String.fromInt remainingFailures) ]
+                    ]
+                ]
+
+
+viewState : State -> String
+viewState state =
+    case state of
+        Ongoing ->
+            "Ongoing"
+
+        Win ->
+            "Win"
+
+        Lose ->
+            "Lose"

--- a/exercises/practice/hangman/.meta/src/Hangman.example.elm
+++ b/exercises/practice/hangman/.meta/src/Hangman.example.elm
@@ -14,8 +14,7 @@ type State
 
 
 type alias Model =
-    { state : State
-    , word : List Char
+    { word : List Char
     , maskedWord : List Char
     , remainingFailures : Int
     , error : Maybe String
@@ -24,8 +23,7 @@ type alias Model =
 
 init : String -> Model
 init word =
-    { state = Ongoing
-    , word = String.toList word
+    { word = String.toList word
     , maskedWord = List.repeat (String.length word) '_'
     , remainingFailures = 9
     , error = Nothing
@@ -44,7 +42,7 @@ update : Msg -> Model -> Model
 update msg model =
     case msg of
         Guess letter ->
-            case model.state of
+            case getState model of
                 Win ->
                     { model | error = Just "cannot guess after the game is won" }
 
@@ -53,6 +51,18 @@ update msg model =
 
                 Ongoing ->
                     guess letter model
+
+
+getState : Model -> State
+getState { word, maskedWord, remainingFailures } =
+    if List.all (\c -> c == '_') word then
+        Win
+
+    else if remainingFailures < 0 then
+        Lose
+
+    else
+        Ongoing
 
 
 guess : Char -> Model -> Model
@@ -68,18 +78,8 @@ guess letter ({ word, maskedWord, remainingFailures } as model) =
 
             ( newWord, newMaskedWord ) =
                 List.map2 revealLetter word maskedWord |> List.unzip
-
-            newState =
-                if List.all (\c -> c == '_') newWord then
-                    Win
-
-                else
-                    Ongoing
         in
-        { model | maskedWord = newMaskedWord, word = newWord, state = newState }
-
-    else if remainingFailures == 0 then
-        { model | state = Lose }
+        { model | maskedWord = newMaskedWord, word = newWord }
 
     else
         { model | remainingFailures = remainingFailures - 1 }
@@ -90,7 +90,7 @@ guess letter ({ word, maskedWord, remainingFailures } as model) =
 
 
 view : Model -> Html Msg
-view { state, maskedWord, remainingFailures, error } =
+view ({ maskedWord, remainingFailures, error } as model) =
     case error of
         Just errorMessage ->
             Html.div [] [ Html.p [] [ Html.text errorMessage ] ]
@@ -99,11 +99,11 @@ view { state, maskedWord, remainingFailures, error } =
             Html.div []
                 [ Html.dl []
                     [ Html.dt [] [ Html.text "State" ]
-                    , Html.dd [] [ Html.text (viewState state) ]
+                    , Html.dd [] [ Html.text (viewState (getState model)) ]
                     , Html.dt [] [ Html.text "Word" ]
                     , Html.dd [] [ Html.text (String.fromList maskedWord) ]
                     , Html.dt [] [ Html.text "Remaining failures" ]
-                    , Html.dd [] [ Html.text (String.fromInt remainingFailures) ]
+                    , Html.dd [] [ Html.text (String.fromInt (max 0 remainingFailures)) ]
                     ]
                 ]
 

--- a/exercises/practice/hangman/.meta/src/Hangman.example.elm
+++ b/exercises/practice/hangman/.meta/src/Hangman.example.elm
@@ -54,7 +54,7 @@ update msg model =
 
 
 getState : Model -> State
-getState { word, maskedWord, remainingFailures } =
+getState { word, remainingFailures } =
     if List.all (\c -> c == '_') word then
         Win
 

--- a/exercises/practice/hangman/.meta/tests.toml
+++ b/exercises/practice/hangman/.meta/tests.toml
@@ -1,0 +1,40 @@
+# This is an auto-generated file.
+#
+# Regenerating this file via `configlet sync` will:
+# - Recreate every `description` key/value pair
+# - Recreate every `reimplements` key/value pair, where they exist in problem-specifications
+# - Remove any `include = true` key/value pair (an omitted `include` key implies inclusion)
+# - Preserve any other key/value pair
+#
+# As user-added comments (using the # character) will be removed when this file
+# is regenerated, comments can be added via a `comment` key.
+
+[2419ffe6-16d8-4059-856a-9a101998a418]
+description = "Initially 9 failures are allowed and no letters are guessed"
+
+[17c4296d-daab-44dc-8155-37c77caa52c1]
+description = "After 10 failures the game is over"
+
+[77c9ae1f-bbc4-4ed4-b67e-08110cbcfc17]
+description = "Losing with several correct guesses"
+
+[25101d8d-9874-405b-9825-193a14b69753]
+description = "Feeding a correct letter removes underscores"
+
+[8e6bd521-bc9b-458f-9cce-f57f4140c173]
+description = "Feeding a correct letter twice counts as a failure"
+
+[5e6971b7-5e5f-49c2-b85d-1dd6aeb53bd5]
+description = "Guessing a repeated letter reveals all instances"
+
+[a6c69d92-01ef-4b81-b9d9-801131e79bbb]
+description = "Getting all the letters right makes for a win"
+
+[2dc47994-b434-4a26-b70c-1eebeff77fe4]
+description = "Winning on the last guess is still a win"
+
+[52801d56-6963-494b-a901-5736e46ddc12]
+description = "Guessing after a lose is error"
+
+[29a874f3-a413-4e1b-9a60-6be018e70b60]
+description = "Guessing after a win is error"

--- a/exercises/practice/hangman/elm.json
+++ b/exercises/practice/hangman/elm.json
@@ -1,0 +1,29 @@
+{
+    "type": "application",
+    "source-directories": [
+        "src"
+    ],
+    "elm-version": "0.19.1",
+    "dependencies": {
+        "direct": {
+            "elm/core": "1.0.5",
+            "elm/json": "1.1.3",
+            "elm/parser": "1.1.0",
+            "elm/random": "1.0.0",
+            "elm/regex": "1.0.0",
+            "elm/time": "1.0.0",
+            "elm/html": "1.0.0"
+        },
+        "indirect": {}
+    },
+    "test-dependencies": {
+        "direct": {
+            "elm-explorations/test": "2.1.0",
+            "rtfeldman/elm-iso8601-date-strings": "1.1.4"
+        },
+        "indirect": {
+            "elm/bytes": "1.0.8",
+            "elm/virtual-dom": "1.0.3"
+        }
+    }
+}

--- a/exercises/practice/hangman/src/Hangman.elm
+++ b/exercises/practice/hangman/src/Hangman.elm
@@ -1,7 +1,6 @@
 module Hangman exposing (Msg(..), init, update, view)
 
 import Html exposing (Html)
-import Html.Attributes
 
 
 

--- a/exercises/practice/hangman/src/Hangman.elm
+++ b/exercises/practice/hangman/src/Hangman.elm
@@ -1,0 +1,41 @@
+module Hangman exposing (Msg(..), init, update, view)
+
+import Html exposing (Html)
+import Html.Attributes
+
+
+
+-- MODEL
+
+
+type alias Model =
+    {}
+
+
+init : String -> Model
+init word =
+    {}
+
+
+
+-- UPDATE
+
+
+type Msg
+    = Guess Char
+
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        Guess letter ->
+            model
+
+
+
+-- VIEW
+
+
+view : Model -> Html Msg
+view model =
+    Html.div [] []

--- a/exercises/practice/hangman/tests/Tests.elm
+++ b/exercises/practice/hangman/tests/Tests.elm
@@ -1,0 +1,206 @@
+module Tests exposing (tests)
+
+import Expect
+import Hangman exposing (Msg(..), init, update, view)
+import Html exposing (Html)
+import Test exposing (Test, describe, skip, test)
+import Test.Html.Query as Query
+import Test.Html.Selector as Selector
+
+
+tests : Test
+tests =
+    describe "Hangman"
+        [ -- skip <|
+          test "Initially 9 failures are allowed and no letters are guessed" <|
+            \() ->
+                Hangman.init "loot"
+                    |> Hangman.view
+                    |> Query.fromHtml
+                    |> Query.find [ Selector.tag "dl" ]
+                    |> Query.has
+                        [ Selector.all [ Selector.tag "dt", Selector.text "State" ]
+                        , Selector.all [ Selector.tag "dd", Selector.text "Ongoing" ]
+                        , Selector.all [ Selector.tag "dt", Selector.text "Word" ]
+                        , Selector.all [ Selector.tag "dd", Selector.text "____" ]
+                        , Selector.all [ Selector.tag "dt", Selector.text "Remaining failures" ]
+                        , Selector.all [ Selector.tag "dd", Selector.text "9" ]
+                        ]
+        , skip <|
+            test "After 10 failures the game is over" <|
+                \() ->
+                    Hangman.init "loot"
+                        |> Hangman.update (Guess 'a')
+                        |> Hangman.update (Guess 'b')
+                        |> Hangman.update (Guess 'c')
+                        |> Hangman.update (Guess 'd')
+                        |> Hangman.update (Guess 'e')
+                        |> Hangman.update (Guess 'f')
+                        |> Hangman.update (Guess 'g')
+                        |> Hangman.update (Guess 'h')
+                        |> Hangman.update (Guess 'i')
+                        |> Hangman.update (Guess 'j')
+                        |> Hangman.view
+                        |> Query.fromHtml
+                        |> Query.find [ Selector.tag "dl" ]
+                        |> Query.has
+                            [ Selector.all [ Selector.tag "dt", Selector.text "State" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "Lose" ]
+                            , Selector.all [ Selector.tag "dt", Selector.text "Word" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "____" ]
+                            , Selector.all [ Selector.tag "dt", Selector.text "Remaining failures" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "0" ]
+                            ]
+        , skip <|
+            test "Losing with several correct guesses" <|
+                \() ->
+                    Hangman.init "loot"
+                        |> Hangman.update (Guess 't')
+                        |> Hangman.update (Guess 'o')
+                        |> Hangman.update (Guess 'a')
+                        |> Hangman.update (Guess 'b')
+                        |> Hangman.update (Guess 'c')
+                        |> Hangman.update (Guess 'd')
+                        |> Hangman.update (Guess 'e')
+                        |> Hangman.update (Guess 'f')
+                        |> Hangman.update (Guess 'g')
+                        |> Hangman.update (Guess 'h')
+                        |> Hangman.update (Guess 'i')
+                        |> Hangman.update (Guess 'j')
+                        |> Hangman.view
+                        |> Query.fromHtml
+                        |> Query.find [ Selector.tag "dl" ]
+                        |> Query.has
+                            [ Selector.all [ Selector.tag "dt", Selector.text "State" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "Lose" ]
+                            , Selector.all [ Selector.tag "dt", Selector.text "Word" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "_oot" ]
+                            , Selector.all [ Selector.tag "dt", Selector.text "Remaining failures" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "0" ]
+                            ]
+        , skip <|
+            test "Feeding a correct letter removes underscores" <|
+                \() ->
+                    Hangman.init "loot"
+                        |> Hangman.update (Guess 't')
+                        |> Hangman.view
+                        |> Query.fromHtml
+                        |> Query.find [ Selector.tag "dl" ]
+                        |> Query.has
+                            [ Selector.all [ Selector.tag "dd", Selector.text "Ongoing" ]
+                            , Selector.all [ Selector.tag "dt", Selector.text "Word" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "___t" ]
+                            , Selector.all [ Selector.tag "dt", Selector.text "Remaining failures" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "9" ]
+                            ]
+        , skip <|
+            test "Feeding a correct letter twice counts as a failure" <|
+                \() ->
+                    Hangman.init "loot"
+                        |> Hangman.update (Guess 't')
+                        |> Hangman.update (Guess 't')
+                        |> Hangman.view
+                        |> Query.fromHtml
+                        |> Query.find [ Selector.tag "dl" ]
+                        |> Query.has
+                            [ Selector.all [ Selector.tag "dt", Selector.text "State" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "Ongoing" ]
+                            , Selector.all [ Selector.tag "dt", Selector.text "Word" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "___t" ]
+                            , Selector.all [ Selector.tag "dt", Selector.text "Remaining failures" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "8" ]
+                            ]
+        , skip <|
+            test "Guessing a repeated letter reveals all instances" <|
+                \() ->
+                    Hangman.init "loot"
+                        |> Hangman.update (Guess 't')
+                        |> Hangman.update (Guess 't')
+                        |> Hangman.update (Guess 'o')
+                        |> Hangman.view
+                        |> Query.fromHtml
+                        |> Query.find [ Selector.tag "dl" ]
+                        |> Query.has
+                            [ Selector.all [ Selector.tag "dt", Selector.text "State" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "Ongoing" ]
+                            , Selector.all [ Selector.tag "dt", Selector.text "Word" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "_oot" ]
+                            , Selector.all [ Selector.tag "dt", Selector.text "Remaining failures" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "8" ]
+                            ]
+        , skip <|
+            test "Getting all the letters right makes for a win" <|
+                \() ->
+                    Hangman.init "loot"
+                        |> Hangman.update (Guess 't')
+                        |> Hangman.update (Guess 't')
+                        |> Hangman.update (Guess 'o')
+                        |> Hangman.update (Guess 'l')
+                        |> Hangman.view
+                        |> Query.fromHtml
+                        |> Query.find [ Selector.tag "dl" ]
+                        |> Query.has
+                            [ Selector.all [ Selector.tag "dt", Selector.text "State" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "Win" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "loot" ]
+                            , Selector.all [ Selector.tag "dt", Selector.text "Remaining failures" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "8" ]
+                            ]
+        , skip <|
+            test "Winning on the last guess is still a win" <|
+                \() ->
+                    Hangman.init "loot"
+                        |> Hangman.update (Guess 'a')
+                        |> Hangman.update (Guess 'b')
+                        |> Hangman.update (Guess 'c')
+                        |> Hangman.update (Guess 'd')
+                        |> Hangman.update (Guess 'e')
+                        |> Hangman.update (Guess 'f')
+                        |> Hangman.update (Guess 'g')
+                        |> Hangman.update (Guess 'h')
+                        |> Hangman.update (Guess 'i')
+                        |> Hangman.update (Guess 't')
+                        |> Hangman.update (Guess 'o')
+                        |> Hangman.update (Guess 'l')
+                        |> Hangman.view
+                        |> Query.fromHtml
+                        |> Query.find [ Selector.tag "dl" ]
+                        |> Query.has
+                            [ Selector.all [ Selector.tag "dt", Selector.text "State" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "Win" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "loot" ]
+                            , Selector.all [ Selector.tag "dt", Selector.text "Remaining failures" ]
+                            , Selector.all [ Selector.tag "dd", Selector.text "0" ]
+                            ]
+        , skip <|
+            test "Guessing after a lose is error" <|
+                \() ->
+                    Hangman.init "loot"
+                        |> Hangman.update (Guess 'a')
+                        |> Hangman.update (Guess 'b')
+                        |> Hangman.update (Guess 'c')
+                        |> Hangman.update (Guess 'd')
+                        |> Hangman.update (Guess 'e')
+                        |> Hangman.update (Guess 'f')
+                        |> Hangman.update (Guess 'g')
+                        |> Hangman.update (Guess 'h')
+                        |> Hangman.update (Guess 'i')
+                        |> Hangman.update (Guess 'j')
+                        |> Hangman.update (Guess 'k')
+                        |> Hangman.view
+                        |> Query.fromHtml
+                        |> Query.find [ Selector.tag "p" ]
+                        |> Query.has [ Selector.text "cannot guess after the game is lost" ]
+        , skip <|
+            test "Guessing after a win is error" <|
+                \() ->
+                    Hangman.init "loot"
+                        |> Hangman.update (Guess 't')
+                        |> Hangman.update (Guess 'o')
+                        |> Hangman.update (Guess 'l')
+                        |> Hangman.update (Guess 'l')
+                        |> Hangman.view
+                        |> Query.fromHtml
+                        |> Query.find [ Selector.tag "p" ]
+                        |> Query.has [ Selector.text "cannot guess after the game is won" ]
+        ]


### PR DESCRIPTION
@ceddlyburge I hope you will be as excited about this one as I am, this is an exercise that practices `web-applications-sandbox`!

It's an old exercise that didn't have canonical tests until recently, and it's supposed to be practicing functional reactive programming. I tried to implement it in Elixir first, but FRP is not a thing at all in Elixir so I didn't manage, but I realized that it's the perfect fit for Elm, since the Elm Architecture is a direct descendant of FRP.

Since HTML output is unexpected for a practice exercise, I added an appendix to the instructions.