### PR TITLE
Format all `instructions.append.md` to start with an H1 (required but ignored) and H2

### DIFF
--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions Append
 
-## Implementation
+## Track specific instructions
 
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/anagram/.docs/instructions.append.md
+++ b/exercises/practice/anagram/.docs/instructions.append.md
@@ -1,3 +1,5 @@
 # Instructions Append
 
+## Implementation
+
 You must return the anagrams in the same order as they are listed in the candidate words.

--- a/exercises/practice/hangman/.docs/instructions.append.md
+++ b/exercises/practice/hangman/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions Append
 
-## Implementation
+## Track specific instructions
 
 Historically, Elm was using functional reactive programming until it specialized to using the Elm Architecture.
 

--- a/exercises/practice/hangman/.docs/instructions.append.md
+++ b/exercises/practice/hangman/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions Append
 
+## Implementation
+
 Historically, Elm was using functional reactive programming until it specialized to using the Elm Architecture.
 
 Solve this exercise as if you were writing a web app using the Elm Architecture.

--- a/exercises/practice/palindrome-products/.docs/instructions.append.md
+++ b/exercises/practice/palindrome-products/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions Append
 
+## Note
+
 ```exercism/note
 Naive solutions may take a long time to pass the tests involving four digit factors, likely longer than the time limit allocated to the online test runner.
 You may need to work on the exercise locally to profile your solution.

--- a/exercises/practice/palindrome-products/.docs/instructions.append.md
+++ b/exercises/practice/palindrome-products/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions Append
 
-## Note
+## Track specific instructions
 
 ```exercism/note
 Naive solutions may take a long time to pass the tests involving four digit factors, likely longer than the time limit allocated to the online test runner.

--- a/exercises/practice/swift-scheduling/.docs/instructions.append.md
+++ b/exercises/practice/swift-scheduling/.docs/instructions.append.md
@@ -1,6 +1,6 @@
 # Instructions Append
 
-## Note
+## Track specific instructions
 
 ```exercism/note
 `elm/time` is meant to display a time provided by the browser, not to manipulate dates and times.

--- a/exercises/practice/swift-scheduling/.docs/instructions.append.md
+++ b/exercises/practice/swift-scheduling/.docs/instructions.append.md
@@ -1,5 +1,7 @@
 # Instructions Append
 
+## Note
+
 ```exercism/note
 `elm/time` is meant to display a time provided by the browser, not to manipulate dates and times.
 In real world applications, one would reach out to packages from the Elm community to manipulate dates and times, but since those are not accessible in the online editor, take this exercise as a challenge rather than as a practice of idiomatic Elm.

--- a/exercises/practice/wordy/.docs/instructions.append.md
+++ b/exercises/practice/wordy/.docs/instructions.append.md
@@ -1,3 +1,5 @@
-# Hints
+# Instructions append
+
+## Hints
 
 This is a perfect opportunity to learn `elm/parser` ([docs](https://package.elm-lang.org/packages/elm/parser/latest/))!

--- a/exercises/practice/wordy/.docs/instructions.append.md
+++ b/exercises/practice/wordy/.docs/instructions.append.md
@@ -1,5 +1,5 @@
 # Instructions append
 
-## Hints
+## Track specific instructions
 
 This is a perfect opportunity to learn `elm/parser` ([docs](https://package.elm-lang.org/packages/elm/parser/latest/))!


### PR DESCRIPTION
See related discussions [here](https://forum.exercism.org/t/grep-instructions-append-may-need-a-visible-header/53923) as well as https://github.com/exercism/docs/pull/592. Append files should all have an H1. Including an H2 helps break the flow from the non-append file to the append file so it does not read as the same stream of thought.